### PR TITLE
fix: Matplotlib input table and execution context not working

### DIFF
--- a/plugins/matplotlib/src/deephaven/plugin/matplotlib/__init__.py
+++ b/plugins/matplotlib/src/deephaven/plugin/matplotlib/__init__.py
@@ -5,6 +5,8 @@ from importlib import resources
 import matplotlib.pyplot as plt
 from matplotlib.animation import Animation
 import itertools
+from deephaven.execution_context import get_exec_ctx
+
 
 __version__ = "0.3.0.dev0"
 
@@ -22,6 +24,7 @@ def _init_theme():
 class MatplotlibRegistration(Registration):
     @classmethod
     def register_into(cls, callback: Callback) -> None:
+        print(get_exec_ctx().update_graph)
         _init_theme()
         plt.switch_backend("AGG")
         from . import figure_type

--- a/plugins/matplotlib/src/deephaven/plugin/matplotlib/__init__.py
+++ b/plugins/matplotlib/src/deephaven/plugin/matplotlib/__init__.py
@@ -24,7 +24,6 @@ def _init_theme():
 class MatplotlibRegistration(Registration):
     @classmethod
     def register_into(cls, callback: Callback) -> None:
-        print(get_exec_ctx().update_graph)
         _init_theme()
         plt.switch_backend("AGG")
         from . import figure_type


### PR DESCRIPTION
`KeyedArrayBackedMutableTable` was renamed, which was causing this to break. Moved to the python api and also fixed some issues with the execution context

```
from deephaven.plugin.matplotlib import TableAnimation
from deephaven import pandas as dhpd
from deephaven import time_table

import matplotlib.pyplot as plt
import seaborn as sns  
import pandas as pd

# Create a ticking table with the cosine function
tt = time_table("PT1S").update(["X = 0.2 * i", "Y = Math.cos(X)"])

fig, ax = plt.subplots() # Create a new figure

# This function updates a figure
def update_fig(data, update):
    # Clear the axes (don't draw over old lines)
    ax.clear()
    # Convert the X and Y columns in `tt` to a DataFrame
    df = dhpd.to_pandas(tt.view(["X", "Y"]))
    # Draw the line plot
    sns.lineplot(df, x="X", y="Y")

# Create our animation. It will listen for updates on `tt` and call `update_fig` whenever there is an update
line_plot_ani = TableAnimation(fig, tt, update_fig)
```