### PR TITLE
ci: Always run the `modified-plugin` actions, don't use paths filter

### DIFF
--- a/.github/workflows/modified-plugin.yml
+++ b/.github/workflows/modified-plugin.yml
@@ -3,12 +3,6 @@ name: Test Modified Plugin
 on:
   pull_request:
     branches: [main]
-    paths:
-      - 'plugins/plotly-express/**'
-      - 'plugins/plotly/**'
-      - 'plugins/matplotlib/**'
-      - 'plugins/json/**'
-      - 'plugins/ui/**'
   push:
     branches: [main]
     tags:


### PR DESCRIPTION
- Checks skipped with the "paths" filter never run, but we want to have branch protection based on the `test-python` and `test-js` steps
- GitHub recommends not filtering on paths for required actions: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/troubleshooting-required-status-checks#handling-skipped-but-required-checks
- Don't filter on paths for triggering the action; each step is already conditional on if there were actually changes to the package or not
