### PR TITLE
fix(ui): Wrap renderer in liveness scope instead of function element

### DIFF
--- a/plugins/ui/src/deephaven/ui/elements/FunctionElement.py
+++ b/plugins/ui/src/deephaven/ui/elements/FunctionElement.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 import logging
 from typing import Callable
-from deephaven.liveness_scope import LivenessScope
 from .Element import Element
 from .._internal import RenderContext, get_context, set_context
 
@@ -19,21 +18,10 @@ class FunctionElement(Element):
         """
         self._name = name
         self._render = render
-        self._liveness_scope = LivenessScope()
 
     @property
     def name(self):
         return self._name
-
-    def release_liveness_scope(self):
-        try:  # May not have an active liveness scope or already been released
-            self._liveness_scope.release()
-            self._liveness_scope = None
-        except:
-            pass
-
-    def __del__(self):
-        self.release_liveness_scope()
 
     def render(self, context: RenderContext) -> list[Element]:
         """
@@ -50,16 +38,8 @@ class FunctionElement(Element):
 
         set_context(context)
 
-        new_liveness_scope = LivenessScope()
-
-        with context, new_liveness_scope.open():
+        with context:
             children = self._render()
-
-        # Release after in case of memoized tables
-        # Ref count goes 1 -> 2 -> 1 by releasing after
-        # instead of 1 -> 0 -> 1 which would release the table
-        self.release_liveness_scope()
-        self._liveness_scope = new_liveness_scope
 
         logger.debug("Resetting to old context %s", old_context)
         set_context(old_context)


### PR DESCRIPTION
Nested components with tables were getting killed if the table was not created in the top-most component