### PR TITLE
feat: Wrap UI components in their own liveness scopes

### DIFF
--- a/plugins/ui/src/deephaven/ui/elements/FunctionElement.py
+++ b/plugins/ui/src/deephaven/ui/elements/FunctionElement.py
@@ -21,13 +21,12 @@ class FunctionElement(Element):
         self._render = render
         self._liveness_scope = LivenessScope()
 
-
     @property
     def name(self):
         return self._name
 
     def release_liveness_scope(self):
-        try: # May not have an active liveness scope or already been released
+        try:  # May not have an active liveness scope or already been released
             self._liveness_scope.release()
             self._liveness_scope = None
         except:


### PR DESCRIPTION
This will be required for anything that uses a table listener according to Colin. Probably also any 3rd party plugin that consumes a table directly and doesn't manage its liveness. Existing plotting and plotly-express have been modified to be robust about managing the liveness of their tables, but a 3rd party plugin might not be as robust. This should help make things easier for plugin authors

I tested w/ plotly-express locally w/o its liveness scope fix. Also needed plotly-express as a `WidgetPlugin` which I will post a PR for.