### PR TITLE
ci: Add mypy type checking

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,3 +9,9 @@ repos:
     rev: 22.10.0
     hooks:
     -   id: black
+-   repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.6.1
+    hooks:
+    -   id: mypy
+        files: plugins.*\/src.*\.py
+        args: [--config-file, mypy.ini]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,3 +15,8 @@ repos:
     -   id: mypy
         files: plugins.*\/src.*\.py
         args: [--config-file, mypy.ini]
+-   repo: https://github.com/RobertCraigie/pyright-python
+    rev: v1.1.334
+    hooks:
+    - id: pyright
+      files: plugins.*\/src.*\.py

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,5 @@
+[mypy]
+
+files=./plugins/*/src/deephaven/
+ignore_missing_imports = True
+disallow_untyped_defs = True


### PR DESCRIPTION
Fixes #97 

This will require typing for all source code, integrated into the `pre-commit` for convenience (but can also be ran directly through `mypy`)

This will also require updating the types as many are currently incorrect or missing.