### PR TITLE
feat(ui): Add error boundary to prevent UI crashing due to rendering errors

### DIFF
--- a/plugins/ui/src/js/src/DashboardPlugin.tsx
+++ b/plugins/ui/src/js/src/DashboardPlugin.tsx
@@ -13,11 +13,11 @@ import { useConnection } from '@deephaven/jsapi-components';
 import { DeferredApiBootstrap } from '@deephaven/jsapi-bootstrap';
 import { Widget } from '@deephaven/jsapi-types';
 import type { VariableDefinition } from '@deephaven/jsapi-types';
+import { ErrorBoundary } from '@deephaven/components';
 import styles from './styles.scss?inline';
 import { WidgetWrapper } from './WidgetTypes';
 import PortalPanel from './PortalPanel';
 import WidgetHandler from './WidgetHandler';
-import { ErrorBoundary } from '@deephaven/components';
 
 const NAME_ELEMENT = 'deephaven.ui.Element';
 const DASHBOARD_ELEMENT = 'deephaven.ui.Dashboard';

--- a/plugins/ui/src/js/src/DashboardPlugin.tsx
+++ b/plugins/ui/src/js/src/DashboardPlugin.tsx
@@ -17,6 +17,7 @@ import styles from './styles.scss?inline';
 import { WidgetWrapper } from './WidgetTypes';
 import PortalPanel from './PortalPanel';
 import WidgetHandler from './WidgetHandler';
+import { ErrorBoundary } from '@deephaven/components';
 
 const NAME_ELEMENT = 'deephaven.ui.Element';
 const DASHBOARD_ELEMENT = 'deephaven.ui.Dashboard';
@@ -204,9 +205,11 @@ export function DashboardPlugin({
   const widgetHandlers = useMemo(
     () =>
       [...widgetMap.entries()].map(([widgetId, widget]) => (
-        <DeferredApiBootstrap key={widgetId} options={widget.metadata}>
-          <WidgetHandler widget={widget} onClose={handleWidgetClose} />
-        </DeferredApiBootstrap>
+        <ErrorBoundary key={widgetId}>
+          <DeferredApiBootstrap options={widget.metadata}>
+            <WidgetHandler widget={widget} onClose={handleWidgetClose} />
+          </DeferredApiBootstrap>
+        </ErrorBoundary>
       )),
     [handleWidgetClose, widgetMap]
   );


### PR DESCRIPTION
This should prevent the whole UI from going blank if there's a rendering error in JS. An example dashboard that would crash the whole UI previously is provided below. Now you get an error message and can still go back to your code studio.

```py
from deephaven import ui

@ui.component
def Foo():
    return [
        ui.row(ui.stack(ui.panel(ui.text('Foo')))),
        ui.row(ui.stack(ui.panel(ui.text('Bar'))))
    ]
f = ui.dashboard(Foo())
```