### PR TITLE
fix: Better render error handling

### DIFF
--- a/plugins/ui/src/deephaven/ui/object_types/ElementMessageStream.py
+++ b/plugins/ui/src/deephaven/ui/object_types/ElementMessageStream.py
@@ -150,15 +150,13 @@ class ElementMessageStream(MessageStream):
 
         self._is_dirty = False
 
-        node = None
         try:
             node = self._renderer.render(self._element)
         except Exception as e:
             logger.exception("Error rendering %s", self._element.name)
             raise e
 
-        if node is not None:
-            self._send_document_update(node)
+        self._send_document_update(node)
 
     def _process_callable_queue(self) -> None:
         """

--- a/plugins/ui/src/deephaven/ui/object_types/ElementMessageStream.py
+++ b/plugins/ui/src/deephaven/ui/object_types/ElementMessageStream.py
@@ -149,8 +149,12 @@ class ElementMessageStream(MessageStream):
             state_update()
 
         self._is_dirty = False
-        node = self._renderer.render(self._element)
-        self._send_document_update(node)
+        try:
+            node = self._renderer.render(self._element)
+            self._send_document_update(node)
+        except Exception as e:
+            logger.exception("Error rendering %s", self._element.name)
+            raise e
 
     def _process_callable_queue(self) -> None:
         """

--- a/plugins/ui/src/deephaven/ui/object_types/ElementMessageStream.py
+++ b/plugins/ui/src/deephaven/ui/object_types/ElementMessageStream.py
@@ -149,12 +149,16 @@ class ElementMessageStream(MessageStream):
             state_update()
 
         self._is_dirty = False
+
+        node = None
         try:
             node = self._renderer.render(self._element)
-            self._send_document_update(node)
         except Exception as e:
             logger.exception("Error rendering %s", self._element.name)
             raise e
+
+        if node is not None:
+            self._send_document_update(node)
 
     def _process_callable_queue(self) -> None:
         """


### PR DESCRIPTION
Fixes #227 

Testing with the examples from the issue logged errors, for example:
```
import deephaven.ui as ui

@ui.component
def hi():
    something, set_something = ui.use_state(0)
    return "Hello, " + something

h = hi()
```
```
Error rendering __main__.hi
Traceback (most recent call last):
  File "/Users/josephnumainville/Documents/deephaven-core/.venv/lib/python3.8/site-packages/deephaven/ui/object_types/ElementMessageStream.py", line 153, in _render
    node = self._renderer.render(self._element)
  File "/Users/josephnumainville/Documents/deephaven-core/.venv/lib/python3.8/site-packages/deephaven/ui/renderer/Renderer.py", line 111, in render
    return _render_element(element, self._context)
  File "/Users/josephnumainville/Documents/deephaven-core/.venv/lib/python3.8/site-packages/deephaven/ui/renderer/Renderer.py", line 84, in _render_element
    props = element.render(context)
  File "/Users/josephnumainville/Documents/deephaven-core/.venv/lib/python3.8/site-packages/deephaven/ui/elements/FunctionElement.py", line 37, in render
    children = self._render()
  File "/Users/josephnumainville/Documents/deephaven-core/.venv/lib/python3.8/site-packages/deephaven/ui/components/make_component.py", line 23, in <lambda>
    return FunctionElement(component_type, lambda: func(*args, **kwargs))
  File "<string>", line 6, in hi
TypeError: can only concatenate str (not "int") to str
```
another:
```
from deephaven import ui

@ui.component
def foo():
    return ui.bad_component()


f = foo()
```
```
Error rendering __main__.foo
Traceback (most recent call last):
  File "/Users/josephnumainville/Documents/deephaven-core/.venv/lib/python3.8/site-packages/deephaven/ui/object_types/ElementMessageStream.py", line 153, in _render
    node = self._renderer.render(self._element)
  File "/Users/josephnumainville/Documents/deephaven-core/.venv/lib/python3.8/site-packages/deephaven/ui/renderer/Renderer.py", line 111, in render
    return _render_element(element, self._context)
  File "/Users/josephnumainville/Documents/deephaven-core/.venv/lib/python3.8/site-packages/deephaven/ui/renderer/Renderer.py", line 84, in _render_element
    props = element.render(context)
  File "/Users/josephnumainville/Documents/deephaven-core/.venv/lib/python3.8/site-packages/deephaven/ui/elements/FunctionElement.py", line 37, in render
    children = self._render()
  File "/Users/josephnumainville/Documents/deephaven-core/.venv/lib/python3.8/site-packages/deephaven/ui/components/make_component.py", line 23, in <lambda>
    return FunctionElement(component_type, lambda: func(*args, **kwargs))
  File "<string>", line 5, in foo
AttributeError: module 'deephaven.ui' has no attribute 'bad_component'
```
