### PR TITLE
feat(ui): Only send new exported objects

### DIFF
--- a/plugins/ui/src/deephaven/ui/components/make_component.py
+++ b/plugins/ui/src/deephaven/ui/components/make_component.py
@@ -1,18 +1,23 @@
 import functools
 import logging
+from typing import Any, Callable
 from .._internal import get_component_qualname
 from ..elements import FunctionElement
 
 logger = logging.getLogger(__name__)
 
 
-def make_component(func):
+def make_component(func: Callable[..., Any]):
     """
     Create a FunctionalElement from the passed in function.
+
+    Args:
+        func: The function to create a FunctionalElement from.
+              Runs when the component is being rendered.
     """
 
     @functools.wraps(func)
-    def make_component_node(*args, **kwargs):
+    def make_component_node(*args: Any, **kwargs: Any):
         component_type = get_component_qualname(func)
 
         return FunctionElement(component_type, lambda: func(*args, **kwargs))

--- a/plugins/ui/src/deephaven/ui/elements/Element.py
+++ b/plugins/ui/src/deephaven/ui/elements/Element.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Any
+from typing import Any, Dict
 from .._internal import RenderContext
+
+PropsType = Dict[str, Any]
 
 
 class Element(ABC):
@@ -21,7 +23,7 @@ class Element(ABC):
         return "deephaven.ui.Element"
 
     @abstractmethod
-    def render(self, context: RenderContext) -> dict[str, Any]:
+    def render(self, context: RenderContext) -> PropsType:
         """
         Renders this element, and returns the result as a dictionary of props for the element.
         If you just want to render children, pass back a dict with children only, e.g. { "children": ... }

--- a/plugins/ui/src/deephaven/ui/elements/__init__.py
+++ b/plugins/ui/src/deephaven/ui/elements/__init__.py
@@ -1,6 +1,6 @@
-from .Element import Element
+from .Element import Element, PropsType
 from .BaseElement import BaseElement
 from .FunctionElement import FunctionElement
 from .UITable import UITable
 
-__all__ = ["BaseElement", "Element", "FunctionElement", "UITable"]
+__all__ = ["BaseElement", "Element", "FunctionElement", "PropsType", "UITable"]

--- a/plugins/ui/src/deephaven/ui/object_types/ElementMessageStream.py
+++ b/plugins/ui/src/deephaven/ui/object_types/ElementMessageStream.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 import io
+import json
 from jsonrpc import JSONRPCResponseManager, Dispatcher
 import logging
 from typing import Any
@@ -83,9 +84,9 @@ class ElementMessageStream(MessageStream):
         if response is None:
             return
 
-        payload = response.json
-        logger.debug("Response: %s, %s", type(payload), payload)
-        self._connection.on_data(payload.encode(), [])
+        response_payload = response.json
+        logger.debug("Response: %s, %s", type(response_payload), response_payload)
+        self._connection.on_data(response_payload.encode(), [])
 
     def _get_next_message_id(self) -> int:
         self._message_id += 1
@@ -129,9 +130,9 @@ class ElementMessageStream(MessageStream):
         """
 
         # TODO(#67): Send a diff of the document instead of the entire document.
-        request = self._make_notification("documentUpdated", root)
-        payload = self._encoder.encode(request)
-
+        encoded_document = self._encoder.encode(root)
+        request = self._make_notification("documentUpdated", encoded_document)
+        payload = json.dumps(request)
         logger.debug(f"Sending payload: {payload}")
 
         dispatcher = Dispatcher()

--- a/plugins/ui/src/deephaven/ui/object_types/ElementMessageStream.py
+++ b/plugins/ui/src/deephaven/ui/object_types/ElementMessageStream.py
@@ -13,6 +13,36 @@ logger = logging.getLogger(__name__)
 
 
 class ElementMessageStream(MessageStream):
