### PR TITLE
fix: Plotly express package.json main field

### DIFF
--- a/plugins/plotly-express/src/js/package.json
+++ b/plugins/plotly-express/src/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deephaven/js-plugin-plotly-express",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Deephaven plotly express plugin",
   "keywords": [
     "Deephaven",

--- a/plugins/plotly-express/src/js/package.json
+++ b/plugins/plotly-express/src/js/package.json
@@ -11,7 +11,7 @@
   ],
   "author": "Deephaven Data Labs LLC",
   "license": "Apache-2.0",
-  "main": "dist/index.js",
+  "main": "dist/bundle/index.js",
   "type": "module",
   "exports": {
     ".": {


### PR DESCRIPTION
The web plugin packager script pulls the main field to put in the manifest. This corrects it to point to the bundled file and also bumps the version so a fixed version can be published.