### PR TITLE
ci: Add a test-results action that is the result of the previous tests

### DIFF
--- a/.github/workflows/modified-plugin.yml
+++ b/.github/workflows/modified-plugin.yml
@@ -50,6 +50,18 @@ jobs:
     if: ${{ needs.changes.outputs.packages != '[]' && needs.changes.outputs.packages != '' }}
     uses: ./.github/workflows/test-js-packages.yml
 
+  # Action that outputs success is test-python and test-js are either both successful or both skipped
+  # This action will simply throw if either of the test-js or test-python jobs fail
+  # https://github.com/orgs/community/discussions/26822#discussioncomment-5122101
+  test-results:
+    if: ${{ always() }}
+    runs-on: ubuntu-22.04
+    needs: [test-python, test-js]
+    steps:
+      # Only fail if one of the previous tests failed
+      - run: exit 1
+        if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
+
   filter-release:
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-22.04


### PR DESCRIPTION
- Should pass if the previous tests pass, otherwise it should fail
- Tested with a whole bunch of actions in my fork: https://github.com/mofojed/deephaven-plugins/pulls
  - Tested scenarios where both actions were skipped, both passed, both failed, or just one action failed, and the test-results action was always the correct success/failure state
- Still need to update the infra protection