### PR TITLE
feat: use_execution_context hook

### DIFF
--- a/plugins/ui/src/deephaven/ui/hooks/__init__.py
+++ b/plugins/ui/src/deephaven/ui/hooks/__init__.py
@@ -9,6 +9,7 @@ from .use_column_data import use_column_data
 from .use_row_data import use_row_data
 from .use_row_list import use_row_list
 from .use_cell_data import use_cell_data
+from .use_execution_context import use_execution_context
 
 
 __all__ = [
@@ -23,4 +24,5 @@ __all__ = [
     "use_row_data",
     "use_row_list",
     "use_cell_data",
+    "use_execution_context",
 ]

--- a/plugins/ui/src/deephaven/ui/hooks/use_execution_context.py
+++ b/plugins/ui/src/deephaven/ui/hooks/use_execution_context.py
@@ -5,7 +5,7 @@ from typing import Callable
 
 from deephaven.execution_context import get_exec_ctx, ExecutionContext
 
-from .use_ref import use_ref
+from . import use_memo
 
 
 def func_with_ctx(
@@ -31,6 +31,6 @@ def use_execution_context(exec_ctx: ExecutionContext = None) -> None:
         exec_ctx: ExecutionContext: The execution context to use. Defaults to
             the current execution context if not provided.
     """
-    exec_ctx = use_ref(exec_ctx if exec_ctx else get_exec_ctx())
-
-    return partial(func_with_ctx, exec_ctx.current)
+    exec_ctx = use_memo(lambda: exec_ctx if exec_ctx else get_exec_ctx(), [exec_ctx])
+    exec_fn = use_memo(lambda: partial(func_with_ctx, exec_ctx), [exec_ctx])
+    return exec_fn

--- a/plugins/ui/src/deephaven/ui/hooks/use_execution_context.py
+++ b/plugins/ui/src/deephaven/ui/hooks/use_execution_context.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from functools import partial
 from typing import Callable
 
 from deephaven.execution_context import get_exec_ctx, ExecutionContext
@@ -7,16 +8,29 @@ from deephaven.execution_context import get_exec_ctx, ExecutionContext
 from .use_ref import use_ref
 
 
-def use_execution_context(func: Callable, exec_ctx: ExecutionContext = None) -> None:
+def func_with_ctx(
+    exec_ctx: ExecutionContext,
+    func: Callable,
+) -> None:
     """
-    Execute a function within an execution context.
+    Call the function within an execution context.
 
     Args:
-        func: Callable: The function to execute.
+        exec_ctx: ExecutionContext: The execution context to use.
+        func: Callable: The function to call.
+    """
+    with exec_ctx:
+        func()
+
+
+def use_execution_context(exec_ctx: ExecutionContext = None) -> None:
+    """
+    Create an execution context wrapper for a function.
+
+    Args:
         exec_ctx: ExecutionContext: The execution context to use. Defaults to
             the current execution context if not provided.
     """
     exec_ctx = use_ref(exec_ctx if exec_ctx else get_exec_ctx())
 
-    with exec_ctx.current:
-        func()
+    return partial(func_with_ctx, exec_ctx.current)

--- a/plugins/ui/src/deephaven/ui/hooks/use_execution_context.py
+++ b/plugins/ui/src/deephaven/ui/hooks/use_execution_context.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from typing import Callable
+
+from deephaven.execution_context import get_exec_ctx, ExecutionContext
+
+from .use_ref import use_ref
+
+
+def use_execution_context(func: Callable, exec_ctx: ExecutionContext = None) -> None:
+    """
+    Execute a function within an execution context.
+
+    Args:
+        func: Callable: The function to execute.
+        exec_ctx: ExecutionContext: The execution context to use. Defaults to
+            the current execution context if not provided.
+    """
+    exec_ctx = use_ref(exec_ctx if exec_ctx else get_exec_ctx())
+
+    with exec_ctx.current:
+        func()

--- a/plugins/ui/test/deephaven/ui/test_hooks.py
+++ b/plugins/ui/test/deephaven/ui/test_hooks.py
@@ -490,6 +490,54 @@ class HooksTest(BaseTestCase):
 
         self.assertEqual(result, expected)
 
+    def test_execution_context(self):
+        from deephaven.ui.hooks import use_execution_context
+
+        called = False
+
+        def execution_context_callback():
+            nonlocal called
+            called = True
+
+        def _test_execution_context(exec_ctx=None):
+            use_execution_context(execution_context_callback, exec_ctx=exec_ctx)
+
+        render_hook(_test_execution_context)
+
+        self.assertTrue(called)
+
+    def test_execution_context_passed(self):
+        from deephaven.ui.hooks import use_execution_context
+        from deephaven.execution_context import make_user_exec_ctx
+
+        called = False
+
+        def execution_context_callback():
+            nonlocal called
+            called = True
+
+        def _test_execution_context():
+            use_execution_context(
+                execution_context_callback, exec_ctx=make_user_exec_ctx()
+            )
+
+        render_hook(_test_execution_context)
+
+        self.assertTrue(called)
+
+    def test_execution_context_error(self):
+        from deephaven.ui.hooks import use_execution_context
+
+        def execution_context_callback():
+            pass
+
+        def _test_execution_context():
+            use_execution_context(
+                execution_context_callback, exec_ctx="invalid execution context"
+            )
+
+        self.assertRaises(AttributeError, render_hook, _test_execution_context)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/plugins/ui/test/deephaven/ui/test_hooks.py
+++ b/plugins/ui/test/deephaven/ui/test_hooks.py
@@ -491,52 +491,52 @@ class HooksTest(BaseTestCase):
         self.assertEqual(result, expected)
 
     def test_execution_context(self):
-        from deephaven.ui.hooks import use_execution_context
+        from deephaven.ui.hooks import use_execution_context, use_state, use_memo
+        from deephaven import empty_table
 
-        called = False
+        def _test_execution_context():
+            with_exec_ctx = use_execution_context()
 
-        def execution_context_callback():
-            nonlocal called
-            called = True
+            def table_func():
+                # This would fail if not using an execution context
+                empty_table(0).update("X=1")
 
-        def _test_execution_context(exec_ctx=None):
-            use_execution_context(execution_context_callback, exec_ctx=exec_ctx)
+            def thread_func():
+                with_exec_ctx(table_func)
+
+            def start_thread():
+                thread = threading.Thread(target=thread_func)
+                thread.start()
+                thread.join()
+
+            use_memo(start_thread, [])
 
         render_hook(_test_execution_context)
 
-        self.assertTrue(called)
-
-    def test_execution_context_passed(self):
-        from deephaven.ui.hooks import use_execution_context
+    def test_execution_context_custom(self):
+        from deephaven.ui.hooks import use_execution_context, use_state, use_memo
+        from deephaven import empty_table
         from deephaven.execution_context import make_user_exec_ctx
 
-        called = False
-
-        def execution_context_callback():
-            nonlocal called
-            called = True
+        table = None
 
         def _test_execution_context():
-            use_execution_context(
-                execution_context_callback, exec_ctx=make_user_exec_ctx()
-            )
+            with_exec_ctx = use_execution_context(make_user_exec_ctx())
+
+            def table_func():
+                # This would fail if not using an execution context
+                empty_table(0).update("X=1")
+
+            def thread_func():
+                with_exec_ctx(table_func)
+
+            def start_thread():
+                thread = threading.Thread(target=thread_func)
+                thread.start()
+
+            use_memo(start_thread, [])
 
         render_hook(_test_execution_context)
-
-        self.assertTrue(called)
-
-    def test_execution_context_error(self):
-        from deephaven.ui.hooks import use_execution_context
-
-        def execution_context_callback():
-            pass
-
-        def _test_execution_context():
-            use_execution_context(
-                execution_context_callback, exec_ctx="invalid execution context"
-            )
-
-        self.assertRaises(AttributeError, render_hook, _test_execution_context)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The hook can be used to call code within an execution context

It is a fairly niche hook, but here as an example of it being used to do a table update on a separate thread

```
import deephaven.ui as ui
import threading
from deephaven.execution_context import get_exec_ctx
from deephaven import agg as agg
import deephaven.pandas as dhpd
import deephaven.plot.express as dx

stocks = dx.data.stocks()

def print_sym(source):
    print(dhpd.to_pandas(source.update(["Symbol = sym"]) \
        .agg_by([agg.avg(cols=["AVG = size"])], by=["Symbol"])))

@ui.component
def exec_ctx_hook(source):

    with_exec_ctx = ui.use_execution_context()
    
    def thread_func():
        #print_sym(source)
        with_exec_ctx(lambda: print_sym(source))

    def start_thread():
        thread = threading.Thread(target=thread_func)
        thread.start()

    ui.use_memo(start_thread, source)

    return None

exec_hook = exec_ctx_hook(stocks)
```

Fixes #184 