### PR TITLE
feat: Picker spec

### DIFF
--- a/plugins/ui/DESIGN.md
+++ b/plugins/ui/DESIGN.md
@@ -1011,6 +1011,94 @@ def my_dashboard():
 d = my_dashboard()
 ```
 
+##### ui.item
+
+An item that can be added to a menu, such as a `ui.picker`
+
+```py
+import deephaven.ui as ui
+ui.item(
+    child: Any
+) -> ItemElement
+```
+
+##### ui.section
+
+A section that can be added to a menu, such as a `ui.picker`. Contains a list of `ui.item` elements or basic types like `str`.
+
+```py
+import deephaven.ui as ui
+PickerOption = Any | ItemElement
+
+ui.section(
+    *children: PickerOption
+) -> SectionElement
+```
+
+##### ui.picker
+A picker that can be used to select from a list. Children should be one of two types:
+`SectionElement` or `PickerOption` (which can be created from `ui.item` or be a basic type like `str`)
+If children are of type `PickerOption`, they are the dropdown options.
+If children are of type `SectionElement`, they are the dropdown sections.
+
+```py
+import deephaven.ui as ui
+ui.item(
+    *children: PickerOption | SectionElement
+) -> ItemElement
+```
+
+```py
+import deephaven.ui as ui
+
+picker1 = ui.picker(
+    ui.section(
+        ui.item("Option 1"),
+        ui.item("Option 2"),
+    ),
+    ui.section(
+        ui.item("Option 3"),
+        ui.item("Option 4"),
+    )
+)
+
+picker2 = ui.picker(
+    ui.section(
+        "Option 1",
+        "Option 2",
+    ),
+    ui.section(
+        "Option 3",
+        "Option 4",
+    )
+)
+
+picker3 = ui.picker(
+    ui.item("Option 1"),
+    ui.item("Option 2"),
+    ui.item("Option 3"),
+    ui.item("Option 4"),
+)
+
+picker4 = ui.picker(
+    "Option 1",
+    "Option 2",
+    "Option 3",
+    "Option 4",
+)
+
+picker5 = ui.picker(
+    children=[
+        "Option 1",
+        "Option 2",
+        "Option 3",
+        "Option 4",
+    ]
+)
+```
+
+
+
 #### ui.table
 
 `ui.table` is a wrapper for a Deephaven `Table` object that allows you to add UI customizations or callbacks. The basic syntax for creating a `UITable` is:


### PR DESCRIPTION
This is of course very early WIP spec, I just wanted to get some initial feedback to see if this the right direction.

Looking at [the picker docs](https://react-spectrum.adobe.com/react-spectrum/Picker.html), it looks like generally the expected behavior is to pass `Item` objects in. I don't think this should be necessary in python (but will need to be wrapped), but should be a possibility if advanced behavior is desired, such as [complex items](https://react-spectrum.adobe.com/react-spectrum/Picker.html#complex-items), which I think would be very powerful, so I have a `ui.item` element.

There is also `Section` objects that can contain `Item` objects, so we'll need a `ui.section` element as well.

The above would be wrapped in the `ui.picker` object itself.

I've got some examples that make everything, I think, more or less clear.