+    _manager: JSONRPCResponseManager
+    """
+    Handle incoming requests from the client.
+    """
+
+    _dispatcher: Dispatcher
+    """
+    The dispatcher to use when client calls callables.
+    """
+
+    _encoder: NodeEncoder
+    """
+    Encoder to use to encode the document.
+    """
+
+    _message_id: int
+    """
+    The next message ID to use.
+    """
+
+    _element: Element
+    """
+    The element to render.
+    """
+
+    _connection: MessageStream
+    """
+    The connection to send the rendered element to.
+    """
+
     def __init__(self, element: Element, connection: MessageStream):
         """
         Create a new ElementMessageStream. Renders the element in a render context, and sends the rendered result to the

--- a/plugins/ui/src/deephaven/ui/renderer/NodeEncoder.py
+++ b/plugins/ui/src/deephaven/ui/renderer/NodeEncoder.py
@@ -9,7 +9,7 @@ CALLABLE_KEY = "__dhCbid"
 OBJECT_KEY = "__dhObid"
 ELEMENT_KEY = "__dhElemName"
 
-DEFALT_CALLABLE_ID_PREFIX = "cb"
+DEFAULT_CALLABLE_ID_PREFIX = "cb"
 
 # IDs for callables are prefixes with a string and then use the `id` of the callable itself
 CallableId = str
@@ -53,7 +53,7 @@ class NodeEncoder(json.JSONEncoder):
 
     def __init__(
         self,
-        callable_id_prefix: str = DEFALT_CALLABLE_ID_PREFIX,
+        callable_id_prefix: str = DEFAULT_CALLABLE_ID_PREFIX,
         *args: Any,
         **kwargs: Any,
     ):

--- a/plugins/ui/src/deephaven/ui/renderer/RenderedNode.py
+++ b/plugins/ui/src/deephaven/ui/renderer/RenderedNode.py
@@ -1,4 +1,6 @@
 from __future__ import annotations
+from typing import Optional
+from ..elements import PropsType
 
 
 class RenderedNode:
@@ -7,9 +9,9 @@ class RenderedNode:
     """
 
     _name: str
-    _props: dict | None
+    _props: Optional[PropsType]
 
