### PR TITLE
ci: Removing repository-url

### DIFF
--- a/.github/workflows/release-python-package.yml
+++ b/.github/workflows/release-python-package.yml
@@ -56,4 +56,3 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: plugins/${{ inputs.package }}/dist/
-          repository-url: https://pypi.org/legacy/


### PR DESCRIPTION
The repository-url is not necessary for publication (see https://blog.pypi.org/posts/2023-04-20-introducing-trusted-publishers/) but was necessary for testing. Removing as it is causing an error.