### PR TITLE
Bump plotly express JS plugin version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16781,15 +16781,6 @@
         "@babel/runtime": "^7.9.2"
       }
     },
-    "node_modules/redux-thunk": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.4.2.tgz",
-      "integrity": "sha512-+P3TjtnP0k/FEjcBL5FZpoovtvrTNT/UXd4/sluaSyrURlSlhLSzEdfsTBW7WsKB6yPvgd7q/iZPICFjW4o57Q==",
-      "extraneous": true,
-      "peerDependencies": {
-        "redux": "^4"
-      }
-    },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.4.tgz",
@@ -19414,7 +19405,7 @@
     },
     "plugins/plotly-express/src/js": {
       "name": "@deephaven/js-plugin-plotly-express",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@deephaven/chart": "0.46.0",

--- a/plugins/plotly-express/src/js/package.json
+++ b/plugins/plotly-express/src/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deephaven/js-plugin-plotly-express",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Deephaven plotly express plugin",
   "keywords": [
     "Deephaven",


### PR DESCRIPTION
Need to publish a new version for the plotly express snapshots in docs. I'm pretty sure the current workflow is manually bump the version in the package.json and then run a publish action manually