-    def __init__(self, name: str, props: dict = None):
+    def __init__(self, name: str, props: Optional[PropsType] = None):
         """
         Stores the result of a rendered node
 
@@ -28,7 +30,7 @@ class RenderedNode:
         return self._name
 
     @property
-    def props(self) -> dict | None:
+    def props(self) -> Optional[PropsType]:
         """
         Get the props of the node.
         """

--- a/plugins/ui/src/js/src/ObjectView.tsx
+++ b/plugins/ui/src/js/src/ObjectView.tsx
@@ -14,7 +14,7 @@ function ObjectView(props: ObjectViewProps) {
   log.info('Object is', object);
 
   const fetch = useCallback(async () => {
-    // We reexport the object in case this object is used in multiplate places or closed/opened multiple times
+    // We re-export the object in case this object is used in multiple places or closed/opened multiple times
     const reexportedObject = await object.reexport();
     return reexportedObject.fetch() as Promise<Widget>;
   }, [object]);

--- a/plugins/ui/src/js/src/ObjectView.tsx
+++ b/plugins/ui/src/js/src/ObjectView.tsx
@@ -13,7 +13,11 @@ function ObjectView(props: ObjectViewProps) {
   const { object } = props;
   log.info('Object is', object);
 
-  const fetch = useCallback(() => object.fetch() as Promise<Widget>, [object]);
+  const fetch = useCallback(async () => {
+    // We reexport the object in case this object is used in multiplate places or closed/opened multiple times
+    const reexportedObject = await object.reexport();
+    return reexportedObject.fetch() as Promise<Widget>;
+  }, [object]);
 
   const plugins = usePlugins();
 

--- a/plugins/ui/src/js/src/UITable.tsx
+++ b/plugins/ui/src/js/src/UITable.tsx
@@ -1,5 +1,9 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import { IrisGridProps } from '@deephaven/iris-grid';
+import {
+  IrisGridModel,
+  IrisGridModelFactory,
+  IrisGridProps,
+} from '@deephaven/iris-grid';
 import { useApi } from '@deephaven/jsapi-bootstrap';
 import type { Table } from '@deephaven/jsapi-types';
 import Log from '@deephaven/log';
@@ -14,23 +18,35 @@ export interface UITableProps {
 
 function UITable({ element }: UITableProps) {
   const dh = useApi();
-  const [table, setTable] = useState<Table>();
+  const [model, setModel] = useState<IrisGridModel>();
   const { props: elementProps } = element;
 
   // Just load the object on mount
   useEffect(() => {
+    let isCancelled = false;
     async function loadModel() {
-      log.debug('Loading table from props', element.props);
-      const newTable = (await element.props.table.fetch()) as Table;
-      setTable(newTable);
+      log.debug('Loading table from props', elementProps);
+      const newTable = (await elementProps.table.fetch()) as Table;
+      const newModel = await IrisGridModelFactory.makeModel(dh, newTable);
+      if (!isCancelled) {
+        setModel(newModel);
+      } else {
+        newModel.close();
+      }
     }
     loadModel();
-  }, [dh, element]);
+    return () => {
+      isCancelled = true;
+    };
+  }, [dh, elementProps]);
 
   const irisGridProps: Partial<IrisGridProps> = useMemo(() => {
     const { onRowDoublePress } = elementProps;
     return { onDataSelected: onRowDoublePress };
   }, [elementProps]);
+
+  // We want to clean up the model when we unmount or get a new model
+  useEffect(() => () => model?.close(), [model]);
 
   return table ? (
     <TableObject object={table} irisGridProps={irisGridProps} />

--- a/plugins/ui/src/js/src/UITable.tsx
+++ b/plugins/ui/src/js/src/UITable.tsx
@@ -19,12 +19,20 @@ function UITable({ element }: UITableProps) {
 
   // Just load the object on mount
   useEffect(() => {
+    let isCancelled = false;
     async function loadModel() {
       log.debug('Loading table from props', element.props);
-      const newTable = (await element.props.table.fetch()) as Table;
+      const reexportedTable = await element.props.table.reexport();
+      const newTable = (await reexportedTable.fetch()) as Table;
+      if (isCancelled) {
+        newTable.close();
+      }
       setTable(newTable);
     }
     loadModel();
+    return () => {
+      isCancelled = true;
+    };
   }, [dh, element]);
 
   const irisGridProps: Partial<IrisGridProps> = useMemo(() => {

--- a/plugins/ui/src/js/src/UITable.tsx
+++ b/plugins/ui/src/js/src/UITable.tsx
@@ -1,9 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import {
-  IrisGridModel,
-  IrisGridModelFactory,
-  IrisGridProps,
-} from '@deephaven/iris-grid';
+import { IrisGridProps } from '@deephaven/iris-grid';
 import { useApi } from '@deephaven/jsapi-bootstrap';
 import type { Table } from '@deephaven/jsapi-types';
 import Log from '@deephaven/log';
@@ -18,35 +14,23 @@ export interface UITableProps {
 
 function UITable({ element }: UITableProps) {
   const dh = useApi();
-  const [model, setModel] = useState<IrisGridModel>();
+  const [table, setTable] = useState<Table>();
   const { props: elementProps } = element;
 
   // Just load the object on mount
   useEffect(() => {
-    let isCancelled = false;
     async function loadModel() {
-      log.debug('Loading table from props', elementProps);
-      const newTable = (await elementProps.table.fetch()) as Table;
-      const newModel = await IrisGridModelFactory.makeModel(dh, newTable);
-      if (!isCancelled) {
-        setModel(newModel);
-      } else {
-        newModel.close();
-      }
+      log.debug('Loading table from props', element.props);
+      const newTable = (await element.props.table.fetch()) as Table;
+      setTable(newTable);
     }
     loadModel();
-    return () => {
-      isCancelled = true;
-    };
-  }, [dh, elementProps]);
+  }, [dh, element]);
 
   const irisGridProps: Partial<IrisGridProps> = useMemo(() => {
     const { onRowDoublePress } = elementProps;
     return { onDataSelected: onRowDoublePress };
   }, [elementProps]);
-
-  // We want to clean up the model when we unmount or get a new model
-  useEffect(() => () => model?.close(), [model]);
 
   return table ? (
     <TableObject object={table} irisGridProps={irisGridProps} />

--- a/plugins/ui/src/js/src/WidgetHandler.tsx
+++ b/plugins/ui/src/js/src/WidgetHandler.tsx
@@ -194,7 +194,7 @@ function WidgetHandler({ onClose, widget: wrapper }: WidgetHandlerProps) {
       log.debug('loadWidget', wrapper.id, wrapper.definition);
       let isCancelled = false;
       async function loadWidgetInternal() {
-        const newWidget = await wrapper.fetch();
+        const newWidget = await wrapper.fetch(false);
         if (isCancelled) {
           newWidget.close();
           return;

--- a/plugins/ui/src/js/src/WidgetHandler.tsx
+++ b/plugins/ui/src/js/src/WidgetHandler.tsx
@@ -97,22 +97,34 @@ function WidgetHandler({ onClose, widget: wrapper }: WidgetHandlerProps) {
         const exportedObjectKey = exportedObjectCount.current;
         exportedObjectCount.current += 1;
 
-        if (exportedObject.type === 'Table') {
-          // Table has some special handling compared to other widgets
-          // We want to return a copy of the table, and only release the table object when the widget is actually closed
-        }
+        // if (exportedObject.type === 'Table') {
+        //   // Table has some special handling compared to other widgets
+        //   // We want to return a copy of the table, and only release the table object when the widget is actually closed
+        // }
         // Some elements may fetch the object, then be hidden and close the object temporarily, and then shown again.
         // We can only fetch each exported object once, so just fetch it once and cache it, then subscribe/unsubscribe as needed.
         const cachedObject: [Promise<unknown> | undefined] = [undefined];
         const proxyObject = new Proxy(exportedObject, {
           get: (target, prop, ...rest) => {
             if (prop === 'fetch') {
-              return () => {
-                if (cachedObject[0] === undefined) {
-                  cachedObject[0] = target.fetch();
-                }
-                return cachedObject[0];
+              return async () => {
+                const newObject = await target.fetch();
+                console.log('XXX newObj', newObject);
+                const newObj2 = await target.fetch();
+                console.log('XXX newObj2', newObj2);
+                (newObject as any).close();
+                console.log('XXX newObj closed');
+                const newObj3 = await target.fetch();
+                console.log('XXX newObj3', newObj3);
+                (newObj2 as any).close();
+                return newObj3;
               };
+              // return () => {
+              //   if (cachedObject[0] === undefined) {
+              //     cachedObject[0] = target.fetch();
+              //   }
+              //   return cachedObject[0];
+              // };
             }
             // if (prop === 'close') {
             //   return () => {

--- a/plugins/ui/src/js/src/WidgetTestUtils.ts
+++ b/plugins/ui/src/js/src/WidgetTestUtils.ts
@@ -34,10 +34,12 @@ export function makeWidgetDefinition({
 export function makeWidget({
   addEventListener = jest.fn(() => jest.fn()),
   getDataAsString = () => makeDocumentUpdatedJsonRpcString(),
+  exportedObjects = [],
 }: Partial<Widget> = {}): Widget {
   return TestUtils.createMockProxy<Widget>({
     addEventListener,
     getDataAsString,
+    exportedObjects,
   });
 }
 

--- a/plugins/ui/src/js/src/WidgetTestUtils.ts
+++ b/plugins/ui/src/js/src/WidgetTestUtils.ts
@@ -9,7 +9,7 @@ export function makeDocumentUpdatedJsonRpc(
   return {
     jsonrpc: '2.0',
     method: 'documentUpdated',
-    params: [document],
+    params: [JSON.stringify(document)],
   };
 }
 

--- a/plugins/ui/src/js/src/WidgetTypes.ts
+++ b/plugins/ui/src/js/src/WidgetTypes.ts
@@ -9,7 +9,7 @@ export interface WidgetMessageDetails {
 
 export type WidgetMessageEvent = CustomEvent<WidgetMessageDetails>;
 
-export type WidgetFetch = () => Promise<Widget>;
+export type WidgetFetch = (takeOwnership?: boolean) => Promise<Widget>;
 
 export type WidgetWrapper = {
   definition: WidgetDefinition;

--- a/plugins/ui/test/deephaven/ui/test_encoder.py
+++ b/plugins/ui/test/deephaven/ui/test_encoder.py
@@ -35,9 +35,13 @@ class EncoderTest(BaseTestCase):
             json.loads(payload), expected_payload, "payloads don't match"
         )
         self.assertListEqual(
-            encoder.callables, expected_callables, "callables don't match"
+            list(encoder.callable_dict.keys()),
+            expected_callables,
+            "callables don't match",
         )
-        self.assertListEqual(encoder.objects, expected_objects, "objects don't match")
+        self.assertListEqual(
+            encoder.new_objects, expected_objects, "objects don't match"
+        )
 
     def test_empty_document(self):
         self.expect_result(make_node(""), {"__dhElemName": ""})
@@ -353,6 +357,138 @@ class EncoderTest(BaseTestCase):
             expected_callables=[cb1, cb2, cb3],
             callable_id_prefix="d2c",
         )
+
+    def test_delta_objects(self):
+        """
+        Test that the encoder retains IDs for objects and callables that are the same between encodings.
+        Also check that the encoder only sends new objects in the most recent encoding.
+        """
+
+        from deephaven.ui.renderer import NodeEncoder
+
+        objs = [TestObject(), TestObject(), TestObject()]
+        cbs = [lambda: None, lambda: None, lambda: None]
+
+        # Should use a depth-first traversal to find all exported objects and their indices
+        encoder = NodeEncoder()
+        node = make_node(
+            "test0",
+            {
+                "children": [
+                    make_node("test1", {"foo": [cbs[0]]}),
+                    cbs[1],
+                    make_node("test3", {"bar": cbs[2], "children": [objs[0], objs[1]]}),
+                    make_node("test4", {"children": [objs[0], objs[2]]}),
+                    objs[1],
+                    make_node("test6", {"children": [objs[2]]}),
+                ]
+            },
+        )
+
+        payload = encoder.encode(node)
+        expected_payload = {
+            "__dhElemName": "test0",
+            "props": {
+                "children": [
+                    {
+                        "__dhElemName": "test1",
+                        "props": {"foo": [{"__dhCbid": "cb0"}]},
+                    },
+                    {"__dhCbid": "cb1"},
+                    {
+                        "__dhElemName": "test3",
+                        "props": {
+                            "bar": {"__dhCbid": "cb2"},
+                            "children": [
+                                {"__dhObid": 0},
+                                {"__dhObid": 1},
+                            ],
+                        },
+                    },
+                    {
+                        "__dhElemName": "test4",
+                        "props": {"children": [{"__dhObid": 0}, {"__dhObid": 2}]},
+                    },
+                    {"__dhObid": 1},
+                    {
+                        "__dhElemName": "test6",
+                        "props": {"children": [{"__dhObid": 2}]},
+                    },
+                ],
+            },
+        }
+
+        self.assertDictEqual(
+            json.loads(payload), expected_payload, "payloads don't match"
+        )
+        self.assertListEqual(
+            list(encoder.callable_dict.keys()), cbs, "callables don't match"
+        )
+        self.assertListEqual(encoder.new_objects, objs, "objects don't match")
+
+        # Add some new objects and callables to the mix for next encoding
+        delta_objs = [TestObject()]
+        delta_cbs = [lambda: None]
+        objs = [objs[0], None, objs[2], delta_objs[0]]
+        cbs = [cbs[0], None, cbs[2], delta_cbs[0]]
+
+        # Replace cb[1] and obj[1] with the new callable/object and encode again
+        node = make_node(
+            "test0",
+            {
+                "children": [
+                    make_node("test1", {"foo": [cbs[0]]}),
+                    cbs[3],
+                    make_node("test3", {"bar": cbs[2], "children": [objs[0], objs[3]]}),
+                    make_node("test4", {"children": [objs[0], objs[2]]}),
+                    objs[3],
+                    make_node("test6", {"children": [objs[2]]}),
+                ]
+            },
+        )
+
+        payload = encoder.encode(node)
+        expected_payload = {
+            "__dhElemName": "test0",
+            "props": {
+                "children": [
+                    {
+                        "__dhElemName": "test1",
+                        "props": {"foo": [{"__dhCbid": "cb0"}]},
+                    },
+                    {"__dhCbid": "cb3"},
+                    {
+                        "__dhElemName": "test3",
+                        "props": {
+                            "bar": {"__dhCbid": "cb2"},
+                            "children": [
+                                {"__dhObid": 0},
+                                {"__dhObid": 3},
+                            ],
+                        },
+                    },
+                    {
+                        "__dhElemName": "test4",
+                        "props": {"children": [{"__dhObid": 0}, {"__dhObid": 2}]},
+                    },
+                    {"__dhObid": 3},
+                    {
+                        "__dhElemName": "test6",
+                        "props": {"children": [{"__dhObid": 2}]},
+                    },
+                ],
+            },
+        }
+
+        self.assertDictEqual(
+            json.loads(payload), expected_payload, "payloads don't match"
+        )
+        self.assertListEqual(
+            list(encoder.callable_dict.keys()),
+            [cbs[0], cbs[2], cbs[3]],
+            "callables don't match",
+        )
+        self.assertListEqual(encoder.new_objects, delta_objs, "objects don't match")
 
 
 if __name__ == "__main__":

--- a/plugins/ui/test/deephaven/ui/test_encoder.py
+++ b/plugins/ui/test/deephaven/ui/test_encoder.py
@@ -30,17 +30,17 @@ class EncoderTest(BaseTestCase):
         from deephaven.ui.renderer import NodeEncoder
 
         encoder = NodeEncoder(callable_id_prefix=callable_id_prefix)
-        payload = encoder.encode(node)
+        result = encoder.encode_node(node)
         self.assertDictEqual(
-            json.loads(payload), expected_payload, "payloads don't match"
+            json.loads(result["encoded_node"]), expected_payload, "payloads don't match"
         )
         self.assertListEqual(
-            list(encoder.callable_dict.keys()),
+            list(result["callable_id_dict"].keys()),
             expected_callables,
             "callables don't match",
         )
         self.assertListEqual(
-            encoder.new_objects, expected_objects, "objects don't match"
+            result["new_objects"], expected_objects, "objects don't match"
         )
 
     def test_empty_document(self):
@@ -385,7 +385,8 @@ class EncoderTest(BaseTestCase):
             },
         )
 
-        payload = encoder.encode(node)
+        result = encoder.encode_node(node)
+
         expected_payload = {
             "__dhElemName": "test0",
             "props": {
@@ -419,12 +420,12 @@ class EncoderTest(BaseTestCase):
         }
 
         self.assertDictEqual(
-            json.loads(payload), expected_payload, "payloads don't match"
+            json.loads(result["encoded_node"]), expected_payload, "payloads don't match"
         )
         self.assertListEqual(
-            list(encoder.callable_dict.keys()), cbs, "callables don't match"
+            list(result["callable_id_dict"].keys()), cbs, "callables don't match"
         )
-        self.assertListEqual(encoder.new_objects, objs, "objects don't match")
+        self.assertListEqual(result["new_objects"], objs, "objects don't match")
 
         # Add some new objects and callables to the mix for next encoding
         delta_objs = [TestObject()]
@@ -447,7 +448,7 @@ class EncoderTest(BaseTestCase):
             },
         )
 
-        payload = encoder.encode(node)
+        result = encoder.encode_node(node)
         expected_payload = {
             "__dhElemName": "test0",
             "props": {
@@ -481,14 +482,14 @@ class EncoderTest(BaseTestCase):
         }
 
         self.assertDictEqual(
-            json.loads(payload), expected_payload, "payloads don't match"
+            json.loads(result["encoded_node"]), expected_payload, "payloads don't match"
         )
         self.assertListEqual(
-            list(encoder.callable_dict.keys()),
+            list(result["callable_id_dict"].keys()),
             [cbs[0], cbs[2], cbs[3]],
             "callables don't match",
         )
-        self.assertListEqual(encoder.new_objects, delta_objs, "objects don't match")
+        self.assertListEqual(result["new_objects"], delta_objs, "objects don't match")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- Instead of resending the full list of exported objects each time, just send the newly exported objects
- Increment the ID for each new object that is created
- Keep a weak reference to old objects so they are released when no longer referenced
- Objects remain the same between renders 
- Tested using the steps in #128 
- Fixes #128, fixes #67
- Needs https://github.com/deephaven/deephaven-core/pull/4909 to handle fetching objects multiple times if necessary

BREAKING CHANGE: JSON protocol now keeps the IDs of objects and callables stable between re-renders, and only exports new objects with each documentUpdated event. The client must track the old objects independently.