### PR TITLE
feat: Queue render state updates on a thread

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31218,7 +31218,7 @@
     },
     "plugins/ui/src/js": {
       "name": "@deephaven/js-plugin-ui",
-      "version": "0.0.1",
+      "version": "0.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/react-spectrum": "^3.29.0",

--- a/plugins/ui/examples/README.md
+++ b/plugins/ui/examples/README.md
@@ -813,3 +813,93 @@ watch = watch_lizards(stocks)
 ```
 
 ![Table Hooks](assets/table_hooks.png)
+
+## Multi-threading
+
+State updates must be called from the render thread. All callbacks are automatically called from the render thread, but sometimes you will need to do some long-running operations asynchronously. You can use the `use_render_queue` hook to run a callback on the render thread. In this example, we create a form that takes a URL as input, and loads the CSV file from another thread before updating the state on the current thread.
+
+```python
+import logging
+import threading
+import time
+from deephaven import read_csv, ui
+
+
+@ui.component
+def csv_loader():
+    # The render_queue we fetch using the `use_render_queue` hook at the top of the component
+    render_queue = ui.use_render_queue()
+    table, set_table = ui.use_state()
+    error, set_error = ui.use_state()
+
+    def handle_submit(data):
+        # We define a callable that we'll queue up on our own thread
+        def load_table():
+            try:
+                # Read the table from the URL
+                t = read_csv(data["url"])
+
+                # Define our state updates in another callable. We'll need to call this on the render thread
+                def update_state():
+                    set_error(None)
+                    set_table(t)
+
+                # Queue up the state update on the render thread
+                render_queue(update_state)
+            except Exception as e:
+                # In case we have any errors, we should show the error to the user. We still need to call this from the render thread,
+                # so we must assign the exception to a variable and call the render_queue with a callable that will set the error
+                error_message = e
+
+                def update_state():
+                    set_table(None)
+                    set_error(error_message)
+
+                # Queue up the state update on the render thread
+                render_queue(update_state)
+
+        # Start our own thread loading the table
+        threading.Thread(target=load_table).start()
+
+    return [
+        # Our form displaying input from the user
+        ui.form(
+            ui.flex(
+                ui.text_field(
+                    default_value="https://media.githubusercontent.com/media/deephaven/examples/main/DeNiro/csv/deniro.csv",
+                    label="Enter URL",
+                    label_position="side",
+                    name="url",
+                    flex_grow=1,
+                ),
+                ui.button(f"Load Table", type="submit"),
+                gap=10,
+            ),
+            on_submit=handle_submit,
+        ),
+        (
+            # Display a hint if the table is not loaded yet and we don't have an error
+            ui.illustrated_message(
+                ui.heading("Enter URL above"),
+                ui.content("Enter a URL of a CSV above and click 'Load' to load it"),
+            )
+            if error is None and table is None
+            else None
+        ),
+        # The loaded table. Doesn't show anything if it is not loaded yet
+        table,
+        # An error message if there is an error
+        (
+            ui.illustrated_message(
+                ui.icon("vsWarning"),
+                ui.heading("Error loading table"),
+                ui.content(f"{error}"),
+            )
+            if error != None
+            else None
+        ),
+    ]
+
+
+my_loader = csv_loader()
+```

--- a/plugins/ui/setup.cfg
+++ b/plugins/ui/setup.cfg
@@ -25,7 +25,8 @@ package_dir=
     =src
 packages=find_namespace:
 install_requires =
-    deephaven-plugin
+    deephaven-core>=0.31.0
+    deephaven-plugin>=0.6.0
     json-rpc
 include_package_data = True
 

--- a/plugins/ui/src/deephaven/ui/_internal/RenderContext.py
+++ b/plugins/ui/src/deephaven/ui/_internal/RenderContext.py
@@ -139,5 +139,8 @@ class RenderContext(AbstractContextManager):
     def queue_render(self, update: Callable[[], None]) -> None:
         """
         Queue up a state update. Needed in multi-threading scenarios.
+
+        Args:
+            update: The update to queue up.
         """
         self._on_queue_render(update)

--- a/plugins/ui/src/deephaven/ui/_internal/RenderContext.py
+++ b/plugins/ui/src/deephaven/ui/_internal/RenderContext.py
@@ -40,7 +40,7 @@ The key for a child context.
 """
 
 
-class RenderContext(AbstractContextManager[None]):
+class RenderContext(AbstractContextManager):
     """
     Context for rendering a component. Keeps track of state and child contexts.
     Used by hooks to get and set state.

--- a/plugins/ui/src/deephaven/ui/_internal/RenderContext.py
+++ b/plugins/ui/src/deephaven/ui/_internal/RenderContext.py
@@ -107,12 +107,10 @@ class RenderContext(AbstractContextManager):
         """
         return key in self._state
 
-    def get_state(self, key: StateKey, default: Any = None) -> None:
+    def get_state(self, key: StateKey) -> Any:
         """
         Get the state for the given key.
         """
-        if key not in self._state:
-            self._state[key] = default
         return self._state[key]
 
     def set_state(self, key: StateKey, value: StateValue[T]) -> None:

--- a/plugins/ui/src/deephaven/ui/_internal/RenderContext.py
+++ b/plugins/ui/src/deephaven/ui/_internal/RenderContext.py
@@ -1,14 +1,14 @@
 from __future__ import annotations
 
 import logging
-from typing import Any, Callable
+from typing import Any, Callable, Union
 from contextlib import AbstractContextManager
 
 logger = logging.getLogger(__name__)
 
 OnChangeCallable = Callable[[], None]
 StateKey = int
-ContextKey = str
+ContextKey = Union[str, int]
 
 
 class RenderContext(AbstractContextManager):
@@ -102,6 +102,7 @@ class RenderContext(AbstractContextManager):
         Set the state for the given key.
         """
         # TODO: Should we throw here if it's called when we're in the middle of a render?
+        # TODO: How do we batch the state changes so they run on the next loop?
         should_notify = False
         if key in self._state:
             # We only want to notify of a change when the value actually changes, not on the initial render

--- a/plugins/ui/src/deephaven/ui/_internal/RenderContext.py
+++ b/plugins/ui/src/deephaven/ui/_internal/RenderContext.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Any, Callable, Union
+from typing import Any, Callable, Union, TypeVar
 from contextlib import AbstractContextManager
 
 logger = logging.getLogger(__name__)
@@ -18,7 +18,20 @@ Callable that is called when there is a change in the context (setting the state
 
 
 StateKey = int
+"""
+The key for a state value. Should be the hook index.
+"""
+
+T = TypeVar("T")
+StateValue = T | Callable[[T | None], T]
+"""
+The value for a state. Can be a callable that takes the old value and returns the new value.
+"""
+
 ContextKey = Union[str, int]
+"""
+The key for a child context.
+"""
 
 
 class RenderContext(AbstractContextManager):
@@ -102,14 +115,22 @@ class RenderContext(AbstractContextManager):
             self._state[key] = default
         return self._state[key]
 
-    def set_state(self, key: StateKey, value: Any) -> None:
+    def set_state(self, key: StateKey, value: StateValue[T]) -> None:
         """
         Set the state for the given key.
+
+        Args:
+            key: The key to set the state for.
+            value: The value to set the state to. Can be a callable that takes the old value and returns the new value.
         """
 
         # We queue up the state change in a callable that will get called from the render loop
         def update_state():
-            self._state[key] = value
+            new_value = value
+            if callable(value):
+                old_value = self._state[key]
+                new_value = value(old_value)
+            self._state[key] = new_value
 
         if key not in self._state:
             # We haven't set the state for this key yet, this is the initial render. We can just set the state immediately, we don't need to queue it for notification

--- a/plugins/ui/src/deephaven/ui/_internal/__init__.py
+++ b/plugins/ui/src/deephaven/ui/_internal/__init__.py
@@ -1,4 +1,9 @@
-from .RenderContext import RenderContext
+from .RenderContext import (
+    RenderContext,
+    StateKey,
+    StateUpdateCallable,
+    OnChangeCallable,
+)
 from .shared import get_context, set_context
 from .utils import (
     get_component_name,

--- a/plugins/ui/src/deephaven/ui/_internal/__init__.py
+++ b/plugins/ui/src/deephaven/ui/_internal/__init__.py
@@ -4,7 +4,7 @@ from .RenderContext import (
     StateUpdateCallable,
     OnChangeCallable,
 )
-from .shared import get_context, set_context
+from .shared import get_context, set_context, NoContextException
 from .utils import (
     get_component_name,
     get_component_qualname,

--- a/plugins/ui/src/deephaven/ui/elements/FunctionElement.py
+++ b/plugins/ui/src/deephaven/ui/elements/FunctionElement.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 import logging
-from typing import Callable
-from .Element import Element
-from .._internal import RenderContext, get_context, set_context
+from typing import Callable, Optional
+from .Element import Element, PropsType
+from .._internal import RenderContext, get_context, set_context, NoContextException
 
 logger = logging.getLogger(__name__)
 
@@ -23,7 +23,7 @@ class FunctionElement(Element):
     def name(self):
         return self._name
 
-    def render(self, context: RenderContext) -> list[Element]:
+    def render(self, context: RenderContext) -> PropsType:
         """
         Render the component. Should only be called when actually rendering the component, e.g. exporting it to the client.
 
@@ -31,9 +31,13 @@ class FunctionElement(Element):
             context: Context to render the component in
 
         Returns:
-            The rendered component.
+            The props of this element.
         """
-        old_context = get_context()
+        old_context: Optional[RenderContext] = None
+        try:
+            old_context = get_context()
+        except NoContextException:
+            pass
         logger.debug("old context is %s and new context is %s", old_context, context)
 
         set_context(context)

--- a/plugins/ui/src/deephaven/ui/hooks/__init__.py
+++ b/plugins/ui/src/deephaven/ui/hooks/__init__.py
@@ -3,6 +3,7 @@ from .use_effect import use_effect
 from .use_memo import use_memo
 from .use_state import use_state
 from .use_ref import use_ref
+from .use_render_queue import use_render_queue
 from .use_table_listener import use_table_listener
 from .use_table_data import use_table_data
 from .use_column_data import use_column_data
@@ -17,6 +18,7 @@ __all__ = [
     "use_memo",
     "use_state",
     "use_ref",
+    "use_render_queue",
     "use_table_listener",
     "use_table_data",
     "use_column_data",

--- a/plugins/ui/src/deephaven/ui/hooks/use_memo.py
+++ b/plugins/ui/src/deephaven/ui/hooks/use_memo.py
@@ -1,7 +1,10 @@
-from .use_ref import use_ref
+from .use_ref import use_ref, Ref
+from typing import Any, Callable, TypeVar
+
+T = TypeVar("T")
 
 
-def use_memo(func, dependencies):
+def use_memo(func: Callable[[], T], dependencies: set[Any]) -> T:
     """
     Memoize the result of a function call. The function will only be called again if the dependencies change.
 
@@ -12,11 +15,11 @@ def use_memo(func, dependencies):
     Returns:
         The memoized result of the function call.
     """
-    deps_ref = use_ref(None)
-    value_ref = use_ref(None)
+    deps_ref: Ref[set[Any] | None] = use_ref(None)
+    value_ref: Ref[T | None] = use_ref(None)
 
     if deps_ref.current != dependencies:
         value_ref.current = func()
         deps_ref.current = dependencies
 
-    return value_ref.current
+    return value_ref.current  # type: ignore

--- a/plugins/ui/src/deephaven/ui/hooks/use_memo.py
+++ b/plugins/ui/src/deephaven/ui/hooks/use_memo.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from .use_ref import use_ref, Ref
 from typing import Any, Callable, TypeVar
 

--- a/plugins/ui/src/deephaven/ui/hooks/use_render_queue.py
+++ b/plugins/ui/src/deephaven/ui/hooks/use_render_queue.py
@@ -1,0 +1,14 @@
+from .._internal import OnChangeCallable
+from .._internal.shared import get_context
+
+
+def use_render_queue() -> OnChangeCallable:
+    """
+    Returns a callback function for adding things to the render queue.
+    Should only be used if you're loading data from a background thread and want to update state.
+
+    Returns:
+        A callback function that takes a function to call on the render thread.
+    """
+    context = get_context()
+    return context.queue_render

--- a/plugins/ui/src/deephaven/ui/hooks/use_state.py
+++ b/plugins/ui/src/deephaven/ui/hooks/use_state.py
@@ -22,14 +22,13 @@ def use_state(
     context = get_context()
     hook_index = context.next_hook_index()
 
-    value = initial_value
-    if context.has_state(hook_index):
-        value = context.get_state(hook_index)
-    else:
-        # Initialize the state
-        context.set_state(hook_index, value)
+    if not context.has_state(hook_index):
+        # Need to initialize the state on the first render
+        context.set_state(hook_index, initial_value)
 
-    def set_value(new_value):
+    value: T = context.get_state(hook_index)
+
+    def set_value(new_value: StateValue[T]):
         # Set the value in the context state and trigger a re-render
         logger.debug("use_state set_value called with %s", new_value)
         context.set_state(hook_index, new_value)

--- a/plugins/ui/src/deephaven/ui/hooks/use_state.py
+++ b/plugins/ui/src/deephaven/ui/hooks/use_state.py
@@ -31,10 +31,7 @@ def use_state(
 
     if not context.has_state(hook_index):
         # This is the first render, initialize the value
-        context.set_state(
-            hook_index,
-            initial_value if not callable(initial_value) else initial_value(),
-        )
+        context.init_state(hook_index, initial_value)
 
     value: T = context.get_state(hook_index)
 

--- a/plugins/ui/src/deephaven/ui/hooks/use_state.py
+++ b/plugins/ui/src/deephaven/ui/hooks/use_state.py
@@ -9,11 +9,11 @@ T = TypeVar("T")
 
 
 @overload
-def use_state(initial_value: T) -> (T, Callable[[T], None]):
+def use_state(initial_value: T) -> tuple[T, Callable[[T], None]]:
     ...
 
 
-def use_state(initial_value: T | None = None) -> (T | None, Callable[[T], None]):
+def use_state(initial_value: T | None = None) -> tuple[T | None, Callable[[T], None]]:
     context = get_context()
     hook_index = context.next_hook_index()
 

--- a/plugins/ui/src/deephaven/ui/hooks/use_state.py
+++ b/plugins/ui/src/deephaven/ui/hooks/use_state.py
@@ -1,12 +1,19 @@
 from __future__ import annotations
 import logging
-from typing import Callable, TypeVar, overload
+from typing import Any, Callable, TypeVar, overload
 from .._internal.shared import get_context
 from .._internal.RenderContext import InitializerFunction, UpdaterFunction
 
 logger = logging.getLogger(__name__)
 
 T = TypeVar("T")
+
+
+# TODO (#208): We can improve the typing in Python 3.12 when we have type parameter syntax for functions
+# For not just allow `None`
+@overload
+def use_state() -> tuple[Any, Callable[[Any | UpdaterFunction[Any]], None]]:
+    ...
 
 
 @overload
@@ -16,30 +23,25 @@ def use_state(
     ...
 
 
-@overload
 def use_state(
-    initial_state: T | InitializerFunction[T] | None = None,
-) -> tuple[T | None, Callable[[T | UpdaterFunction[T]], None]]:
-    ...
-
-
-def use_state(
-    initial_state: T | InitializerFunction[T] | None = None,
-) -> tuple[T | None, Callable[[T | UpdaterFunction[T]], None]]:
+    initial_state: T | InitializerFunction[T] = None,
+) -> tuple[T, Callable[[T | UpdaterFunction[T]], None]]:
     """
     Hook to add a state variable to your component. The state will persist across renders.
 
     Args:
         initial_state: The initial value for the state.
-        It can be any type, but passing a function will treat it as an initializer function.
-        An initializer function is called with no parameters once on the first render to get the initial value.
-        After the initial render the argument is ignored.
+            It can be any type, but passing a function will treat it as an initializer function.
+            An initializer function is called with no parameters once on the first render to get the initial value.
+            After the initial render the argument is ignored.
+            If an initial value is provided, only types matching that initial value will be valid when calling the returned set state function.
+            If no initial value is provided, any type can be passed to the set state function.
 
     Returns:
         A tuple containing the current value of the state and a function to set the state.
         The set state function can take a new value or an updater function.
-        If the set state function is called with a new value, the state will be set to that value.
-        If the set state function is called with an updater function, the updater function will be called with the current state value and the new state will be set to the return value of the updater function.
+        - If the set state function is called with a new value, the state will be set to that value.
+        - If the set state function is called with an updater function, the updater function will be called with the current state value and the new state will be set to the return value of the updater function.
     """
     context = get_context()
     hook_index = context.next_hook_index()

--- a/plugins/ui/src/deephaven/ui/hooks/use_state.py
+++ b/plugins/ui/src/deephaven/ui/hooks/use_state.py
@@ -11,27 +11,42 @@ T = TypeVar("T")
 
 @overload
 def use_state(
-    initial_value: T | InitializerFunction[T],
+    initial_state: T | InitializerFunction[T],
 ) -> tuple[T, Callable[[T | UpdaterFunction[T]], None]]:
     ...
 
 
 @overload
 def use_state(
-    initial_value: T | InitializerFunction[T] | None = None,
+    initial_state: T | InitializerFunction[T] | None = None,
 ) -> tuple[T | None, Callable[[T | UpdaterFunction[T]], None]]:
     ...
 
 
 def use_state(
-    initial_value: T | InitializerFunction[T] | None = None,
+    initial_state: T | InitializerFunction[T] | None = None,
 ) -> tuple[T | None, Callable[[T | UpdaterFunction[T]], None]]:
+    """
+    Hook to add a state variable to your component. The state will persist across renders.
+
+    Args:
+        initial_state: The initial value for the state.
+        It can be any type, but passing a function will treat it as an initializer function.
+        An initializer function is called with no parameters once on the first render to get the initial value.
+        After the initial render the argument is ignored.
+
+    Returns:
+        A tuple containing the current value of the state and a function to set the state.
+        The set state function can take a new value or an updater function.
+        If the set state function is called with a new value, the state will be set to that value.
+        If the set state function is called with an updater function, the updater function will be called with the current state value and the new state will be set to the return value of the updater function.
+    """
     context = get_context()
     hook_index = context.next_hook_index()
 
     if not context.has_state(hook_index):
         # This is the first render, initialize the value
-        context.init_state(hook_index, initial_value)
+        context.init_state(hook_index, initial_state)
 
     value: T = context.get_state(hook_index)
 

--- a/plugins/ui/src/deephaven/ui/hooks/use_state.py
+++ b/plugins/ui/src/deephaven/ui/hooks/use_state.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 import logging
 from typing import Callable, TypeVar, overload
 from .._internal.shared import get_context
+from .._internal.RenderContext import StateValue
 
 logger = logging.getLogger(__name__)
 
@@ -9,11 +10,15 @@ T = TypeVar("T")
 
 
 @overload
-def use_state(initial_value: T) -> tuple[T, Callable[[T], None]]:
+def use_state(
+    initial_value: T,
+) -> tuple[T, Callable[[StateValue[T]], None]]:
     ...
 
 
-def use_state(initial_value: T | None = None) -> tuple[T | None, Callable[[T], None]]:
+def use_state(
+    initial_value: StateValue[T] | None = None,
+) -> tuple[T | None, Callable[[StateValue[T]], None]]:
     context = get_context()
     hook_index = context.next_hook_index()
 
@@ -22,8 +27,6 @@ def use_state(initial_value: T | None = None) -> tuple[T | None, Callable[[T], N
         value = context.get_state(hook_index)
     else:
         # Initialize the state
-        if callable(value):
-            value = value()
         context.set_state(hook_index, value)
 
     def set_value(new_value):

--- a/plugins/ui/src/deephaven/ui/object_types/ElementMessageStream.py
+++ b/plugins/ui/src/deephaven/ui/object_types/ElementMessageStream.py
@@ -12,6 +12,8 @@ from ..renderer.NodeEncoder import NodeEncoder
 
 logger = logging.getLogger(__name__)
 
+# TODO: Get a thread from a thread pool here for rendering and callbacks?
+
 
 class ElementMessageStream(MessageStream):
     _manager: JSONRPCResponseManager

--- a/plugins/ui/src/deephaven/ui/renderer/Renderer.py
+++ b/plugins/ui/src/deephaven/ui/renderer/Renderer.py
@@ -76,7 +76,7 @@ def _render_element(element: Element, context: RenderContext) -> RenderedNode:
 class Renderer:
     _liveness_scope: LivenessScope
 
-    def __init__(self, context: RenderContext = RenderContext()):
+    def __init__(self, context: RenderContext):
         self._context = context
         self._liveness_scope = LivenessScope()
 

--- a/plugins/ui/src/deephaven/ui/renderer/Renderer.py
+++ b/plugins/ui/src/deephaven/ui/renderer/Renderer.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import logging
 from typing import Any
 from deephaven.liveness_scope import LivenessScope

--- a/plugins/ui/src/deephaven/ui/renderer/Renderer.py
+++ b/plugins/ui/src/deephaven/ui/renderer/Renderer.py
@@ -2,13 +2,57 @@ import logging
 from typing import Any
 from deephaven.liveness_scope import LivenessScope
 from .._internal import RenderContext
-from ..elements import Element
+from ..elements import Element, PropsType
 from .RenderedNode import RenderedNode
 
 logger = logging.getLogger(__name__)
 
 
-def _render(context: RenderContext, element: Element):
+def _render_item(item: Any, context: RenderContext) -> Any:
+    logger.debug("_render_item context is %s", context)
+    if isinstance(item, list) or isinstance(item, tuple):
+        # I couldn't figure out how to map a `list[Unknown]` to a `list[Any]`, or to accept a `list[Unknown]` as a parameter
+        return _render_list(item, context)  # type: ignore
+    if isinstance(item, dict):
+        return _render_dict(item, context)  # type: ignore
+    if isinstance(item, Element):
+        logger.debug(
+            "render_child element %s: %s",
+            type(item),
+            item,
+        )
+        return _render_element(item, context)
+    else:
+        logger.debug("render_item returning child (%s): %s", type(item), item)
+        return item
+
+
+def _render_list(
+    item: list[Any] | tuple[Any, ...], context: RenderContext
+) -> list[Any]:
+    """
+    Render a list. You may be able to pass in an element as a prop that needs to be rendered, not just as a child.
+    """
+    logger.debug("_render_list %s", item)
+    return [
+        _render_item(value, context.get_child_context(key))
+        for key, value in enumerate(item)
+    ]
+
+
+def _render_dict(item: PropsType, context: RenderContext) -> PropsType:
+    """
+    Render a dictionary. You may be able to pass in an element as a prop that needs to be rendered, not just as a child.
+    For example, a `label` prop of a button can accept a string or an element.
+    """
+    logger.debug("_render_props %s", item)
+    return {
+        key: _render_item(value, context.get_child_context(key))
+        for key, value in item.items()
+    }
+
+
+def _render_element(element: Element, context: RenderContext) -> RenderedNode:
     """
     Render an Element.
 
@@ -19,43 +63,19 @@ def _render(context: RenderContext, element: Element):
     Returns:
         The RenderedNode representing the element.
     """
-
-    def render_child(child: Any, child_context: RenderContext):
-        logger.debug("child_context is %s", child_context)
-        if isinstance(child, list) or isinstance(child, tuple):
-            logger.debug("render_child list: %s", child)
-            return [
-                render_child(child, child_context.get_child_context(i))
-                for i, child in enumerate(child)
-            ]
-        if isinstance(child, dict):
-            logger.debug("render_child dict: %s", child)
-            return {
-                key: render_child(value, child_context.get_child_context(key))
-                for key, value in child.items()
-            }
-        if isinstance(child, Element):
-            logger.debug(
-                "render_child element %s: %s",
-                type(child),
-                child,
-            )
-            return _render(child_context, child)
-        else:
-            logger.debug("render_child returning child (%s): %s", type(child), child)
-            return child
-
     logger.debug("Rendering %s: ", element.name)
 
     props = element.render(context)
 
     # We also need to render any elements that are passed in as props
-    props = render_child(props, context)
+    props = _render_dict(props, context)
 
     return RenderedNode(element.name, props)
 
 
 class Renderer:
+    _liveness_scope: LivenessScope
+
     def __init__(self, context: RenderContext = RenderContext()):
         self._context = context
         self._liveness_scope = LivenessScope()
@@ -66,14 +86,15 @@ class Renderer:
     def release_liveness_scope(self):
         try:  # May not have an active liveness scope or already been released
             self._liveness_scope.release()
-            self._liveness_scope = None
         except:
             pass
 
-    def render(self, element: Element):
+    def render(self, element: Element) -> RenderedNode:
+        # TODO: Should we be tracking if we're mid render here?
+        # TODO: Should we be doing this render on a separate thread?
         new_liveness_scope = LivenessScope()
         with new_liveness_scope.open():
-            render_res = _render(self._context, element)
+            render_res = _render_element(element, self._context)
 
         # Release after in case of memoized tables
         # Ref count goes 1 -> 2 -> 1 by releasing after

--- a/plugins/ui/test/deephaven/ui/test_hooks.py
+++ b/plugins/ui/test/deephaven/ui/test_hooks.py
@@ -19,7 +19,7 @@ def render_hook(fn: Callable):
     from deephaven.ui._internal.RenderContext import RenderContext
     from deephaven.ui._internal.shared import get_context, set_context
 
-    context = RenderContext()
+    context = RenderContext(lambda x: None)
 
     return_dict = {"context": context, "result": None, "rerender": None}
 

--- a/plugins/ui/test/deephaven/ui/test_hooks.py
+++ b/plugins/ui/test/deephaven/ui/test_hooks.py
@@ -19,7 +19,7 @@ def render_hook(fn: Callable):
     from deephaven.ui._internal.RenderContext import RenderContext
     from deephaven.ui._internal.shared import get_context, set_context
 
-    context = RenderContext(lambda x: None)
+    context = RenderContext(lambda x: x())
 
     return_dict = {"context": context, "result": None, "rerender": None}
 

--- a/plugins/ui/test/deephaven/ui/test_hooks.py
+++ b/plugins/ui/test/deephaven/ui/test_hooks.py
@@ -19,7 +19,7 @@ def render_hook(fn: Callable):
     from deephaven.ui._internal.RenderContext import RenderContext
     from deephaven.ui._internal.shared import get_context, set_context
 
-    context = RenderContext(lambda x: x())
+    context = RenderContext(lambda x: x(), lambda x: x())
 
     return_dict = {"context": context, "result": None, "rerender": None}
 

--- a/plugins/ui/test/deephaven/ui/test_render.py
+++ b/plugins/ui/test/deephaven/ui/test_render.py
@@ -10,7 +10,6 @@ class RenderTestCase(BaseTestCase):
         self.assertEqual(rc._hook_index, -1)
         self.assertEqual(rc._state, {})
         self.assertEqual(rc._children_context, {})
-        self.assertEqual(rc._on_change(), None)
 
     def test_hook_index(self):
         from deephaven.ui._internal.RenderContext import RenderContext
@@ -46,10 +45,8 @@ class RenderTestCase(BaseTestCase):
     def test_state(self):
         from deephaven.ui._internal.RenderContext import RenderContext
 
-        rc = RenderContext()
-
         on_change = Mock()
-        rc.set_on_change(on_change)
+        rc = RenderContext(on_change)
 
         self.assertEqual(rc.has_state(0), False)
         self.assertEqual(rc.get_state(0), None)
@@ -68,10 +65,8 @@ class RenderTestCase(BaseTestCase):
     def test_context(self):
         from deephaven.ui._internal.RenderContext import RenderContext
 
-        rc = RenderContext()
-
         on_change = Mock()
-        rc.set_on_change(on_change)
+        rc = RenderContext(on_change)
 
         child_context0 = rc.get_child_context(0)
         child_context1 = rc.get_child_context(1)

--- a/plugins/ui/test/deephaven/ui/test_render.py
+++ b/plugins/ui/test/deephaven/ui/test_render.py
@@ -2,12 +2,16 @@ from unittest.mock import Mock
 from .BaseTest import BaseTestCase
 
 
+def make_render_context(on_change=lambda x: x(), on_queue=lambda x: x()):
+    from deephaven.ui._internal.RenderContext import RenderContext
+
+    return RenderContext(on_change, on_queue)
+
+
 class RenderTestCase(BaseTestCase):
     def test_empty_render(self):
-        from deephaven.ui._internal.RenderContext import RenderContext
-
-        on_change = Mock()
-        rc = RenderContext(on_change)
+        on_change = Mock(side_effect=lambda x: x())
+        rc = make_render_context(on_change)
         self.assertEqual(rc._hook_index, -1)
         self.assertEqual(rc._state, {})
         self.assertEqual(rc._children_context, {})
@@ -17,7 +21,7 @@ class RenderTestCase(BaseTestCase):
         from deephaven.ui._internal.RenderContext import RenderContext
 
         on_change = Mock(side_effect=lambda x: x())
-        rc = RenderContext(on_change)
+        rc = make_render_context(on_change)
 
         # Set up the hooks used with initial render (3 hooks)
         with rc:
@@ -49,7 +53,7 @@ class RenderTestCase(BaseTestCase):
         from deephaven.ui._internal.RenderContext import RenderContext
 
         on_change = Mock(side_effect=lambda x: x())
-        rc = RenderContext(on_change)
+        rc = make_render_context(on_change)
 
         self.assertEqual(rc.has_state(0), False)
         self.assertEqual(rc.get_state(0), None)
@@ -69,7 +73,7 @@ class RenderTestCase(BaseTestCase):
         from deephaven.ui._internal.RenderContext import RenderContext
 
         on_change = Mock(side_effect=lambda x: x())
-        rc = RenderContext(on_change)
+        rc = make_render_context(on_change)
 
         child_context0 = rc.get_child_context(0)
         child_context1 = rc.get_child_context(1)

--- a/plugins/ui/test/deephaven/ui/test_render.py
+++ b/plugins/ui/test/deephaven/ui/test_render.py
@@ -57,11 +57,13 @@ class RenderTestCase(BaseTestCase):
 
         self.assertEqual(rc.has_state(0), False)
         self.assertRaises(KeyError, rc.get_state, 0)
+        self.assertRaises(KeyError, rc.set_state, 0, 2)
         self.assertEqual(on_change.call_count, 0)
 
-        rc.set_state(0, 2)
+        rc.init_state(0, 2)
         self.assertEqual(rc.has_state(0), True)
         self.assertEqual(rc.get_state(0), 2)
+        self.assertRaises(KeyError, rc.init_state, 0, 3)
         self.assertEqual(on_change.call_count, 0)
 
     def test_context(self):
@@ -76,7 +78,7 @@ class RenderTestCase(BaseTestCase):
         self.assertEqual(on_change.call_count, 0)
 
         # Check that setting the initial state does not trigger a change event
-        rc.set_state(0, 0)
+        rc.init_state(0, 0)
         self.assertEqual(on_change.call_count, 0)
 
         # Check that changing state triggers a change event
@@ -87,7 +89,7 @@ class RenderTestCase(BaseTestCase):
         self.assertEqual(on_change.call_count, 1)
         self.assertEqual(child_context0.has_state(0), False)
         self.assertRaises(KeyError, child_context0.get_state, 0)
-        child_context0.set_state(0, 2)
+        child_context0.init_state(0, 2)
         self.assertEqual(child_context0.has_state(0), True)
         self.assertEqual(child_context0.get_state(0), 2)
         # The initial setting of the child context state shouldn't trigger a change, so we should still be at 1
@@ -99,7 +101,7 @@ class RenderTestCase(BaseTestCase):
 
         self.assertEqual(child_context1.has_state(0), False)
         self.assertRaises(KeyError, child_context1.get_state, 0)
-        child_context1.set_state(0, 3)
+        child_context1.init_state(0, 3)
         self.assertEqual(rc.get_state(0), 1)
         self.assertEqual(child_context0.get_state(0), 20)
         self.assertEqual(child_context1.get_state(0), 3)

--- a/plugins/ui/test/deephaven/ui/test_render.py
+++ b/plugins/ui/test/deephaven/ui/test_render.py
@@ -6,15 +6,18 @@ class RenderTestCase(BaseTestCase):
     def test_empty_render(self):
         from deephaven.ui._internal.RenderContext import RenderContext
 
-        rc = RenderContext()
+        on_change = Mock()
+        rc = RenderContext(on_change)
         self.assertEqual(rc._hook_index, -1)
         self.assertEqual(rc._state, {})
         self.assertEqual(rc._children_context, {})
+        on_change.assert_not_called()
 
     def test_hook_index(self):
         from deephaven.ui._internal.RenderContext import RenderContext
 
-        rc = RenderContext()
+        on_change = Mock(side_effect=lambda x: x())
+        rc = RenderContext(on_change)
 
         # Set up the hooks used with initial render (3 hooks)
         with rc:
@@ -45,7 +48,7 @@ class RenderTestCase(BaseTestCase):
     def test_state(self):
         from deephaven.ui._internal.RenderContext import RenderContext
 
-        on_change = Mock()
+        on_change = Mock(side_effect=lambda x: x())
         rc = RenderContext(on_change)
 
         self.assertEqual(rc.has_state(0), False)
@@ -65,7 +68,7 @@ class RenderTestCase(BaseTestCase):
     def test_context(self):
         from deephaven.ui._internal.RenderContext import RenderContext
 
-        on_change = Mock()
+        on_change = Mock(side_effect=lambda x: x())
         rc = RenderContext(on_change)
 
         child_context0 = rc.get_child_context(0)

--- a/plugins/ui/test/deephaven/ui/test_ui_table.py
+++ b/plugins/ui/test/deephaven/ui/test_ui_table.py
@@ -15,7 +15,8 @@ class UITableTestCase(BaseTestCase):
         from deephaven.ui._internal import RenderContext
 
         on_change = Mock()
-        context = RenderContext(on_change)
+        on_queue = Mock()
+        context = RenderContext(on_change, on_queue)
         result = ui_table.render(context)
 
         self.assertDictEqual(result, expected_props)

--- a/plugins/ui/test/deephaven/ui/test_ui_table.py
+++ b/plugins/ui/test/deephaven/ui/test_ui_table.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from unittest.mock import Mock
 from typing import Any
 from .BaseTest import BaseTestCase
 
@@ -13,7 +14,8 @@ class UITableTestCase(BaseTestCase):
     def expect_render(self, ui_table, expected_props: dict[str, Any]):
         from deephaven.ui._internal import RenderContext
 
-        context = RenderContext()
+        on_change = Mock()
+        context = RenderContext(on_change)
         result = ui_table.render(context)
 
         self.assertDictEqual(result, expected_props)


### PR DESCRIPTION
- Create a thread and queue for applying state updates
- Now callbacks and state updates are all queued on the same thread
- Cleaned up some typing in the `Renderer` class
- Added a `use_render_queue` hook and example for showing how to queue state updates
- Fixes #116
- Tested using the snippet from #116:
```python
import deephaven.ui as ui
from deephaven.ui import use_state


@ui.component
def foo():
    a, set_a = use_state(0)
    b, set_b = use_state(0)

    print(f"Render with a {a} and b {b}")

    def handle_press():
        set_a(a + 1)
        set_b(b + 1)

    return ui.action_button(
        f"a is {a} and b is {b}", on_press=handle_press
    )


f = foo()
```
- Ensured that the print out was only printed once per press of the button, and both values stayed the same
- Allow a callable to be passed into the use_state setter function that takes the old value as a parameter. Tested using the following component:
```python
import deephaven.ui as ui
from deephaven.ui import use_state


@ui.component
def bar():
    x, set_x = use_state(0)

    print(f"Render with x {x}")

    def handle_press():
        # Call set_x twice in the same method, using a callable. This should result in x increasing by 2 each time the button is pressed
        set_x(lambda old_x: old_x + 1)
        set_x(lambda old_x: old_x + 1)

    return ui.action_button(
        f"x is {x}", on_press=handle_press
    )


b = bar()
```
- Tested that trying to update state from the wrong thread throws an error:
```python
import deephaven.ui as ui
import threading
import time
from deephaven.ui import use_state


@ui.component
def foo():
    a, set_a = use_state(0)
    b, set_b = use_state(0)

    print(f"Render with a {a} and b {b}")

    def handle_press():
        def update_state():
            time.sleep(1)
            set_a(a + 1)
            set_b(b + 1)
        # Not using the correct thread
        threading.Thread(target=update_state).start()

    return ui.action_button(
        f"a is {a} and b is {b}", on_press=handle_press
    )


f = foo()
```