### PR TITLE
build: Fix docker script to always update the volumes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,3 +7,5 @@ services:
       pull: true
     ports:
       - '${DEEPHAVEN_PORT:-10000}:10000'
+    volumes:
+      - ./docker/data/:/data

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "./plugins/*/src/js/"
   ],
   "scripts": {
-    "docker": "docker compose up --build",
+    "docker": "docker compose up --renew-anon-volumes --build",
     "start": "run-p start:packages serve:plugins",
     "build": "lerna run build --stream",
     "serve:plugins": "vite",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "./plugins/*/src/js/"
   ],
   "scripts": {
-    "docker": "docker compose up --renew-anon-volumes --build",
+    "docker": "docker compose up --build",
     "start": "run-p start:packages serve:plugins",
     "build": "lerna run build --stream",
     "serve:plugins": "vite",


### PR DESCRIPTION
- Noticed since switching to a docker-compose, that changes I made to DEMO.md weren't being copied to the image if I hadn't made any other changes and the image still existed
- Instead of doing a docker-compose down after and removing the image, just add a volume for the data directory as well to always get data instead of using data from a previous container
- Tested by running `npm run docker`, closing, then changing the DEMO.md, running `npm run docker` again, and checking my changes to DEMO.md were displayed
- Also tested with a docker-compose.override.yml with a path to a folder for my own data as detailed in the README, and that worked correctly as well
