### PR TITLE
fix: plotly-express error when running from docker

### DIFF
--- a/docker/config/deephaven.prop
+++ b/docker/config/deephaven.prop
@@ -4,7 +4,6 @@ deephaven.console.type=python
 
 # Add all plugins that you want installed here
 deephaven.jsPlugins.@deephaven/js-plugin-ui=/opt/deephaven/config/plugins/plugins/ui/src/js
-deephaven.jsPlugins.@deephaven/js-plugin-plotly-express=/opt/deephaven/config/plugins/plugins/plotly-express/src/js
 
 # Anonymous authentication so we don't need to put in a password
 AuthHandlers=io.deephaven.auth.AnonymousAuthenticationHandler


### PR DESCRIPTION
- plotly-express JS plugin is included in the docker container, so no need to install it separately
