### PR TITLE
fix: type hint was wrong type in dx data generator

### DIFF
--- a/plugins/plotly-express/src/deephaven/plot/express/data/data_generators.py
+++ b/plugins/plotly-express/src/deephaven/plot/express/data/data_generators.py
@@ -178,7 +178,7 @@ def stocks(ticking: bool = True, hours_of_data: int = 1) -> Table:
     def random_list_exchange(seed: int) -> str:
         return random.choices(exchange, exchange_weights)[0]
 
-    def random_trade_size(rand: int) -> int:
+    def random_trade_size(rand: float) -> int:
         """
         Random distribution of trade size, approximately mirroring market data
         """


### PR DESCRIPTION
Better type hinting support means this mistake was now actually triggering an error. 

Engine is currently returning numpy types instead of python types, which is a bug in core. Initial random.seed(seed) is printing this error because of the numpy.int64 type, but is expected to be fixed in the next dhc release.

> DeprecationWarning: Seeding based on hashing is deprecated
since Python 3.9 and will be removed in a subsequent version. The only
supported seed types are: None, int, float, str, bytes, and bytearray.

See: deephaven/deephaven-core#4933