### PR TITLE
feat: Remove UI theme from PlotlyExpressChartModel

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2293,6 +2293,124 @@
         "babel-plugin-transform-rename-import": "^2.3.0"
       }
     },
+    "node_modules/@deephaven/chart": {
+      "version": "0.64.0",
+      "resolved": "https://registry.npmjs.org/@deephaven/chart/-/chart-0.64.0.tgz",
+      "integrity": "sha512-mlwSBSA5BsckUf/6hULyW0MWmWXqfgB17MaI2f0Kmcdzmw2By6zWSkqM1vB/esKYOLhKkofoI5NhymeryS+uDg==",
+      "dependencies": {
+        "@deephaven/components": "^0.64.0",
+        "@deephaven/icons": "^0.64.0",
+        "@deephaven/jsapi-types": "^0.64.0",
+        "@deephaven/jsapi-utils": "^0.64.0",
+        "@deephaven/log": "^0.64.0",
+        "@deephaven/react-hooks": "^0.64.0",
+        "@deephaven/utils": "^0.64.0",
+        "deep-equal": "^2.0.5",
+        "lodash.debounce": "^4.0.8",
+        "lodash.set": "^4.3.2",
+        "memoize-one": "^5.1.1",
+        "memoizee": "^0.4.15",
+        "plotly.js": "^2.18.2",
+        "prop-types": "^15.7.2",
+        "react-plotly.js": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "react": "^17.x"
+      }
+    },
+    "node_modules/@deephaven/chart/node_modules/@deephaven/components": {
+      "version": "0.64.0",
+      "resolved": "https://registry.npmjs.org/@deephaven/components/-/components-0.64.0.tgz",
+      "integrity": "sha512-L/G3r94eoHx7OzZM5DpbshGFgvmXyBi0SdmPKp872zfrWu/rcSTrsB2Mz3/QmJIBaO2wn8U5tw5pTKGoML8IfQ==",
+      "dependencies": {
+        "@adobe/react-spectrum": "^3.29.0",
+        "@deephaven/icons": "^0.64.0",
+        "@deephaven/log": "^0.64.0",
+        "@deephaven/react-hooks": "^0.64.0",
+        "@deephaven/utils": "^0.64.0",
+        "@fortawesome/fontawesome-svg-core": "^6.2.1",
+        "@fortawesome/react-fontawesome": "^0.2.0",
+        "@react-spectrum/theme-default": "^3.5.1",
+        "bootstrap": "4.6.2",
+        "classnames": "^2.3.1",
+        "event-target-shim": "^6.0.2",
+        "lodash.clamp": "^4.0.3",
+        "lodash.debounce": "^4.0.8",
+        "lodash.flatten": "^4.4.0",
+        "memoizee": "^0.4.15",
+        "popper.js": "^1.16.1",
+        "prop-types": "^15.7.2",
+        "react-beautiful-dnd": "^13.1.0",
+        "react-transition-group": "^4.4.2",
+        "react-virtualized-auto-sizer": "1.0.6",
+        "react-window": "^1.8.6",
+        "shortid": "^2.2.16"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": "^17.x",
+        "react-dom": "^17.x"
+      }
+    },
+    "node_modules/@deephaven/chart/node_modules/@deephaven/jsapi-types": {
+      "version": "0.64.0",
+      "resolved": "https://registry.npmjs.org/@deephaven/jsapi-types/-/jsapi-types-0.64.0.tgz",
+      "integrity": "sha512-8e1YzqRPtRg0bhqUC4R3nZ9ICE/3ITRaLgFOmw8yjtGnp+VWG+RvYp/5EELIizrklfUkuWv/+Z5uxMbQYQNQRQ==",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@deephaven/chart/node_modules/@deephaven/jsapi-utils": {
+      "version": "0.64.0",
+      "resolved": "https://registry.npmjs.org/@deephaven/jsapi-utils/-/jsapi-utils-0.64.0.tgz",
+      "integrity": "sha512-U+cCICH8hcehbwqMlgG5+sGS3bcvm4GiY0SB+N15M3spLU3iAbWB5pMYo1lv8hf20TTnIYsJjF52MNp3R+F2FQ==",
+      "dependencies": {
+        "@deephaven/filters": "^0.64.0",
+        "@deephaven/jsapi-types": "^0.64.0",
+        "@deephaven/log": "^0.64.0",
+        "@deephaven/utils": "^0.64.0",
+        "lodash.clamp": "^4.0.3",
+        "shortid": "^2.2.16"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@deephaven/chart/node_modules/@deephaven/log": {
+      "version": "0.64.0",
+      "resolved": "https://registry.npmjs.org/@deephaven/log/-/log-0.64.0.tgz",
+      "integrity": "sha512-E2/gUb/lfFIGxM/bm0Wimpu+EUVY1xNubItiedMKDEp/dfmVKMVng6XdF2pPw73kaeGAs7NoCbdnWnXdns5QdA==",
+      "dependencies": {
+        "event-target-shim": "^6.0.2"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@deephaven/chart/node_modules/@deephaven/utils": {
+      "version": "0.64.0",
+      "resolved": "https://registry.npmjs.org/@deephaven/utils/-/utils-0.64.0.tgz",
+      "integrity": "sha512-lt9cXEw0j2KMmUvR/+jmrpmWihrkYxNmhClW778WLFf0oi6Y4V/hsJxiNz+QvFvNbg3HqU6ZBMPHOtCNjKe7bQ==",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@deephaven/chart/node_modules/event-target-shim": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-6.0.2.tgz",
+      "integrity": "sha512-8q3LsZjRezbFZ2PN+uP+Q7pnHUMmAOziU2vA2OwoFaKIXxlxl38IylhSSgUorWu/rf4er67w0ikBqjBFk/pomA==",
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mysticatea"
+      }
+    },
     "node_modules/@deephaven/components": {
       "version": "0.40.1",
       "resolved": "https://registry.npmjs.org/@deephaven/components/-/components-0.40.1.tgz",
@@ -2367,6 +2485,133 @@
         "url": "https://github.com/sponsors/mysticatea"
       }
     },
+    "node_modules/@deephaven/console": {
+      "version": "0.64.0",
+      "resolved": "https://registry.npmjs.org/@deephaven/console/-/console-0.64.0.tgz",
+      "integrity": "sha512-2uOMS+JruIFtJXQww19a8I9GoGM7rF/rNowF9Dv2xXNF85TR+TXineo39yw8U6n/OfLUonhS90LIShlo4USU1w==",
+      "dependencies": {
+        "@deephaven/chart": "^0.64.0",
+        "@deephaven/components": "^0.64.0",
+        "@deephaven/icons": "^0.64.0",
+        "@deephaven/jsapi-bootstrap": "^0.64.0",
+        "@deephaven/jsapi-types": "^0.64.0",
+        "@deephaven/log": "^0.64.0",
+        "@deephaven/react-hooks": "^0.64.0",
+        "@deephaven/storage": "^0.64.0",
+        "@deephaven/utils": "^0.64.0",
+        "@fortawesome/react-fontawesome": "^0.2.0",
+        "classnames": "^2.3.1",
+        "linkifyjs": "^4.1.0",
+        "lodash.debounce": "^4.0.8",
+        "lodash.throttle": "^4.1.1",
+        "memoize-one": "^5.1.1",
+        "memoizee": "^0.4.15",
+        "monaco-editor": "^0.41.0",
+        "papaparse": "5.3.2",
+        "popper.js": "^1.16.1",
+        "prop-types": "^15.7.2",
+        "shell-quote": "^1.7.2",
+        "shortid": "^2.2.16"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "react": "^17.x",
+        "react-dom": "^17.x"
+      }
+    },
+    "node_modules/@deephaven/console/node_modules/@deephaven/components": {
+      "version": "0.64.0",
+      "resolved": "https://registry.npmjs.org/@deephaven/components/-/components-0.64.0.tgz",
+      "integrity": "sha512-L/G3r94eoHx7OzZM5DpbshGFgvmXyBi0SdmPKp872zfrWu/rcSTrsB2Mz3/QmJIBaO2wn8U5tw5pTKGoML8IfQ==",
+      "dependencies": {
+        "@adobe/react-spectrum": "^3.29.0",
+        "@deephaven/icons": "^0.64.0",
+        "@deephaven/log": "^0.64.0",
+        "@deephaven/react-hooks": "^0.64.0",
+        "@deephaven/utils": "^0.64.0",
+        "@fortawesome/fontawesome-svg-core": "^6.2.1",
+        "@fortawesome/react-fontawesome": "^0.2.0",
+        "@react-spectrum/theme-default": "^3.5.1",
+        "bootstrap": "4.6.2",
+        "classnames": "^2.3.1",
+        "event-target-shim": "^6.0.2",
+        "lodash.clamp": "^4.0.3",
+        "lodash.debounce": "^4.0.8",
+        "lodash.flatten": "^4.4.0",
+        "memoizee": "^0.4.15",
+        "popper.js": "^1.16.1",
+        "prop-types": "^15.7.2",
+        "react-beautiful-dnd": "^13.1.0",
+        "react-transition-group": "^4.4.2",
+        "react-virtualized-auto-sizer": "1.0.6",
+        "react-window": "^1.8.6",
+        "shortid": "^2.2.16"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": "^17.x",
+        "react-dom": "^17.x"
+      }
+    },
+    "node_modules/@deephaven/console/node_modules/@deephaven/jsapi-bootstrap": {
+      "version": "0.64.0",
+      "resolved": "https://registry.npmjs.org/@deephaven/jsapi-bootstrap/-/jsapi-bootstrap-0.64.0.tgz",
+      "integrity": "sha512-EGTYR1koWlG0nebD/7/1vCnA/McJqFCjIf+uL8y/2D945WMED3CalM3EwCLmXkYlQep0wtm9KgFyIhwenlwaCQ==",
+      "dependencies": {
+        "@deephaven/components": "^0.64.0",
+        "@deephaven/jsapi-types": "^0.64.0",
+        "@deephaven/log": "^0.64.0",
+        "@deephaven/react-hooks": "^0.64.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "react": "^17.x"
+      }
+    },
+    "node_modules/@deephaven/console/node_modules/@deephaven/jsapi-types": {
+      "version": "0.64.0",
+      "resolved": "https://registry.npmjs.org/@deephaven/jsapi-types/-/jsapi-types-0.64.0.tgz",
+      "integrity": "sha512-8e1YzqRPtRg0bhqUC4R3nZ9ICE/3ITRaLgFOmw8yjtGnp+VWG+RvYp/5EELIizrklfUkuWv/+Z5uxMbQYQNQRQ==",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@deephaven/console/node_modules/@deephaven/log": {
+      "version": "0.64.0",
+      "resolved": "https://registry.npmjs.org/@deephaven/log/-/log-0.64.0.tgz",
+      "integrity": "sha512-E2/gUb/lfFIGxM/bm0Wimpu+EUVY1xNubItiedMKDEp/dfmVKMVng6XdF2pPw73kaeGAs7NoCbdnWnXdns5QdA==",
+      "dependencies": {
+        "event-target-shim": "^6.0.2"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@deephaven/console/node_modules/@deephaven/utils": {
+      "version": "0.64.0",
+      "resolved": "https://registry.npmjs.org/@deephaven/utils/-/utils-0.64.0.tgz",
+      "integrity": "sha512-lt9cXEw0j2KMmUvR/+jmrpmWihrkYxNmhClW778WLFf0oi6Y4V/hsJxiNz+QvFvNbg3HqU6ZBMPHOtCNjKe7bQ==",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@deephaven/console/node_modules/event-target-shim": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-6.0.2.tgz",
+      "integrity": "sha512-8q3LsZjRezbFZ2PN+uP+Q7pnHUMmAOziU2vA2OwoFaKIXxlxl38IylhSSgUorWu/rf4er67w0ikBqjBFk/pomA==",
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mysticatea"
+      }
+    },
     "node_modules/@deephaven/dashboard": {
       "version": "0.40.4",
       "resolved": "https://registry.npmjs.org/@deephaven/dashboard/-/dashboard-0.40.4.tgz",
@@ -2392,6 +2637,1956 @@
         "react": "^17.0.0",
         "react-dom": "^17.0.0",
         "react-redux": "^7.2.4"
+      }
+    },
+    "node_modules/@deephaven/dashboard-core-plugins": {
+      "version": "0.64.0",
+      "resolved": "https://registry.npmjs.org/@deephaven/dashboard-core-plugins/-/dashboard-core-plugins-0.64.0.tgz",
+      "integrity": "sha512-3YQ5ZvIR8OFetwB7+GGEnXxBlwRp+ow0I/918k+nlNyEGUDHIkTck4Ntvlj4ind1GKHZ/RpFOpY237cA75M34g==",
+      "dependencies": {
+        "@deephaven/chart": "^0.64.0",
+        "@deephaven/components": "^0.64.0",
+        "@deephaven/console": "^0.64.0",
+        "@deephaven/dashboard": "^0.64.0",
+        "@deephaven/file-explorer": "^0.64.0",
+        "@deephaven/filters": "^0.64.0",
+        "@deephaven/golden-layout": "^0.64.0",
+        "@deephaven/grid": "^0.64.0",
+        "@deephaven/icons": "^0.64.0",
+        "@deephaven/iris-grid": "^0.64.0",
+        "@deephaven/jsapi-bootstrap": "^0.64.0",
+        "@deephaven/jsapi-components": "^0.64.0",
+        "@deephaven/jsapi-types": "^0.64.0",
+        "@deephaven/jsapi-utils": "^0.64.0",
+        "@deephaven/log": "^0.64.0",
+        "@deephaven/plugin": "^0.64.0",
+        "@deephaven/react-hooks": "^0.64.0",
+        "@deephaven/redux": "^0.64.0",
+        "@deephaven/storage": "^0.64.0",
+        "@deephaven/utils": "^0.64.0",
+        "@fortawesome/react-fontawesome": "^0.2.0",
+        "classnames": "^2.3.1",
+        "deep-equal": "^2.0.5",
+        "lodash.clamp": "^4.0.3",
+        "lodash.debounce": "^4.0.8",
+        "lodash.throttle": "^4.1.1",
+        "memoize-one": "^5.1.1",
+        "memoizee": "^0.4.15",
+        "prop-types": "^15.7.2",
+        "react-markdown": "^8.0.7",
+        "react-transition-group": "^4.4.2",
+        "redux": "^4.2.0",
+        "redux-thunk": "^2.4.1",
+        "rehype-mathjax": "^4.0.3",
+        "remark-gfm": "^4.0.0",
+        "remark-math": "^5.1.1",
+        "shortid": "^2.2.16"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0",
+        "react-dom": "^17.0.0",
+        "react-redux": "^7.2.4"
+      }
+    },
+    "node_modules/@deephaven/dashboard-core-plugins/node_modules/@deephaven/components": {
+      "version": "0.64.0",
+      "resolved": "https://registry.npmjs.org/@deephaven/components/-/components-0.64.0.tgz",
+      "integrity": "sha512-L/G3r94eoHx7OzZM5DpbshGFgvmXyBi0SdmPKp872zfrWu/rcSTrsB2Mz3/QmJIBaO2wn8U5tw5pTKGoML8IfQ==",
+      "dependencies": {
+        "@adobe/react-spectrum": "^3.29.0",
+        "@deephaven/icons": "^0.64.0",
+        "@deephaven/log": "^0.64.0",
+        "@deephaven/react-hooks": "^0.64.0",
+        "@deephaven/utils": "^0.64.0",
+        "@fortawesome/fontawesome-svg-core": "^6.2.1",
+        "@fortawesome/react-fontawesome": "^0.2.0",
+        "@react-spectrum/theme-default": "^3.5.1",
+        "bootstrap": "4.6.2",
+        "classnames": "^2.3.1",
+        "event-target-shim": "^6.0.2",
+        "lodash.clamp": "^4.0.3",
+        "lodash.debounce": "^4.0.8",
+        "lodash.flatten": "^4.4.0",
+        "memoizee": "^0.4.15",
+        "popper.js": "^1.16.1",
+        "prop-types": "^15.7.2",
+        "react-beautiful-dnd": "^13.1.0",
+        "react-transition-group": "^4.4.2",
+        "react-virtualized-auto-sizer": "1.0.6",
+        "react-window": "^1.8.6",
+        "shortid": "^2.2.16"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": "^17.x",
+        "react-dom": "^17.x"
+      }
+    },
+    "node_modules/@deephaven/dashboard-core-plugins/node_modules/@deephaven/dashboard": {
+      "version": "0.64.0",
+      "resolved": "https://registry.npmjs.org/@deephaven/dashboard/-/dashboard-0.64.0.tgz",
+      "integrity": "sha512-/8jd2XjSLzm8DP9dCIZD9I+cF5W9qAvxoXT7x4FQ7oUPP8Mog3FHSQSD/xB+6SHlzJTf7YhdDqdCEf1kPLa7IQ==",
+      "dependencies": {
+        "@deephaven/components": "^0.64.0",
+        "@deephaven/golden-layout": "^0.64.0",
+        "@deephaven/log": "^0.64.0",
+        "@deephaven/react-hooks": "^0.64.0",
+        "@deephaven/redux": "^0.64.0",
+        "@deephaven/utils": "^0.64.0",
+        "deep-equal": "^2.0.5",
+        "lodash.ismatch": "^4.1.1",
+        "lodash.throttle": "^4.1.1",
+        "prop-types": "^15.7.2",
+        "shortid": "^2.2.16"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0",
+        "react-dom": "^17.0.0",
+        "react-is": "^17.0.0",
+        "react-redux": "^7.2.4"
+      }
+    },
+    "node_modules/@deephaven/dashboard-core-plugins/node_modules/@deephaven/golden-layout": {
+      "version": "0.64.0",
+      "resolved": "https://registry.npmjs.org/@deephaven/golden-layout/-/golden-layout-0.64.0.tgz",
+      "integrity": "sha512-MP5H8EvhdVEJzJKDPEp5xO1kBjqbv8hg/PMkR7EcFJJjxvTcJXcx24prfqBDeHVHbcWzDce5HeI56j6I93iFwQ==",
+      "dependencies": {
+        "@deephaven/components": "^0.64.0",
+        "jquery": "^3.6.0"
+      },
+      "peerDependencies": {
+        "react": "^17.x",
+        "react-dom": "^17.x"
+      }
+    },
+    "node_modules/@deephaven/dashboard-core-plugins/node_modules/@deephaven/jsapi-bootstrap": {
+      "version": "0.64.0",
+      "resolved": "https://registry.npmjs.org/@deephaven/jsapi-bootstrap/-/jsapi-bootstrap-0.64.0.tgz",
+      "integrity": "sha512-EGTYR1koWlG0nebD/7/1vCnA/McJqFCjIf+uL8y/2D945WMED3CalM3EwCLmXkYlQep0wtm9KgFyIhwenlwaCQ==",
+      "dependencies": {
+        "@deephaven/components": "^0.64.0",
+        "@deephaven/jsapi-types": "^0.64.0",
+        "@deephaven/log": "^0.64.0",
+        "@deephaven/react-hooks": "^0.64.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "react": "^17.x"
+      }
+    },
+    "node_modules/@deephaven/dashboard-core-plugins/node_modules/@deephaven/jsapi-components": {
+      "version": "0.64.0",
+      "resolved": "https://registry.npmjs.org/@deephaven/jsapi-components/-/jsapi-components-0.64.0.tgz",
+      "integrity": "sha512-2WeV8IbHbgwAXRIiLM7H2iXTmVd53UKiC9BSdFCynH59o/+CApbinthtS5/e8R7fF2m/DBIe8MrWpCQbPikI8Q==",
+      "dependencies": {
+        "@deephaven/components": "^0.64.0",
+        "@deephaven/jsapi-bootstrap": "^0.64.0",
+        "@deephaven/jsapi-types": "^0.64.0",
+        "@deephaven/jsapi-utils": "^0.64.0",
+        "@deephaven/log": "^0.64.0",
+        "@deephaven/react-hooks": "^0.64.0",
+        "@deephaven/utils": "^0.64.0",
+        "@types/js-cookie": "^3.0.3",
+        "classnames": "^2.3.2",
+        "js-cookie": "^3.0.5",
+        "lodash.debounce": "^4.0.8",
+        "prop-types": "^15.8.1"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "react": "^17.x"
+      }
+    },
+    "node_modules/@deephaven/dashboard-core-plugins/node_modules/@deephaven/jsapi-types": {
+      "version": "0.64.0",
+      "resolved": "https://registry.npmjs.org/@deephaven/jsapi-types/-/jsapi-types-0.64.0.tgz",
+      "integrity": "sha512-8e1YzqRPtRg0bhqUC4R3nZ9ICE/3ITRaLgFOmw8yjtGnp+VWG+RvYp/5EELIizrklfUkuWv/+Z5uxMbQYQNQRQ==",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@deephaven/dashboard-core-plugins/node_modules/@deephaven/jsapi-utils": {
+      "version": "0.64.0",
+      "resolved": "https://registry.npmjs.org/@deephaven/jsapi-utils/-/jsapi-utils-0.64.0.tgz",
+      "integrity": "sha512-U+cCICH8hcehbwqMlgG5+sGS3bcvm4GiY0SB+N15M3spLU3iAbWB5pMYo1lv8hf20TTnIYsJjF52MNp3R+F2FQ==",
+      "dependencies": {
+        "@deephaven/filters": "^0.64.0",
+        "@deephaven/jsapi-types": "^0.64.0",
+        "@deephaven/log": "^0.64.0",
+        "@deephaven/utils": "^0.64.0",
+        "lodash.clamp": "^4.0.3",
+        "shortid": "^2.2.16"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@deephaven/dashboard-core-plugins/node_modules/@deephaven/log": {
+      "version": "0.64.0",
+      "resolved": "https://registry.npmjs.org/@deephaven/log/-/log-0.64.0.tgz",
+      "integrity": "sha512-E2/gUb/lfFIGxM/bm0Wimpu+EUVY1xNubItiedMKDEp/dfmVKMVng6XdF2pPw73kaeGAs7NoCbdnWnXdns5QdA==",
+      "dependencies": {
+        "event-target-shim": "^6.0.2"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@deephaven/dashboard-core-plugins/node_modules/@deephaven/redux": {
+      "version": "0.64.0",
+      "resolved": "https://registry.npmjs.org/@deephaven/redux/-/redux-0.64.0.tgz",
+      "integrity": "sha512-mnBMzJCUhBKDnA7yJGY49lJickgqDGb4ck2FpQEUtpzSsquOmjtz4glxBOgaNN3vLbm1bfXJyKUqkT08Hjknfw==",
+      "dependencies": {
+        "@deephaven/jsapi-types": "^0.64.0",
+        "@deephaven/jsapi-utils": "^0.64.0",
+        "@deephaven/log": "^0.64.0",
+        "@deephaven/plugin": "^0.64.0",
+        "deep-equal": "^2.0.5",
+        "redux-thunk": "2.4.1"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "redux": "^4.2.0"
+      }
+    },
+    "node_modules/@deephaven/dashboard-core-plugins/node_modules/@deephaven/utils": {
+      "version": "0.64.0",
+      "resolved": "https://registry.npmjs.org/@deephaven/utils/-/utils-0.64.0.tgz",
+      "integrity": "sha512-lt9cXEw0j2KMmUvR/+jmrpmWihrkYxNmhClW778WLFf0oi6Y4V/hsJxiNz+QvFvNbg3HqU6ZBMPHOtCNjKe7bQ==",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@deephaven/dashboard-core-plugins/node_modules/bail": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+      "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/@deephaven/dashboard-core-plugins/node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/@deephaven/dashboard-core-plugins/node_modules/comma-separated-tokens": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/@deephaven/dashboard-core-plugins/node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@deephaven/dashboard-core-plugins/node_modules/event-target-shim": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-6.0.2.tgz",
+      "integrity": "sha512-8q3LsZjRezbFZ2PN+uP+Q7pnHUMmAOziU2vA2OwoFaKIXxlxl38IylhSSgUorWu/rf4er67w0ikBqjBFk/pomA==",
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mysticatea"
+      }
+    },
+    "node_modules/@deephaven/dashboard-core-plugins/node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@deephaven/dashboard-core-plugins/node_modules/longest-streak": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+      "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/@deephaven/dashboard-core-plugins/node_modules/markdown-table": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.3.tgz",
+      "integrity": "sha512-Z1NL3Tb1M9wH4XESsCDEksWoKTdlUafKc4pt0GRwjUyXaCFZ+dc3g2erqB6zm3szA2IUSi7VnPI+o/9jnxh9hw==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/@deephaven/dashboard-core-plugins/node_modules/mdast-util-definitions": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-definitions/-/mdast-util-definitions-5.1.2.tgz",
+      "integrity": "sha512-8SVPMuHqlPME/z3gqVwWY4zVXn8lqKv/pAhC57FuJ40ImXyBpmO5ukh98zB2v7Blql2FiHjHv9LVztSIqjY+MA==",
+      "dependencies": {
+        "@types/mdast": "^3.0.0",
+        "@types/unist": "^2.0.0",
+        "unist-util-visit": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/@deephaven/dashboard-core-plugins/node_modules/mdast-util-find-and-replace": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.1.tgz",
+      "integrity": "sha512-SG21kZHGC3XRTSUhtofZkBzZTJNM5ecCi0SK2IMKmSXR8vO3peL+kb1O0z7Zl83jKtutG4k5Wv/W7V3/YHvzPA==",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "escape-string-regexp": "^5.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/@deephaven/dashboard-core-plugins/node_modules/mdast-util-find-and-replace/node_modules/@types/mdast": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.3.tgz",
+      "integrity": "sha512-LsjtqsyF+d2/yFOYaN22dHZI1Cpwkrj+g06G8+qtUKlhovPW89YhqSnfKtMbkgmEtYpH2gydRNULd6y8mciAFg==",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@deephaven/dashboard-core-plugins/node_modules/mdast-util-from-markdown": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.0.tgz",
+      "integrity": "sha512-n7MTOr/z+8NAX/wmhhDji8O3bRvPTV/U0oTCaZJkjhPSKTPhS3xufVhKGF8s1pJ7Ox4QgoIU7KHseh09S+9rTA==",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark": "^4.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/@deephaven/dashboard-core-plugins/node_modules/mdast-util-from-markdown/node_modules/@types/mdast": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.3.tgz",
+      "integrity": "sha512-LsjtqsyF+d2/yFOYaN22dHZI1Cpwkrj+g06G8+qtUKlhovPW89YhqSnfKtMbkgmEtYpH2gydRNULd6y8mciAFg==",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@deephaven/dashboard-core-plugins/node_modules/mdast-util-from-markdown/node_modules/@types/unist": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.2.tgz",
+      "integrity": "sha512-dqId9J8K/vGi5Zr7oo212BGii5m3q5Hxlkwy3WpYuKPklmBEvsbMYYyLxAQpSffdLl/gdW0XUpKWFvYmyoWCoQ=="
+    },
+    "node_modules/@deephaven/dashboard-core-plugins/node_modules/mdast-util-gfm": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.0.0.tgz",
+      "integrity": "sha512-dgQEX5Amaq+DuUqf26jJqSK9qgixgd6rYDHAv4aTBuA92cTknZlKpPfa86Z/s8Dj8xsAQpFfBmPUHWJBWqS4Bw==",
+      "dependencies": {
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-gfm-autolink-literal": "^2.0.0",
+        "mdast-util-gfm-footnote": "^2.0.0",
+        "mdast-util-gfm-strikethrough": "^2.0.0",
+        "mdast-util-gfm-table": "^2.0.0",
+        "mdast-util-gfm-task-list-item": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/@deephaven/dashboard-core-plugins/node_modules/mdast-util-gfm-autolink-literal": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.0.tgz",
+      "integrity": "sha512-FyzMsduZZHSc3i0Px3PQcBT4WJY/X/RCtEJKuybiC6sjPqLv7h1yqAkmILZtuxMSsUyaLUWNp71+vQH2zqp5cg==",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-find-and-replace": "^3.0.0",
+        "micromark-util-character": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/@deephaven/dashboard-core-plugins/node_modules/mdast-util-gfm-autolink-literal/node_modules/@types/mdast": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.3.tgz",
+      "integrity": "sha512-LsjtqsyF+d2/yFOYaN22dHZI1Cpwkrj+g06G8+qtUKlhovPW89YhqSnfKtMbkgmEtYpH2gydRNULd6y8mciAFg==",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@deephaven/dashboard-core-plugins/node_modules/mdast-util-gfm-strikethrough": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
+      "integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/@deephaven/dashboard-core-plugins/node_modules/mdast-util-gfm-strikethrough/node_modules/@types/mdast": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.3.tgz",
+      "integrity": "sha512-LsjtqsyF+d2/yFOYaN22dHZI1Cpwkrj+g06G8+qtUKlhovPW89YhqSnfKtMbkgmEtYpH2gydRNULd6y8mciAFg==",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@deephaven/dashboard-core-plugins/node_modules/mdast-util-gfm-table": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
+      "integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "markdown-table": "^3.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/@deephaven/dashboard-core-plugins/node_modules/mdast-util-gfm-table/node_modules/@types/mdast": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.3.tgz",
+      "integrity": "sha512-LsjtqsyF+d2/yFOYaN22dHZI1Cpwkrj+g06G8+qtUKlhovPW89YhqSnfKtMbkgmEtYpH2gydRNULd6y8mciAFg==",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@deephaven/dashboard-core-plugins/node_modules/mdast-util-gfm-task-list-item": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
+      "integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/@deephaven/dashboard-core-plugins/node_modules/mdast-util-gfm-task-list-item/node_modules/@types/mdast": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.3.tgz",
+      "integrity": "sha512-LsjtqsyF+d2/yFOYaN22dHZI1Cpwkrj+g06G8+qtUKlhovPW89YhqSnfKtMbkgmEtYpH2gydRNULd6y8mciAFg==",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@deephaven/dashboard-core-plugins/node_modules/mdast-util-to-hast": {
+      "version": "12.3.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-12.3.0.tgz",
+      "integrity": "sha512-pits93r8PhnIoU4Vy9bjW39M2jJ6/tdHyja9rrot9uujkN7UTU9SDnE6WNJz/IGyQk3XHX6yNNtrBH6cQzm8Hw==",
+      "dependencies": {
+        "@types/hast": "^2.0.0",
+        "@types/mdast": "^3.0.0",
+        "mdast-util-definitions": "^5.0.0",
+        "micromark-util-sanitize-uri": "^1.1.0",
+        "trim-lines": "^3.0.0",
+        "unist-util-generated": "^2.0.0",
+        "unist-util-position": "^4.0.0",
+        "unist-util-visit": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/@deephaven/dashboard-core-plugins/node_modules/mdast-util-to-hast/node_modules/micromark-util-character": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-1.2.0.tgz",
+      "integrity": "sha512-lXraTwcX3yH/vMDaFWCQJP1uIszLVebzUa3ZHdrgxr7KEU/9mL4mVgCpGbyhvNLNlauROiNUq7WN5u7ndbY6xg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0"
+      }
+    },
+    "node_modules/@deephaven/dashboard-core-plugins/node_modules/mdast-util-to-hast/node_modules/micromark-util-encode": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-1.1.0.tgz",
+      "integrity": "sha512-EuEzTWSTAj9PA5GOAs992GzNh2dGQO52UvAbtSOMvXTxv3Criqb6IOzJUBCmEqrrXSblJIJBbFFv6zPxpreiJw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ]
+    },
+    "node_modules/@deephaven/dashboard-core-plugins/node_modules/mdast-util-to-hast/node_modules/micromark-util-sanitize-uri": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-1.2.0.tgz",
+      "integrity": "sha512-QO4GXv0XZfWey4pYFndLUKEAktKkG5kZTdUNaTAkzbuJxn2tNBOr+QtxR2XpWaMhbImT2dPzyLrPXLlPhph34A==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-encode": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0"
+      }
+    },
+    "node_modules/@deephaven/dashboard-core-plugins/node_modules/mdast-util-to-hast/node_modules/micromark-util-symbol": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-1.1.0.tgz",
+      "integrity": "sha512-uEjpEYY6KMs1g7QfJ2eX1SQEV+ZT4rUD3UcF6l57acZvLNK7PBZL+ty82Z1qhK1/yXIY4bdx04FKMgR0g4IAag==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ]
+    },
+    "node_modules/@deephaven/dashboard-core-plugins/node_modules/mdast-util-to-hast/node_modules/micromark-util-types": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-1.1.0.tgz",
+      "integrity": "sha512-ukRBgie8TIAcacscVHSiddHjO4k/q3pnedmzMQ4iwDcK0FtFCohKOlFbaOL/mPgfnPsL3C1ZyxJa4sbWrBl3jg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ]
+    },
+    "node_modules/@deephaven/dashboard-core-plugins/node_modules/mdast-util-to-markdown": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.0.tgz",
+      "integrity": "sha512-SR2VnIEdVNCJbP6y7kVTJgPLifdr8WEU440fQec7qHoHOUz/oJ2jmNRqdDQ3rbiStOXb2mCDGTuwsK5OPUgYlQ==",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-phrasing": "^4.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "unist-util-visit": "^5.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/@deephaven/dashboard-core-plugins/node_modules/mdast-util-to-markdown/node_modules/@types/mdast": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.3.tgz",
+      "integrity": "sha512-LsjtqsyF+d2/yFOYaN22dHZI1Cpwkrj+g06G8+qtUKlhovPW89YhqSnfKtMbkgmEtYpH2gydRNULd6y8mciAFg==",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@deephaven/dashboard-core-plugins/node_modules/mdast-util-to-markdown/node_modules/@types/unist": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.2.tgz",
+      "integrity": "sha512-dqId9J8K/vGi5Zr7oo212BGii5m3q5Hxlkwy3WpYuKPklmBEvsbMYYyLxAQpSffdLl/gdW0XUpKWFvYmyoWCoQ=="
+    },
+    "node_modules/@deephaven/dashboard-core-plugins/node_modules/mdast-util-to-markdown/node_modules/unist-util-visit": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.0.0.tgz",
+      "integrity": "sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/@deephaven/dashboard-core-plugins/node_modules/mdast-util-to-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+      "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+      "dependencies": {
+        "@types/mdast": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/@deephaven/dashboard-core-plugins/node_modules/mdast-util-to-string/node_modules/@types/mdast": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.3.tgz",
+      "integrity": "sha512-LsjtqsyF+d2/yFOYaN22dHZI1Cpwkrj+g06G8+qtUKlhovPW89YhqSnfKtMbkgmEtYpH2gydRNULd6y8mciAFg==",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@deephaven/dashboard-core-plugins/node_modules/micromark": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.0.tgz",
+      "integrity": "sha512-o/sd0nMof8kYff+TqcDx3VSrgBTcZpSvYcAHIfHhv5VAuNmisCxjhx6YmxS8PFEpb9z5WKWKPdzf0jM23ro3RQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "@types/debug": "^4.0.0",
+        "debug": "^4.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/@deephaven/dashboard-core-plugins/node_modules/micromark-extension-gfm": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
+      "integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
+      "dependencies": {
+        "micromark-extension-gfm-autolink-literal": "^2.0.0",
+        "micromark-extension-gfm-footnote": "^2.0.0",
+        "micromark-extension-gfm-strikethrough": "^2.0.0",
+        "micromark-extension-gfm-table": "^2.0.0",
+        "micromark-extension-gfm-tagfilter": "^2.0.0",
+        "micromark-extension-gfm-task-list-item": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/@deephaven/dashboard-core-plugins/node_modules/micromark-extension-gfm-autolink-literal": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.0.0.tgz",
+      "integrity": "sha512-rTHfnpt/Q7dEAK1Y5ii0W8bhfJlVJFnJMHIPisfPK3gpVNuOP0VnRl96+YJ3RYWV/P4gFeQoGKNlT3RhuvpqAg==",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/@deephaven/dashboard-core-plugins/node_modules/micromark-extension-gfm-strikethrough": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.0.0.tgz",
+      "integrity": "sha512-c3BR1ClMp5fxxmwP6AoOY2fXO9U8uFMKs4ADD66ahLTNcwzSCyRVU4k7LPV5Nxo/VJiR4TdzxRQY2v3qIUceCw==",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/@deephaven/dashboard-core-plugins/node_modules/micromark-extension-gfm-table": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.0.0.tgz",
+      "integrity": "sha512-PoHlhypg1ItIucOaHmKE8fbin3vTLpDOUg8KAr8gRCF1MOZI9Nquq2i/44wFvviM4WuxJzc3demT8Y3dkfvYrw==",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/@deephaven/dashboard-core-plugins/node_modules/micromark-extension-gfm-tagfilter": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
+      "integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/@deephaven/dashboard-core-plugins/node_modules/micromark-extension-gfm-task-list-item": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.0.1.tgz",
+      "integrity": "sha512-cY5PzGcnULaN5O7T+cOzfMoHjBW7j+T9D2sucA5d/KbsBTPcYdebm9zUd9zzdgJGCwahV+/W78Z3nbulBYVbTw==",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/@deephaven/dashboard-core-plugins/node_modules/micromark-factory-destination": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-1.1.0.tgz",
+      "integrity": "sha512-XaNDROBgx9SgSChd69pjiGKbV+nfHGDPVYFs5dOoDd7ZnMAE+Cuu91BCpsY8RT2NP9vo/B8pds2VQNCLiu0zhg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0"
+      }
+    },
+    "node_modules/@deephaven/dashboard-core-plugins/node_modules/micromark-factory-destination/node_modules/micromark-util-character": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-1.2.0.tgz",
+      "integrity": "sha512-lXraTwcX3yH/vMDaFWCQJP1uIszLVebzUa3ZHdrgxr7KEU/9mL4mVgCpGbyhvNLNlauROiNUq7WN5u7ndbY6xg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0"
+      }
+    },
+    "node_modules/@deephaven/dashboard-core-plugins/node_modules/micromark-factory-destination/node_modules/micromark-util-symbol": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-1.1.0.tgz",
+      "integrity": "sha512-uEjpEYY6KMs1g7QfJ2eX1SQEV+ZT4rUD3UcF6l57acZvLNK7PBZL+ty82Z1qhK1/yXIY4bdx04FKMgR0g4IAag==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ]
+    },
+    "node_modules/@deephaven/dashboard-core-plugins/node_modules/micromark-factory-destination/node_modules/micromark-util-types": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-1.1.0.tgz",
+      "integrity": "sha512-ukRBgie8TIAcacscVHSiddHjO4k/q3pnedmzMQ4iwDcK0FtFCohKOlFbaOL/mPgfnPsL3C1ZyxJa4sbWrBl3jg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ]
+    },
+    "node_modules/@deephaven/dashboard-core-plugins/node_modules/micromark-factory-label": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-1.1.0.tgz",
+      "integrity": "sha512-OLtyez4vZo/1NjxGhcpDSbHQ+m0IIGnT8BoPamh+7jVlzLJBH98zzuCoUeMxvM6WsNeh8wx8cKvqLiPHEACn0w==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0",
+        "uvu": "^0.5.0"
+      }
+    },
+    "node_modules/@deephaven/dashboard-core-plugins/node_modules/micromark-factory-label/node_modules/micromark-util-character": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-1.2.0.tgz",
+      "integrity": "sha512-lXraTwcX3yH/vMDaFWCQJP1uIszLVebzUa3ZHdrgxr7KEU/9mL4mVgCpGbyhvNLNlauROiNUq7WN5u7ndbY6xg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0"
+      }
+    },
+    "node_modules/@deephaven/dashboard-core-plugins/node_modules/micromark-factory-label/node_modules/micromark-util-symbol": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-1.1.0.tgz",
+      "integrity": "sha512-uEjpEYY6KMs1g7QfJ2eX1SQEV+ZT4rUD3UcF6l57acZvLNK7PBZL+ty82Z1qhK1/yXIY4bdx04FKMgR0g4IAag==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ]
+    },
+    "node_modules/@deephaven/dashboard-core-plugins/node_modules/micromark-factory-label/node_modules/micromark-util-types": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-1.1.0.tgz",
+      "integrity": "sha512-ukRBgie8TIAcacscVHSiddHjO4k/q3pnedmzMQ4iwDcK0FtFCohKOlFbaOL/mPgfnPsL3C1ZyxJa4sbWrBl3jg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ]
+    },
+    "node_modules/@deephaven/dashboard-core-plugins/node_modules/micromark-factory-space": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.0.tgz",
+      "integrity": "sha512-TKr+LIDX2pkBJXFLzpyPyljzYK3MtmllMUMODTQJIUfDGncESaqB90db9IAUcz4AZAJFdd8U9zOp9ty1458rxg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/@deephaven/dashboard-core-plugins/node_modules/micromark-factory-title": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-1.1.0.tgz",
+      "integrity": "sha512-J7n9R3vMmgjDOCY8NPw55jiyaQnH5kBdV2/UXCtZIpnHH3P6nHUKaH7XXEYuWwx/xUJcawa8plLBEjMPU24HzQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-factory-space": "^1.0.0",
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0"
+      }
+    },
+    "node_modules/@deephaven/dashboard-core-plugins/node_modules/micromark-factory-title/node_modules/micromark-factory-space": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-1.1.0.tgz",
+      "integrity": "sha512-cRzEj7c0OL4Mw2v6nwzttyOZe8XY/Z8G0rzmWQZTBi/jjwyw/U4uqKtUORXQrR5bAZZnbTI/feRV/R7hc4jQYQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-types": "^1.0.0"
+      }
+    },
+    "node_modules/@deephaven/dashboard-core-plugins/node_modules/micromark-factory-title/node_modules/micromark-util-character": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-1.2.0.tgz",
+      "integrity": "sha512-lXraTwcX3yH/vMDaFWCQJP1uIszLVebzUa3ZHdrgxr7KEU/9mL4mVgCpGbyhvNLNlauROiNUq7WN5u7ndbY6xg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0"
+      }
+    },
+    "node_modules/@deephaven/dashboard-core-plugins/node_modules/micromark-factory-title/node_modules/micromark-util-symbol": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-1.1.0.tgz",
+      "integrity": "sha512-uEjpEYY6KMs1g7QfJ2eX1SQEV+ZT4rUD3UcF6l57acZvLNK7PBZL+ty82Z1qhK1/yXIY4bdx04FKMgR0g4IAag==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ]
+    },
+    "node_modules/@deephaven/dashboard-core-plugins/node_modules/micromark-factory-title/node_modules/micromark-util-types": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-1.1.0.tgz",
+      "integrity": "sha512-ukRBgie8TIAcacscVHSiddHjO4k/q3pnedmzMQ4iwDcK0FtFCohKOlFbaOL/mPgfnPsL3C1ZyxJa4sbWrBl3jg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ]
+    },
+    "node_modules/@deephaven/dashboard-core-plugins/node_modules/micromark-factory-whitespace": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-1.1.0.tgz",
+      "integrity": "sha512-v2WlmiymVSp5oMg+1Q0N1Lxmt6pMhIHD457whWM7/GUlEks1hI9xj5w3zbc4uuMKXGisksZk8DzP2UyGbGqNsQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-factory-space": "^1.0.0",
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0"
+      }
+    },
+    "node_modules/@deephaven/dashboard-core-plugins/node_modules/micromark-factory-whitespace/node_modules/micromark-factory-space": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-1.1.0.tgz",
+      "integrity": "sha512-cRzEj7c0OL4Mw2v6nwzttyOZe8XY/Z8G0rzmWQZTBi/jjwyw/U4uqKtUORXQrR5bAZZnbTI/feRV/R7hc4jQYQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-types": "^1.0.0"
+      }
+    },
+    "node_modules/@deephaven/dashboard-core-plugins/node_modules/micromark-factory-whitespace/node_modules/micromark-util-character": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-1.2.0.tgz",
+      "integrity": "sha512-lXraTwcX3yH/vMDaFWCQJP1uIszLVebzUa3ZHdrgxr7KEU/9mL4mVgCpGbyhvNLNlauROiNUq7WN5u7ndbY6xg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0"
+      }
+    },
+    "node_modules/@deephaven/dashboard-core-plugins/node_modules/micromark-factory-whitespace/node_modules/micromark-util-symbol": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-1.1.0.tgz",
+      "integrity": "sha512-uEjpEYY6KMs1g7QfJ2eX1SQEV+ZT4rUD3UcF6l57acZvLNK7PBZL+ty82Z1qhK1/yXIY4bdx04FKMgR0g4IAag==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ]
+    },
+    "node_modules/@deephaven/dashboard-core-plugins/node_modules/micromark-factory-whitespace/node_modules/micromark-util-types": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-1.1.0.tgz",
+      "integrity": "sha512-ukRBgie8TIAcacscVHSiddHjO4k/q3pnedmzMQ4iwDcK0FtFCohKOlFbaOL/mPgfnPsL3C1ZyxJa4sbWrBl3jg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ]
+    },
+    "node_modules/@deephaven/dashboard-core-plugins/node_modules/micromark-util-character": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.0.tgz",
+      "integrity": "sha512-KvOVV+X1yLBfs9dCBSopq/+G1PcgT3lAK07mC4BzXi5E7ahzMAF8oIupDDJ6mievI6F+lAATkbQQlQixJfT3aQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/@deephaven/dashboard-core-plugins/node_modules/micromark-util-html-tag-name": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-1.2.0.tgz",
+      "integrity": "sha512-VTQzcuQgFUD7yYztuQFKXT49KghjtETQ+Wv/zUjGSGBioZnkA4P1XXZPT1FHeJA6RwRXSF47yvJ1tsJdoxwO+Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ]
+    },
+    "node_modules/@deephaven/dashboard-core-plugins/node_modules/micromark-util-symbol": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.0.tgz",
+      "integrity": "sha512-8JZt9ElZ5kyTnO94muPxIGS8oyElRJaiJO8EzV6ZSyGQ1Is8xwl4Q45qU5UOg+bGH4AikWziz0iN4sFLWs8PGw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ]
+    },
+    "node_modules/@deephaven/dashboard-core-plugins/node_modules/micromark-util-types": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.0.tgz",
+      "integrity": "sha512-oNh6S2WMHWRZrmutsRmDDfkzKtxF+bc2VxLC9dvtrDIRFln627VsFP6fLMgTryGDljgLPjkrzQSDcPrjPyDJ5w==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ]
+    },
+    "node_modules/@deephaven/dashboard-core-plugins/node_modules/property-information": {
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-6.4.1.tgz",
+      "integrity": "sha512-OHYtXfu5aI2sS2LWFSN5rgJjrQ4pCy8i1jubJLe2QvMF8JJ++HXTUIVWFLfXJoaOfvYYjk2SN8J2wFUWIGXT4w==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/@deephaven/dashboard-core-plugins/node_modules/react-markdown": {
+      "version": "8.0.7",
+      "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-8.0.7.tgz",
+      "integrity": "sha512-bvWbzG4MtOU62XqBx3Xx+zB2raaFFsq4mYiAzfjXJMEz2sixgeAfraA3tvzULF02ZdOMUOKTBFFaZJDDrq+BJQ==",
+      "dependencies": {
+        "@types/hast": "^2.0.0",
+        "@types/prop-types": "^15.0.0",
+        "@types/unist": "^2.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-whitespace": "^2.0.0",
+        "prop-types": "^15.0.0",
+        "property-information": "^6.0.0",
+        "react-is": "^18.0.0",
+        "remark-parse": "^10.0.0",
+        "remark-rehype": "^10.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "style-to-object": "^0.4.0",
+        "unified": "^10.0.0",
+        "unist-util-visit": "^4.0.0",
+        "vfile": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16",
+        "react": ">=16"
+      }
+    },
+    "node_modules/@deephaven/dashboard-core-plugins/node_modules/react-markdown/node_modules/react-is": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
+    },
+    "node_modules/@deephaven/dashboard-core-plugins/node_modules/redux-thunk": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.4.1.tgz",
+      "integrity": "sha512-OOYGNY5Jy2TWvTL1KgAlVy6dcx3siPJ1wTq741EPyUKfn6W6nChdICjZwCd0p8AZBs5kWpZlbkXW2nE/zjUa+Q==",
+      "peerDependencies": {
+        "redux": "^4"
+      }
+    },
+    "node_modules/@deephaven/dashboard-core-plugins/node_modules/remark-gfm": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.0.tgz",
+      "integrity": "sha512-U92vJgBPkbw4Zfu/IiW2oTZLSL3Zpv+uI7My2eq8JxKgqraFdU8YUGicEJCEgSbeaG+QDFqIcwwfMTOEelPxuA==",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-gfm": "^3.0.0",
+        "micromark-extension-gfm": "^3.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-stringify": "^11.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/@deephaven/dashboard-core-plugins/node_modules/remark-gfm/node_modules/@types/mdast": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.3.tgz",
+      "integrity": "sha512-LsjtqsyF+d2/yFOYaN22dHZI1Cpwkrj+g06G8+qtUKlhovPW89YhqSnfKtMbkgmEtYpH2gydRNULd6y8mciAFg==",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@deephaven/dashboard-core-plugins/node_modules/remark-gfm/node_modules/@types/unist": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.2.tgz",
+      "integrity": "sha512-dqId9J8K/vGi5Zr7oo212BGii5m3q5Hxlkwy3WpYuKPklmBEvsbMYYyLxAQpSffdLl/gdW0XUpKWFvYmyoWCoQ=="
+    },
+    "node_modules/@deephaven/dashboard-core-plugins/node_modules/remark-gfm/node_modules/remark-parse": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
+      "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/@deephaven/dashboard-core-plugins/node_modules/remark-gfm/node_modules/unified": {
+      "version": "11.0.4",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.4.tgz",
+      "integrity": "sha512-apMPnyLjAX+ty4OrNap7yumyVAMlKx5IWU2wlzzUdYJO9A8f1p9m/gywF/GM2ZDFcjQPrx59Mc90KwmxsoklxQ==",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "bail": "^2.0.0",
+        "devlop": "^1.0.0",
+        "extend": "^3.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/@deephaven/dashboard-core-plugins/node_modules/remark-gfm/node_modules/vfile": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.1.tgz",
+      "integrity": "sha512-1bYqc7pt6NIADBJ98UiG0Bn/CHIVOoZ/IyEkqIruLg0mE1BKzkOXY2D6CSqQIcKqgadppE5lrxgWXJmXd7zZJw==",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/@deephaven/dashboard-core-plugins/node_modules/remark-gfm/node_modules/vfile-message": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.2.tgz",
+      "integrity": "sha512-jRDZ1IMLttGj41KcZvlrYAaI3CfqpLpfpf+Mfig13viT6NKvRzWZ+lXz0Y5D60w6uJIBAOGq9mSHf0gktF0duw==",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/@deephaven/dashboard-core-plugins/node_modules/remark-parse": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-10.0.2.tgz",
+      "integrity": "sha512-3ydxgHa/ZQzG8LvC7jTXccARYDcRld3VfcgIIFs7bI6vbRSxJJmzgLEIIoYKyrfhaY+ujuWaf/PJiMZXoiCXgw==",
+      "dependencies": {
+        "@types/mdast": "^3.0.0",
+        "mdast-util-from-markdown": "^1.0.0",
+        "unified": "^10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/@deephaven/dashboard-core-plugins/node_modules/remark-parse/node_modules/mdast-util-from-markdown": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-1.3.1.tgz",
+      "integrity": "sha512-4xTO/M8c82qBcnQc1tgpNtubGUW/Y1tBQ1B0i5CtSoelOLKFYlElIr3bvgREYYO5iRqbMY1YuqZng0GVOI8Qww==",
+      "dependencies": {
+        "@types/mdast": "^3.0.0",
+        "@types/unist": "^2.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "mdast-util-to-string": "^3.1.0",
+        "micromark": "^3.0.0",
+        "micromark-util-decode-numeric-character-reference": "^1.0.0",
+        "micromark-util-decode-string": "^1.0.0",
+        "micromark-util-normalize-identifier": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0",
+        "unist-util-stringify-position": "^3.0.0",
+        "uvu": "^0.5.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/@deephaven/dashboard-core-plugins/node_modules/remark-parse/node_modules/mdast-util-to-string": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-3.2.0.tgz",
+      "integrity": "sha512-V4Zn/ncyN1QNSqSBxTrMOLpjr+IKdHl2v3KVLoWmDPscP4r9GcCi71gjgvUV1SFSKh92AjAG4peFuBl2/YgCJg==",
+      "dependencies": {
+        "@types/mdast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/@deephaven/dashboard-core-plugins/node_modules/remark-parse/node_modules/micromark": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-3.2.0.tgz",
+      "integrity": "sha512-uD66tJj54JLYq0De10AhWycZWGQNUvDI55xPgk2sQM5kn1JYlhbCMTtEeT27+vAhW2FBQxLlOmS3pmA7/2z4aA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "@types/debug": "^4.0.0",
+        "debug": "^4.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-core-commonmark": "^1.0.1",
+        "micromark-factory-space": "^1.0.0",
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-chunked": "^1.0.0",
+        "micromark-util-combine-extensions": "^1.0.0",
+        "micromark-util-decode-numeric-character-reference": "^1.0.0",
+        "micromark-util-encode": "^1.0.0",
+        "micromark-util-normalize-identifier": "^1.0.0",
+        "micromark-util-resolve-all": "^1.0.0",
+        "micromark-util-sanitize-uri": "^1.0.0",
+        "micromark-util-subtokenize": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.1",
+        "uvu": "^0.5.0"
+      }
+    },
+    "node_modules/@deephaven/dashboard-core-plugins/node_modules/remark-parse/node_modules/micromark-core-commonmark": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-1.1.0.tgz",
+      "integrity": "sha512-BgHO1aRbolh2hcrzL2d1La37V0Aoz73ymF8rAcKnohLy93titmv62E0gP8Hrx9PKcKrqCZ1BbLGbP3bEhoXYlw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-factory-destination": "^1.0.0",
+        "micromark-factory-label": "^1.0.0",
+        "micromark-factory-space": "^1.0.0",
+        "micromark-factory-title": "^1.0.0",
+        "micromark-factory-whitespace": "^1.0.0",
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-chunked": "^1.0.0",
+        "micromark-util-classify-character": "^1.0.0",
+        "micromark-util-html-tag-name": "^1.0.0",
+        "micromark-util-normalize-identifier": "^1.0.0",
+        "micromark-util-resolve-all": "^1.0.0",
+        "micromark-util-subtokenize": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.1",
+        "uvu": "^0.5.0"
+      }
+    },
+    "node_modules/@deephaven/dashboard-core-plugins/node_modules/remark-parse/node_modules/micromark-factory-space": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-1.1.0.tgz",
+      "integrity": "sha512-cRzEj7c0OL4Mw2v6nwzttyOZe8XY/Z8G0rzmWQZTBi/jjwyw/U4uqKtUORXQrR5bAZZnbTI/feRV/R7hc4jQYQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-types": "^1.0.0"
+      }
+    },
+    "node_modules/@deephaven/dashboard-core-plugins/node_modules/remark-parse/node_modules/micromark-util-character": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-1.2.0.tgz",
+      "integrity": "sha512-lXraTwcX3yH/vMDaFWCQJP1uIszLVebzUa3ZHdrgxr7KEU/9mL4mVgCpGbyhvNLNlauROiNUq7WN5u7ndbY6xg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0"
+      }
+    },
+    "node_modules/@deephaven/dashboard-core-plugins/node_modules/remark-parse/node_modules/micromark-util-chunked": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-1.1.0.tgz",
+      "integrity": "sha512-Ye01HXpkZPNcV6FiyoW2fGZDUw4Yc7vT0E9Sad83+bEDiCJ1uXu0S3mr8WLpsz3HaG3x2q0HM6CTuPdcZcluFQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-symbol": "^1.0.0"
+      }
+    },
+    "node_modules/@deephaven/dashboard-core-plugins/node_modules/remark-parse/node_modules/micromark-util-classify-character": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-1.1.0.tgz",
+      "integrity": "sha512-SL0wLxtKSnklKSUplok1WQFoGhUdWYKggKUiqhX+Swala+BtptGCu5iPRc+xvzJ4PXE/hwM3FNXsfEVgoZsWbw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0"
+      }
+    },
+    "node_modules/@deephaven/dashboard-core-plugins/node_modules/remark-parse/node_modules/micromark-util-combine-extensions": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-1.1.0.tgz",
+      "integrity": "sha512-Q20sp4mfNf9yEqDL50WwuWZHUrCO4fEyeDCnMGmG5Pr0Cz15Uo7KBs6jq+dq0EgX4DPwwrh9m0X+zPV1ypFvUA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-chunked": "^1.0.0",
+        "micromark-util-types": "^1.0.0"
+      }
+    },
+    "node_modules/@deephaven/dashboard-core-plugins/node_modules/remark-parse/node_modules/micromark-util-decode-numeric-character-reference": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-1.1.0.tgz",
+      "integrity": "sha512-m9V0ExGv0jB1OT21mrWcuf4QhP46pH1KkfWy9ZEezqHKAxkj4mPCy3nIH1rkbdMlChLHX531eOrymlwyZIf2iw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-symbol": "^1.0.0"
+      }
+    },
+    "node_modules/@deephaven/dashboard-core-plugins/node_modules/remark-parse/node_modules/micromark-util-decode-string": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-1.1.0.tgz",
+      "integrity": "sha512-YphLGCK8gM1tG1bd54azwyrQRjCFcmgj2S2GoJDNnh4vYtnL38JS8M4gpxzOPNyHdNEpheyWXCTnnTDY3N+NVQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-decode-numeric-character-reference": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0"
+      }
+    },
+    "node_modules/@deephaven/dashboard-core-plugins/node_modules/remark-parse/node_modules/micromark-util-encode": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-1.1.0.tgz",
+      "integrity": "sha512-EuEzTWSTAj9PA5GOAs992GzNh2dGQO52UvAbtSOMvXTxv3Criqb6IOzJUBCmEqrrXSblJIJBbFFv6zPxpreiJw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ]
+    },
+    "node_modules/@deephaven/dashboard-core-plugins/node_modules/remark-parse/node_modules/micromark-util-normalize-identifier": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-1.1.0.tgz",
+      "integrity": "sha512-N+w5vhqrBihhjdpM8+5Xsxy71QWqGn7HYNUvch71iV2PM7+E3uWGox1Qp90loa1ephtCxG2ftRV/Conitc6P2Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-symbol": "^1.0.0"
+      }
+    },
+    "node_modules/@deephaven/dashboard-core-plugins/node_modules/remark-parse/node_modules/micromark-util-resolve-all": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-1.1.0.tgz",
+      "integrity": "sha512-b/G6BTMSg+bX+xVCshPTPyAu2tmA0E4X98NSR7eIbeC6ycCqCeE7wjfDIgzEbkzdEVJXRtOG4FbEm/uGbCRouA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-types": "^1.0.0"
+      }
+    },
+    "node_modules/@deephaven/dashboard-core-plugins/node_modules/remark-parse/node_modules/micromark-util-sanitize-uri": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-1.2.0.tgz",
+      "integrity": "sha512-QO4GXv0XZfWey4pYFndLUKEAktKkG5kZTdUNaTAkzbuJxn2tNBOr+QtxR2XpWaMhbImT2dPzyLrPXLlPhph34A==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-encode": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0"
+      }
+    },
+    "node_modules/@deephaven/dashboard-core-plugins/node_modules/remark-parse/node_modules/micromark-util-subtokenize": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-1.1.0.tgz",
+      "integrity": "sha512-kUQHyzRoxvZO2PuLzMt2P/dwVsTiivCK8icYTeR+3WgbuPqfHgPPy7nFKbeqRivBvn/3N3GBiNC+JRTMSxEC7A==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-chunked": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0",
+        "uvu": "^0.5.0"
+      }
+    },
+    "node_modules/@deephaven/dashboard-core-plugins/node_modules/remark-parse/node_modules/micromark-util-symbol": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-1.1.0.tgz",
+      "integrity": "sha512-uEjpEYY6KMs1g7QfJ2eX1SQEV+ZT4rUD3UcF6l57acZvLNK7PBZL+ty82Z1qhK1/yXIY4bdx04FKMgR0g4IAag==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ]
+    },
+    "node_modules/@deephaven/dashboard-core-plugins/node_modules/remark-parse/node_modules/micromark-util-types": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-1.1.0.tgz",
+      "integrity": "sha512-ukRBgie8TIAcacscVHSiddHjO4k/q3pnedmzMQ4iwDcK0FtFCohKOlFbaOL/mPgfnPsL3C1ZyxJa4sbWrBl3jg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ]
+    },
+    "node_modules/@deephaven/dashboard-core-plugins/node_modules/remark-parse/node_modules/unist-util-stringify-position": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-3.0.3.tgz",
+      "integrity": "sha512-k5GzIBZ/QatR8N5X2y+drfpWG8IDBzdnVj6OInRNWm1oXrzydiaAT2OQiA8DPRRZyAKb9b6I2a6PxYklZD0gKg==",
+      "dependencies": {
+        "@types/unist": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/@deephaven/dashboard-core-plugins/node_modules/remark-rehype": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-10.1.0.tgz",
+      "integrity": "sha512-EFmR5zppdBp0WQeDVZ/b66CWJipB2q2VLNFMabzDSGR66Z2fQii83G5gTBbgGEnEEA0QRussvrFHxk1HWGJskw==",
+      "dependencies": {
+        "@types/hast": "^2.0.0",
+        "@types/mdast": "^3.0.0",
+        "mdast-util-to-hast": "^12.1.0",
+        "unified": "^10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/@deephaven/dashboard-core-plugins/node_modules/space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/@deephaven/dashboard-core-plugins/node_modules/style-to-object": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-0.4.4.tgz",
+      "integrity": "sha512-HYNoHZa2GorYNyqiCaBgsxvcJIn7OHq6inEga+E6Ke3m5JkoqpQbnFssk4jwe+K7AhGa2fcha4wSOf1Kn01dMg==",
+      "dependencies": {
+        "inline-style-parser": "0.1.1"
+      }
+    },
+    "node_modules/@deephaven/dashboard-core-plugins/node_modules/trough": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+      "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/@deephaven/dashboard-core-plugins/node_modules/unified": {
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-10.1.2.tgz",
+      "integrity": "sha512-pUSWAi/RAnVy1Pif2kAoeWNBa3JVrx0MId2LASj8G+7AiHWoKZNTomq6LG326T68U7/e263X6fTdcXIy7XnF7Q==",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "bail": "^2.0.0",
+        "extend": "^3.0.0",
+        "is-buffer": "^2.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/@deephaven/dashboard-core-plugins/node_modules/unist-util-generated": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-generated/-/unist-util-generated-2.0.1.tgz",
+      "integrity": "sha512-qF72kLmPxAw0oN2fwpWIqbXAVyEqUzDHMsbtPvOudIlUzXYFIeQIuxXQCRCFh22B7cixvU0MG7m3MW8FTq/S+A==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/@deephaven/dashboard-core-plugins/node_modules/unist-util-is": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.0.tgz",
+      "integrity": "sha512-2qCTHimwdxLfz+YzdGfkqNlH0tLi9xjTnHddPmJwtIG9MGsdbutfTc4P+haPD7l7Cjxf/WZj+we5qfVPvvxfYw==",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/@deephaven/dashboard-core-plugins/node_modules/unist-util-is/node_modules/@types/unist": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.2.tgz",
+      "integrity": "sha512-dqId9J8K/vGi5Zr7oo212BGii5m3q5Hxlkwy3WpYuKPklmBEvsbMYYyLxAQpSffdLl/gdW0XUpKWFvYmyoWCoQ=="
+    },
+    "node_modules/@deephaven/dashboard-core-plugins/node_modules/unist-util-position": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-4.0.4.tgz",
+      "integrity": "sha512-kUBE91efOWfIVBo8xzh/uZQ7p9ffYRtUbMRZBNFYwf0RK8koUMx6dGUfwylLOKmaT2cs4wSW96QoYUSXAyEtpg==",
+      "dependencies": {
+        "@types/unist": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/@deephaven/dashboard-core-plugins/node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/@deephaven/dashboard-core-plugins/node_modules/unist-util-stringify-position/node_modules/@types/unist": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.2.tgz",
+      "integrity": "sha512-dqId9J8K/vGi5Zr7oo212BGii5m3q5Hxlkwy3WpYuKPklmBEvsbMYYyLxAQpSffdLl/gdW0XUpKWFvYmyoWCoQ=="
+    },
+    "node_modules/@deephaven/dashboard-core-plugins/node_modules/unist-util-visit": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-4.1.2.tgz",
+      "integrity": "sha512-MSd8OUGISqHdVvfY9TPhyK2VdUrPgxkUtWSuMHF6XAAFuL4LokseigBnZtPnJMu+FbynTkFNnFlyjxpVKujMRg==",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "unist-util-is": "^5.0.0",
+        "unist-util-visit-parents": "^5.1.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/@deephaven/dashboard-core-plugins/node_modules/unist-util-visit-parents": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.1.tgz",
+      "integrity": "sha512-L/PqWzfTP9lzzEa6CKs0k2nARxTdZduw3zyh8d2NVBnsyvHjSX4TWse388YrrQKbvI8w20fGjGlhgT96WwKykw==",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/@deephaven/dashboard-core-plugins/node_modules/unist-util-visit-parents/node_modules/@types/unist": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.2.tgz",
+      "integrity": "sha512-dqId9J8K/vGi5Zr7oo212BGii5m3q5Hxlkwy3WpYuKPklmBEvsbMYYyLxAQpSffdLl/gdW0XUpKWFvYmyoWCoQ=="
+    },
+    "node_modules/@deephaven/dashboard-core-plugins/node_modules/unist-util-visit/node_modules/unist-util-is": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-5.2.1.tgz",
+      "integrity": "sha512-u9njyyfEh43npf1M+yGKDGVPbY/JWEemg5nH05ncKPfi+kBbKBJoTdsogMu33uhytuLlv9y0O7GH7fEdwLdLQw==",
+      "dependencies": {
+        "@types/unist": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/@deephaven/dashboard-core-plugins/node_modules/unist-util-visit/node_modules/unist-util-visit-parents": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-5.1.3.tgz",
+      "integrity": "sha512-x6+y8g7wWMyQhL1iZfhIPhDAs7Xwbn9nRosDXl7qoPTSCy0yNxnKc+hWokFifWQIDGi154rdUqKvbCa4+1kLhg==",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "unist-util-is": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/@deephaven/dashboard-core-plugins/node_modules/vfile": {
+      "version": "5.3.7",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-5.3.7.tgz",
+      "integrity": "sha512-r7qlzkgErKjobAmyNIkkSpizsFPYiUPuJb5pNW1RB4JcYVZhs4lIbVqk8XPk033CV/1z8ss5pkax8SuhGpcG8g==",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "is-buffer": "^2.0.0",
+        "unist-util-stringify-position": "^3.0.0",
+        "vfile-message": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/@deephaven/dashboard-core-plugins/node_modules/vfile-message": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-3.1.4.tgz",
+      "integrity": "sha512-fa0Z6P8HUrQN4BZaX05SIVXic+7kE3b05PWAtPuYP9QLHsLKYR7/AlLW3NtOrpXRLeawpDLMsVkmk5DG0NXgWw==",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "unist-util-stringify-position": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/@deephaven/dashboard-core-plugins/node_modules/vfile-message/node_modules/unist-util-stringify-position": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-3.0.3.tgz",
+      "integrity": "sha512-k5GzIBZ/QatR8N5X2y+drfpWG8IDBzdnVj6OInRNWm1oXrzydiaAT2OQiA8DPRRZyAKb9b6I2a6PxYklZD0gKg==",
+      "dependencies": {
+        "@types/unist": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/@deephaven/dashboard-core-plugins/node_modules/vfile/node_modules/unist-util-stringify-position": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-3.0.3.tgz",
+      "integrity": "sha512-k5GzIBZ/QatR8N5X2y+drfpWG8IDBzdnVj6OInRNWm1oXrzydiaAT2OQiA8DPRRZyAKb9b6I2a6PxYklZD0gKg==",
+      "dependencies": {
+        "@types/unist": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/@deephaven/dashboard-core-plugins/node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/@deephaven/dashboard/node_modules/@deephaven/react-hooks": {
@@ -2430,6 +4625,103 @@
         "eslint-plugin-react-refresh": "0.3.4"
       }
     },
+    "node_modules/@deephaven/file-explorer": {
+      "version": "0.64.0",
+      "resolved": "https://registry.npmjs.org/@deephaven/file-explorer/-/file-explorer-0.64.0.tgz",
+      "integrity": "sha512-TSQTBgyO7XBzgi8sXILt5CWUMvT7NZhoFs/yiVVFT5ZPuaxLKmM2rW1SCw65eNcnnMswqTdfC8V9S6WQ62WrXw==",
+      "dependencies": {
+        "@deephaven/components": "^0.64.0",
+        "@deephaven/icons": "^0.64.0",
+        "@deephaven/log": "^0.64.0",
+        "@deephaven/storage": "^0.64.0",
+        "@deephaven/utils": "^0.64.0",
+        "@fortawesome/fontawesome-svg-core": "^6.2.1",
+        "@fortawesome/react-fontawesome": "^0.2.0",
+        "classnames": "^2.3.1",
+        "lodash.throttle": "^4.1.1",
+        "prop-types": "^15.7.2"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0"
+      }
+    },
+    "node_modules/@deephaven/file-explorer/node_modules/@deephaven/components": {
+      "version": "0.64.0",
+      "resolved": "https://registry.npmjs.org/@deephaven/components/-/components-0.64.0.tgz",
+      "integrity": "sha512-L/G3r94eoHx7OzZM5DpbshGFgvmXyBi0SdmPKp872zfrWu/rcSTrsB2Mz3/QmJIBaO2wn8U5tw5pTKGoML8IfQ==",
+      "dependencies": {
+        "@adobe/react-spectrum": "^3.29.0",
+        "@deephaven/icons": "^0.64.0",
+        "@deephaven/log": "^0.64.0",
+        "@deephaven/react-hooks": "^0.64.0",
+        "@deephaven/utils": "^0.64.0",
+        "@fortawesome/fontawesome-svg-core": "^6.2.1",
+        "@fortawesome/react-fontawesome": "^0.2.0",
+        "@react-spectrum/theme-default": "^3.5.1",
+        "bootstrap": "4.6.2",
+        "classnames": "^2.3.1",
+        "event-target-shim": "^6.0.2",
+        "lodash.clamp": "^4.0.3",
+        "lodash.debounce": "^4.0.8",
+        "lodash.flatten": "^4.4.0",
+        "memoizee": "^0.4.15",
+        "popper.js": "^1.16.1",
+        "prop-types": "^15.7.2",
+        "react-beautiful-dnd": "^13.1.0",
+        "react-transition-group": "^4.4.2",
+        "react-virtualized-auto-sizer": "1.0.6",
+        "react-window": "^1.8.6",
+        "shortid": "^2.2.16"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": "^17.x",
+        "react-dom": "^17.x"
+      }
+    },
+    "node_modules/@deephaven/file-explorer/node_modules/@deephaven/log": {
+      "version": "0.64.0",
+      "resolved": "https://registry.npmjs.org/@deephaven/log/-/log-0.64.0.tgz",
+      "integrity": "sha512-E2/gUb/lfFIGxM/bm0Wimpu+EUVY1xNubItiedMKDEp/dfmVKMVng6XdF2pPw73kaeGAs7NoCbdnWnXdns5QdA==",
+      "dependencies": {
+        "event-target-shim": "^6.0.2"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@deephaven/file-explorer/node_modules/@deephaven/utils": {
+      "version": "0.64.0",
+      "resolved": "https://registry.npmjs.org/@deephaven/utils/-/utils-0.64.0.tgz",
+      "integrity": "sha512-lt9cXEw0j2KMmUvR/+jmrpmWihrkYxNmhClW778WLFf0oi6Y4V/hsJxiNz+QvFvNbg3HqU6ZBMPHOtCNjKe7bQ==",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@deephaven/file-explorer/node_modules/event-target-shim": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-6.0.2.tgz",
+      "integrity": "sha512-8q3LsZjRezbFZ2PN+uP+Q7pnHUMmAOziU2vA2OwoFaKIXxlxl38IylhSSgUorWu/rf4er67w0ikBqjBFk/pomA==",
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mysticatea"
+      }
+    },
+    "node_modules/@deephaven/filters": {
+      "version": "0.64.0",
+      "resolved": "https://registry.npmjs.org/@deephaven/filters/-/filters-0.64.0.tgz",
+      "integrity": "sha512-/CnrdetauiBmS6sMybMUQ9ssDFk36jAvhskzYVLGzxX5Rhya2pobZBjz5JfQcUKLkm9B+5GUc7Qa9R5x/EOzBw==",
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/@deephaven/golden-layout": {
       "version": "0.40.4",
       "resolved": "https://registry.npmjs.org/@deephaven/golden-layout/-/golden-layout-0.40.4.tgz",
@@ -2441,6 +4733,249 @@
       "peerDependencies": {
         "react": "^17.x",
         "react-dom": "^17.x"
+      }
+    },
+    "node_modules/@deephaven/grid": {
+      "version": "0.64.0",
+      "resolved": "https://registry.npmjs.org/@deephaven/grid/-/grid-0.64.0.tgz",
+      "integrity": "sha512-avMaYmVwvbmeY63SQzE6aGJb4nDuZlklJB3f4WWfLw7w86haJkg8Gv+R5jNCM6NCMXyvG3y2/GfPeH2sca+GyA==",
+      "dependencies": {
+        "@deephaven/utils": "^0.64.0",
+        "classnames": "^2.3.1",
+        "color-convert": "^2.0.1",
+        "event-target-shim": "^6.0.2",
+        "linkifyjs": "^4.1.0",
+        "lodash.clamp": "^4.0.3",
+        "memoize-one": "^5.1.1",
+        "memoizee": "^0.4.15",
+        "prop-types": "^15.7.2"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "react": "^17.x"
+      }
+    },
+    "node_modules/@deephaven/grid/node_modules/@deephaven/utils": {
+      "version": "0.64.0",
+      "resolved": "https://registry.npmjs.org/@deephaven/utils/-/utils-0.64.0.tgz",
+      "integrity": "sha512-lt9cXEw0j2KMmUvR/+jmrpmWihrkYxNmhClW778WLFf0oi6Y4V/hsJxiNz+QvFvNbg3HqU6ZBMPHOtCNjKe7bQ==",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@deephaven/grid/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/@deephaven/grid/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "node_modules/@deephaven/grid/node_modules/event-target-shim": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-6.0.2.tgz",
+      "integrity": "sha512-8q3LsZjRezbFZ2PN+uP+Q7pnHUMmAOziU2vA2OwoFaKIXxlxl38IylhSSgUorWu/rf4er67w0ikBqjBFk/pomA==",
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mysticatea"
+      }
+    },
+    "node_modules/@deephaven/icons": {
+      "version": "0.64.0",
+      "resolved": "https://registry.npmjs.org/@deephaven/icons/-/icons-0.64.0.tgz",
+      "integrity": "sha512-p2ntfCFRi9F7G0eVX695ce6EeIiRQINSZP60ndRk0bmQkT4CL2Vm5Sx6ag0ErL8yr2M4e+VLJ9UPjrzTc6QSZg==",
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "^6.1.1"
+      },
+      "peerDependencies": {
+        "@fortawesome/fontawesome-svg-core": "^6.2.1",
+        "@fortawesome/react-fontawesome": "^0.2.0"
+      }
+    },
+    "node_modules/@deephaven/iris-grid": {
+      "version": "0.64.0",
+      "resolved": "https://registry.npmjs.org/@deephaven/iris-grid/-/iris-grid-0.64.0.tgz",
+      "integrity": "sha512-w80DxEeAjjil/NUB4dHMHjieGpYZdbPki3HgKbQmbSHpZ0hZXRL4/DERFrFioHhPOrWD/4EBnzdCHtsyaJgrlg==",
+      "dependencies": {
+        "@deephaven/components": "^0.64.0",
+        "@deephaven/console": "^0.64.0",
+        "@deephaven/filters": "^0.64.0",
+        "@deephaven/grid": "^0.64.0",
+        "@deephaven/icons": "^0.64.0",
+        "@deephaven/jsapi-components": "^0.64.0",
+        "@deephaven/jsapi-types": "^0.64.0",
+        "@deephaven/jsapi-utils": "^0.64.0",
+        "@deephaven/log": "^0.64.0",
+        "@deephaven/react-hooks": "^0.64.0",
+        "@deephaven/storage": "^0.64.0",
+        "@deephaven/utils": "^0.64.0",
+        "@dnd-kit/core": "^6.0.5",
+        "@dnd-kit/sortable": "^7.0.0",
+        "@dnd-kit/utilities": "^3.2.0",
+        "@fortawesome/react-fontawesome": "^0.2.0",
+        "classnames": "^2.3.1",
+        "deep-equal": "^2.0.5",
+        "lodash.clamp": "^4.0.3",
+        "lodash.debounce": "^4.0.8",
+        "lodash.throttle": "^4.1.1",
+        "memoize-one": "^5.1.1",
+        "memoizee": "^0.4.15",
+        "monaco-editor": "^0.41.0",
+        "prop-types": "^15.7.2",
+        "react-beautiful-dnd": "^13.1.0",
+        "react-transition-group": "^4.4.2",
+        "shortid": "^2.2.16"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": "^17.x",
+        "react-dom": "^17.x"
+      }
+    },
+    "node_modules/@deephaven/iris-grid/node_modules/@deephaven/components": {
+      "version": "0.64.0",
+      "resolved": "https://registry.npmjs.org/@deephaven/components/-/components-0.64.0.tgz",
+      "integrity": "sha512-L/G3r94eoHx7OzZM5DpbshGFgvmXyBi0SdmPKp872zfrWu/rcSTrsB2Mz3/QmJIBaO2wn8U5tw5pTKGoML8IfQ==",
+      "dependencies": {
+        "@adobe/react-spectrum": "^3.29.0",
+        "@deephaven/icons": "^0.64.0",
+        "@deephaven/log": "^0.64.0",
+        "@deephaven/react-hooks": "^0.64.0",
+        "@deephaven/utils": "^0.64.0",
+        "@fortawesome/fontawesome-svg-core": "^6.2.1",
+        "@fortawesome/react-fontawesome": "^0.2.0",
+        "@react-spectrum/theme-default": "^3.5.1",
+        "bootstrap": "4.6.2",
+        "classnames": "^2.3.1",
+        "event-target-shim": "^6.0.2",
+        "lodash.clamp": "^4.0.3",
+        "lodash.debounce": "^4.0.8",
+        "lodash.flatten": "^4.4.0",
+        "memoizee": "^0.4.15",
+        "popper.js": "^1.16.1",
+        "prop-types": "^15.7.2",
+        "react-beautiful-dnd": "^13.1.0",
+        "react-transition-group": "^4.4.2",
+        "react-virtualized-auto-sizer": "1.0.6",
+        "react-window": "^1.8.6",
+        "shortid": "^2.2.16"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": "^17.x",
+        "react-dom": "^17.x"
+      }
+    },
+    "node_modules/@deephaven/iris-grid/node_modules/@deephaven/jsapi-bootstrap": {
+      "version": "0.64.0",
+      "resolved": "https://registry.npmjs.org/@deephaven/jsapi-bootstrap/-/jsapi-bootstrap-0.64.0.tgz",
+      "integrity": "sha512-EGTYR1koWlG0nebD/7/1vCnA/McJqFCjIf+uL8y/2D945WMED3CalM3EwCLmXkYlQep0wtm9KgFyIhwenlwaCQ==",
+      "dependencies": {
+        "@deephaven/components": "^0.64.0",
+        "@deephaven/jsapi-types": "^0.64.0",
+        "@deephaven/log": "^0.64.0",
+        "@deephaven/react-hooks": "^0.64.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "react": "^17.x"
+      }
+    },
+    "node_modules/@deephaven/iris-grid/node_modules/@deephaven/jsapi-components": {
+      "version": "0.64.0",
+      "resolved": "https://registry.npmjs.org/@deephaven/jsapi-components/-/jsapi-components-0.64.0.tgz",
+      "integrity": "sha512-2WeV8IbHbgwAXRIiLM7H2iXTmVd53UKiC9BSdFCynH59o/+CApbinthtS5/e8R7fF2m/DBIe8MrWpCQbPikI8Q==",
+      "dependencies": {
+        "@deephaven/components": "^0.64.0",
+        "@deephaven/jsapi-bootstrap": "^0.64.0",
+        "@deephaven/jsapi-types": "^0.64.0",
+        "@deephaven/jsapi-utils": "^0.64.0",
+        "@deephaven/log": "^0.64.0",
+        "@deephaven/react-hooks": "^0.64.0",
+        "@deephaven/utils": "^0.64.0",
+        "@types/js-cookie": "^3.0.3",
+        "classnames": "^2.3.2",
+        "js-cookie": "^3.0.5",
+        "lodash.debounce": "^4.0.8",
+        "prop-types": "^15.8.1"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "react": "^17.x"
+      }
+    },
+    "node_modules/@deephaven/iris-grid/node_modules/@deephaven/jsapi-types": {
+      "version": "0.64.0",
+      "resolved": "https://registry.npmjs.org/@deephaven/jsapi-types/-/jsapi-types-0.64.0.tgz",
+      "integrity": "sha512-8e1YzqRPtRg0bhqUC4R3nZ9ICE/3ITRaLgFOmw8yjtGnp+VWG+RvYp/5EELIizrklfUkuWv/+Z5uxMbQYQNQRQ==",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@deephaven/iris-grid/node_modules/@deephaven/jsapi-utils": {
+      "version": "0.64.0",
+      "resolved": "https://registry.npmjs.org/@deephaven/jsapi-utils/-/jsapi-utils-0.64.0.tgz",
+      "integrity": "sha512-U+cCICH8hcehbwqMlgG5+sGS3bcvm4GiY0SB+N15M3spLU3iAbWB5pMYo1lv8hf20TTnIYsJjF52MNp3R+F2FQ==",
+      "dependencies": {
+        "@deephaven/filters": "^0.64.0",
+        "@deephaven/jsapi-types": "^0.64.0",
+        "@deephaven/log": "^0.64.0",
+        "@deephaven/utils": "^0.64.0",
+        "lodash.clamp": "^4.0.3",
+        "shortid": "^2.2.16"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@deephaven/iris-grid/node_modules/@deephaven/log": {
+      "version": "0.64.0",
+      "resolved": "https://registry.npmjs.org/@deephaven/log/-/log-0.64.0.tgz",
+      "integrity": "sha512-E2/gUb/lfFIGxM/bm0Wimpu+EUVY1xNubItiedMKDEp/dfmVKMVng6XdF2pPw73kaeGAs7NoCbdnWnXdns5QdA==",
+      "dependencies": {
+        "event-target-shim": "^6.0.2"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@deephaven/iris-grid/node_modules/@deephaven/utils": {
+      "version": "0.64.0",
+      "resolved": "https://registry.npmjs.org/@deephaven/utils/-/utils-0.64.0.tgz",
+      "integrity": "sha512-lt9cXEw0j2KMmUvR/+jmrpmWihrkYxNmhClW778WLFf0oi6Y4V/hsJxiNz+QvFvNbg3HqU6ZBMPHOtCNjKe7bQ==",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@deephaven/iris-grid/node_modules/event-target-shim": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-6.0.2.tgz",
+      "integrity": "sha512-8q3LsZjRezbFZ2PN+uP+Q7pnHUMmAOziU2vA2OwoFaKIXxlxl38IylhSSgUorWu/rf4er67w0ikBqjBFk/pomA==",
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mysticatea"
       }
     },
     "node_modules/@deephaven/js-plugin-auth-keycloak": {
@@ -2601,6 +5136,115 @@
         "url": "https://github.com/sponsors/mysticatea"
       }
     },
+    "node_modules/@deephaven/plugin": {
+      "version": "0.64.0",
+      "resolved": "https://registry.npmjs.org/@deephaven/plugin/-/plugin-0.64.0.tgz",
+      "integrity": "sha512-bMHriX77WQ/iCyU1xas9CjRIkxfcOeUTVv02LUqIMzPvftVlqNKrEoRHz2txu0UFDWCDvB3HrgvwVOi2aTGb3A==",
+      "dependencies": {
+        "@deephaven/components": "^0.64.0",
+        "@deephaven/golden-layout": "^0.64.0",
+        "@deephaven/icons": "^0.64.0",
+        "@deephaven/iris-grid": "^0.64.0",
+        "@deephaven/jsapi-types": "^0.64.0",
+        "@deephaven/log": "^0.64.0",
+        "@deephaven/react-hooks": "^0.64.0",
+        "@fortawesome/fontawesome-common-types": "^6.1.1",
+        "@fortawesome/react-fontawesome": "^0.2.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "react": "^17.x"
+      }
+    },
+    "node_modules/@deephaven/plugin/node_modules/@deephaven/components": {
+      "version": "0.64.0",
+      "resolved": "https://registry.npmjs.org/@deephaven/components/-/components-0.64.0.tgz",
+      "integrity": "sha512-L/G3r94eoHx7OzZM5DpbshGFgvmXyBi0SdmPKp872zfrWu/rcSTrsB2Mz3/QmJIBaO2wn8U5tw5pTKGoML8IfQ==",
+      "dependencies": {
+        "@adobe/react-spectrum": "^3.29.0",
+        "@deephaven/icons": "^0.64.0",
+        "@deephaven/log": "^0.64.0",
+        "@deephaven/react-hooks": "^0.64.0",
+        "@deephaven/utils": "^0.64.0",
+        "@fortawesome/fontawesome-svg-core": "^6.2.1",
+        "@fortawesome/react-fontawesome": "^0.2.0",
+        "@react-spectrum/theme-default": "^3.5.1",
+        "bootstrap": "4.6.2",
+        "classnames": "^2.3.1",
+        "event-target-shim": "^6.0.2",
+        "lodash.clamp": "^4.0.3",
+        "lodash.debounce": "^4.0.8",
+        "lodash.flatten": "^4.4.0",
+        "memoizee": "^0.4.15",
+        "popper.js": "^1.16.1",
+        "prop-types": "^15.7.2",
+        "react-beautiful-dnd": "^13.1.0",
+        "react-transition-group": "^4.4.2",
+        "react-virtualized-auto-sizer": "1.0.6",
+        "react-window": "^1.8.6",
+        "shortid": "^2.2.16"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": "^17.x",
+        "react-dom": "^17.x"
+      }
+    },
+    "node_modules/@deephaven/plugin/node_modules/@deephaven/golden-layout": {
+      "version": "0.64.0",
+      "resolved": "https://registry.npmjs.org/@deephaven/golden-layout/-/golden-layout-0.64.0.tgz",
+      "integrity": "sha512-MP5H8EvhdVEJzJKDPEp5xO1kBjqbv8hg/PMkR7EcFJJjxvTcJXcx24prfqBDeHVHbcWzDce5HeI56j6I93iFwQ==",
+      "dependencies": {
+        "@deephaven/components": "^0.64.0",
+        "jquery": "^3.6.0"
+      },
+      "peerDependencies": {
+        "react": "^17.x",
+        "react-dom": "^17.x"
+      }
+    },
+    "node_modules/@deephaven/plugin/node_modules/@deephaven/jsapi-types": {
+      "version": "0.64.0",
+      "resolved": "https://registry.npmjs.org/@deephaven/jsapi-types/-/jsapi-types-0.64.0.tgz",
+      "integrity": "sha512-8e1YzqRPtRg0bhqUC4R3nZ9ICE/3ITRaLgFOmw8yjtGnp+VWG+RvYp/5EELIizrklfUkuWv/+Z5uxMbQYQNQRQ==",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@deephaven/plugin/node_modules/@deephaven/log": {
+      "version": "0.64.0",
+      "resolved": "https://registry.npmjs.org/@deephaven/log/-/log-0.64.0.tgz",
+      "integrity": "sha512-E2/gUb/lfFIGxM/bm0Wimpu+EUVY1xNubItiedMKDEp/dfmVKMVng6XdF2pPw73kaeGAs7NoCbdnWnXdns5QdA==",
+      "dependencies": {
+        "event-target-shim": "^6.0.2"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@deephaven/plugin/node_modules/@deephaven/utils": {
+      "version": "0.64.0",
+      "resolved": "https://registry.npmjs.org/@deephaven/utils/-/utils-0.64.0.tgz",
+      "integrity": "sha512-lt9cXEw0j2KMmUvR/+jmrpmWihrkYxNmhClW778WLFf0oi6Y4V/hsJxiNz+QvFvNbg3HqU6ZBMPHOtCNjKe7bQ==",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@deephaven/plugin/node_modules/event-target-shim": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-6.0.2.tgz",
+      "integrity": "sha512-8q3LsZjRezbFZ2PN+uP+Q7pnHUMmAOziU2vA2OwoFaKIXxlxl38IylhSSgUorWu/rf4er67w0ikBqjBFk/pomA==",
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mysticatea"
+      }
+    },
     "node_modules/@deephaven/prettier-config": {
       "version": "0.40.0",
       "resolved": "https://registry.npmjs.org/@deephaven/prettier-config/-/prettier-config-0.40.0.tgz",
@@ -2608,6 +5252,54 @@
       "dev": true,
       "peerDependencies": {
         "prettier": "^2.2.1"
+      }
+    },
+    "node_modules/@deephaven/react-hooks": {
+      "version": "0.64.0",
+      "resolved": "https://registry.npmjs.org/@deephaven/react-hooks/-/react-hooks-0.64.0.tgz",
+      "integrity": "sha512-Y1VpFh8F5NVoXmcwQMBGbi/eAoN/JBds2+Nm33FQ4pkL1C20+RAdwthD0z6hW0Sn1hqNZzZMNV+/w0L9eEgkIA==",
+      "dependencies": {
+        "@adobe/react-spectrum": "^3.29.0",
+        "@deephaven/log": "^0.64.0",
+        "@deephaven/utils": "^0.64.0",
+        "lodash.debounce": "^4.0.8",
+        "shortid": "^2.2.16"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "react": "^17.x"
+      }
+    },
+    "node_modules/@deephaven/react-hooks/node_modules/@deephaven/log": {
+      "version": "0.64.0",
+      "resolved": "https://registry.npmjs.org/@deephaven/log/-/log-0.64.0.tgz",
+      "integrity": "sha512-E2/gUb/lfFIGxM/bm0Wimpu+EUVY1xNubItiedMKDEp/dfmVKMVng6XdF2pPw73kaeGAs7NoCbdnWnXdns5QdA==",
+      "dependencies": {
+        "event-target-shim": "^6.0.2"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@deephaven/react-hooks/node_modules/@deephaven/utils": {
+      "version": "0.64.0",
+      "resolved": "https://registry.npmjs.org/@deephaven/utils/-/utils-0.64.0.tgz",
+      "integrity": "sha512-lt9cXEw0j2KMmUvR/+jmrpmWihrkYxNmhClW778WLFf0oi6Y4V/hsJxiNz+QvFvNbg3HqU6ZBMPHOtCNjKe7bQ==",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@deephaven/react-hooks/node_modules/event-target-shim": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-6.0.2.tgz",
+      "integrity": "sha512-8q3LsZjRezbFZ2PN+uP+Q7pnHUMmAOziU2vA2OwoFaKIXxlxl38IylhSSgUorWu/rf4er67w0ikBqjBFk/pomA==",
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mysticatea"
       }
     },
     "node_modules/@deephaven/redux": {
@@ -2634,6 +5326,44 @@
       "integrity": "sha512-OOYGNY5Jy2TWvTL1KgAlVy6dcx3siPJ1wTq741EPyUKfn6W6nChdICjZwCd0p8AZBs5kWpZlbkXW2nE/zjUa+Q==",
       "peerDependencies": {
         "redux": "^4"
+      }
+    },
+    "node_modules/@deephaven/storage": {
+      "version": "0.64.0",
+      "resolved": "https://registry.npmjs.org/@deephaven/storage/-/storage-0.64.0.tgz",
+      "integrity": "sha512-QFZ+ul70U6I2YrCEjLhMh7pnRowhSsgqRS4Tg5Y4Ydob6fBl1cp4w41FxuHnO/+1gZznWdpfGL6kYVrcL2qAeA==",
+      "dependencies": {
+        "@deephaven/filters": "^0.64.0",
+        "@deephaven/log": "^0.64.0",
+        "lodash.throttle": "^4.1.1"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "react": "^17.x"
+      }
+    },
+    "node_modules/@deephaven/storage/node_modules/@deephaven/log": {
+      "version": "0.64.0",
+      "resolved": "https://registry.npmjs.org/@deephaven/log/-/log-0.64.0.tgz",
+      "integrity": "sha512-E2/gUb/lfFIGxM/bm0Wimpu+EUVY1xNubItiedMKDEp/dfmVKMVng6XdF2pPw73kaeGAs7NoCbdnWnXdns5QdA==",
+      "dependencies": {
+        "event-target-shim": "^6.0.2"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@deephaven/storage/node_modules/event-target-shim": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-6.0.2.tgz",
+      "integrity": "sha512-8q3LsZjRezbFZ2PN+uP+Q7pnHUMmAOziU2vA2OwoFaKIXxlxl38IylhSSgUorWu/rf4er67w0ikBqjBFk/pomA==",
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mysticatea"
       }
     },
     "node_modules/@deephaven/tsconfig": {
@@ -9906,7 +12636,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
       "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
-      "dev": true,
       "engines": {
         "node": ">= 10"
       }
@@ -10059,6 +12788,14 @@
         "@babel/types": "^7.20.7"
       }
     },
+    "node_modules/@types/debug": {
+      "version": "4.1.12",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
+      "integrity": "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==",
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
     "node_modules/@types/deep-equal": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@types/deep-equal/-/deep-equal-1.0.4.tgz",
@@ -10191,6 +12928,16 @@
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true
     },
+    "node_modules/@types/katex": {
+      "version": "0.16.7",
+      "resolved": "https://registry.npmjs.org/@types/katex/-/katex-0.16.7.tgz",
+      "integrity": "sha512-HMwFiRujE5PjrgwHQ25+bsLJgowjGjm5Z8FVSf0N6PwgJrwxH0QxzHYDcKsTfV3wva0vzrpqMTJS2jXPr5BMEQ=="
+    },
+    "node_modules/@types/mathjax": {
+      "version": "0.0.37",
+      "resolved": "https://registry.npmjs.org/@types/mathjax/-/mathjax-0.0.37.tgz",
+      "integrity": "sha512-y0WSZBtBNQwcYipTU/BhgeFu1EZNlFvUNCmkMXV9kBQZq7/o5z82dNVyH3yy2Xv5zzeNeQoHSL4Xm06+EQiH+g=="
+    },
     "node_modules/@types/mdast": {
       "version": "3.0.15",
       "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-3.0.15.tgz",
@@ -10210,6 +12957,11 @@
       "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.5.tgz",
       "integrity": "sha512-hov8bUuiLiyFPGyFPE1lwWhmzYbirOXQNNo40+y3zow8aFVTeyn3VWL0VFFfdNddA8S4Vf0Tc062rzyNr7Paag==",
       "dev": true
+    },
+    "node_modules/@types/ms": {
+      "version": "0.7.34",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.34.tgz",
+      "integrity": "sha512-nG96G3Wp6acyAgJqGasjODb+acrI7KltPiRxzHPXnP3NgI28bpQDRv53olbqGXbfcgF5aiiHmO3xpwEpS5Ld9g=="
     },
     "node_modules/@types/node": {
       "version": "20.10.1",
@@ -10731,8 +13483,7 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.6.tgz",
       "integrity": "sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==",
-      "deprecated": "Use your platform's native atob() and btoa() methods instead",
-      "dev": true
+      "deprecated": "Use your platform's native atob() and btoa() methods instead"
     },
     "node_modules/abbrev": {
       "version": "2.0.0",
@@ -10764,7 +13515,6 @@
       "version": "8.11.2",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.2.tgz",
       "integrity": "sha512-nc0Axzp/0FILLEVsm4fNwLCwMttvhEI263QtVPQcbpfZZ3ts0hLsZGOpE6czNlid7CJ9MlyH8reXkpsf3YUY4w==",
-      "dev": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -10776,7 +13526,6 @@
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-7.0.1.tgz",
       "integrity": "sha512-umOSDSDrfHbTNPuNpC2NSnnA3LUrqpevPb4T9jRx4MagXNS0rs+gwiTcAvqCRmsD6utzsrzNt+ebm00SNWiC3Q==",
-      "dev": true,
       "dependencies": {
         "acorn": "^8.1.0",
         "acorn-walk": "^8.0.2"
@@ -10795,7 +13544,6 @@
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.0.tgz",
       "integrity": "sha512-FS7hV565M5l1R08MXqo8odwMTB02C2UqzB17RVgu9EyuYFBqJZ3/ZY97sQD5FewVu1UyDFc1yztUDrAwT0EypA==",
-      "dev": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -10810,7 +13558,6 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
       "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "dev": true,
       "dependencies": {
         "debug": "4"
       },
@@ -11179,8 +13926,7 @@
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "node_modules/at-least-node": {
       "version": "1.0.0",
@@ -12408,7 +15154,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
@@ -13083,14 +15828,12 @@
     "node_modules/cssom": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.5.0.tgz",
-      "integrity": "sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw==",
-      "dev": true
+      "integrity": "sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw=="
     },
     "node_modules/cssstyle": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-2.3.0.tgz",
       "integrity": "sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==",
-      "dev": true,
       "dependencies": {
         "cssom": "~0.3.6"
       },
@@ -13101,8 +15844,7 @@
     "node_modules/cssstyle/node_modules/cssom": {
       "version": "0.3.8",
       "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
-      "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
-      "dev": true
+      "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg=="
     },
     "node_modules/csstype": {
       "version": "3.1.2",
@@ -13254,7 +15996,6 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-3.0.2.tgz",
       "integrity": "sha512-Jy/tj3ldjZJo63sVAvg6LHt2mHvl4V6AgRAmNDtLdm7faqtsx+aJG42rsyCo9JCoRVKwPFzKlIPx3DIibwSIaQ==",
-      "dev": true,
       "dependencies": {
         "abab": "^2.0.6",
         "whatwg-mimetype": "^3.0.0",
@@ -13326,8 +16067,28 @@
     "node_modules/decimal.js": {
       "version": "10.4.3",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.4.3.tgz",
-      "integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA==",
-      "dev": true
+      "integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA=="
+    },
+    "node_modules/decode-named-character-reference": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.0.2.tgz",
+      "integrity": "sha512-O8x12RzrUF8xyVcY0KJowWsmaJxQbmy0/EtnNtHRpsOcT7dFk5W598coHqBVpmWo1oQQfsCqfCmkZN5DJrZVdg==",
+      "dependencies": {
+        "character-entities": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/decode-named-character-reference/node_modules/character-entities": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+      "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/dedent": {
       "version": "1.5.1",
@@ -13472,7 +16233,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "dev": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -13493,7 +16253,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -13519,6 +16278,26 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/diff": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.0.tgz",
+      "integrity": "sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==",
+      "engines": {
+        "node": ">=0.3.1"
       }
     },
     "node_modules/diff-sequences": {
@@ -13574,7 +16353,6 @@
       "resolved": "https://registry.npmjs.org/domexception/-/domexception-4.0.0.tgz",
       "integrity": "sha512-A2is4PLG+eeSfoTMA95/s4pvAoSo2mKtiM5jlHkAVewmiO8ISFTFKZjH7UAM1Atli/OT/7JHOrJRJiMKUZKYBw==",
       "deprecated": "Use your platform's native DOMException instead",
-      "dev": true,
       "dependencies": {
         "webidl-conversions": "^7.0.0"
       },
@@ -13796,7 +16574,6 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
       "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
-      "dev": true,
       "engines": {
         "node": ">=0.12"
       },
@@ -14077,7 +16854,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
       "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
-      "dev": true,
       "dependencies": {
         "esprima": "^4.0.1",
         "estraverse": "^5.2.0",
@@ -14758,6 +17534,14 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/esm": {
+      "version": "3.2.25",
+      "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
+      "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/espree": {
       "version": "9.6.1",
       "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
@@ -14815,7 +17599,6 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-      "dev": true,
       "engines": {
         "node": ">=4.0"
       }
@@ -15318,7 +18101,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
       "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-      "dev": true,
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -16352,6 +19134,111 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hast-util-from-dom": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/hast-util-from-dom/-/hast-util-from-dom-4.2.0.tgz",
+      "integrity": "sha512-t1RJW/OpJbCAJQeKi3Qrj1cAOLA0+av/iPFori112+0X7R3wng+jxLA+kXec8K4szqPRGI8vPxbbpEYvvpwaeQ==",
+      "dependencies": {
+        "hastscript": "^7.0.0",
+        "web-namespaces": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-is-element": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-2.1.3.tgz",
+      "integrity": "sha512-O1bKah6mhgEq2WtVMk+Ta5K7pPMqsBBlmzysLdcwKVrqzZQ0CHqUPiIVspNhAG1rvxpvJjtGee17XfauZYKqVA==",
+      "dependencies": {
+        "@types/hast": "^2.0.0",
+        "@types/unist": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-parse-selector": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-3.1.1.tgz",
+      "integrity": "sha512-jdlwBjEexy1oGz0aJ2f4GKMaVKkA9jwjr4MjAAI22E5fM/TXVZHuS5OpONtdeIkRKqAaryQ2E9xNQxijoThSZA==",
+      "dependencies": {
+        "@types/hast": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-text": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/hast-util-to-text/-/hast-util-to-text-3.1.2.tgz",
+      "integrity": "sha512-tcllLfp23dJJ+ju5wCCZHVpzsQQ43+moJbqVX3jNWPB7z/KFC4FyZD6R7y94cHL6MQ33YtMZL8Z0aIXXI4XFTw==",
+      "dependencies": {
+        "@types/hast": "^2.0.0",
+        "@types/unist": "^2.0.0",
+        "hast-util-is-element": "^2.0.0",
+        "unist-util-find-after": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-whitespace": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-2.0.1.tgz",
+      "integrity": "sha512-nAxA0v8+vXSBDt3AnRUNjyRIQ0rD+ntpbAp4LnPkumc5M9yUbSMa4XDU9Q6etY4f1Wp4bNgvc1yjiZtsTTrSng==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hastscript": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-7.2.0.tgz",
+      "integrity": "sha512-TtYPq24IldU8iKoJQqvZOuhi5CyCQRAbvDOX0x1eW6rsHSxa/1i2CCiptNTotGHJ3VoHRGmqiv6/D3q113ikkw==",
+      "dependencies": {
+        "@types/hast": "^2.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-parse-selector": "^3.0.0",
+        "property-information": "^6.0.0",
+        "space-separated-tokens": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hastscript/node_modules/comma-separated-tokens": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/hastscript/node_modules/property-information": {
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-6.4.1.tgz",
+      "integrity": "sha512-OHYtXfu5aI2sS2LWFSN5rgJjrQ4pCy8i1jubJLe2QvMF8JJ++HXTUIVWFLfXJoaOfvYYjk2SN8J2wFUWIGXT4w==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/hastscript/node_modules/space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/hoist-non-react-statics": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
@@ -16395,7 +19282,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-3.0.0.tgz",
       "integrity": "sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==",
-      "dev": true,
       "dependencies": {
         "whatwg-encoding": "^2.0.0"
       },
@@ -16432,7 +19318,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
       "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
-      "dev": true,
       "dependencies": {
         "@tootallnate/once": "2",
         "agent-base": "6",
@@ -16446,7 +19331,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
       "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-      "dev": true,
       "dependencies": {
         "agent-base": "6",
         "debug": "4"
@@ -17306,8 +20190,7 @@
     "node_modules/is-potential-custom-element-name": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
-      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
-      "dev": true
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ=="
     },
     "node_modules/is-promise": {
       "version": "2.2.2",
@@ -20110,7 +22993,6 @@
       "version": "20.0.3",
       "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-20.0.3.tgz",
       "integrity": "sha512-SYhBvTh89tTfCD/CRdSOm13mOBa42iTaTyfyEWBdKcGdPxPtLFBXuHR8XHb33YNYaP+lLbmSvBTsnoesCNJEsQ==",
-      "dev": true,
       "dependencies": {
         "abab": "^2.0.6",
         "acorn": "^8.8.1",
@@ -20297,6 +23179,29 @@
       "resolved": "https://registry.npmjs.org/just-diff-apply/-/just-diff-apply-5.5.0.tgz",
       "integrity": "sha512-OYTthRfSh55WOItVqwpefPtNt2VdKsq5AnAK6apdtR6yCH8pr0CmSr710J0Mf+WdQy7K/OzMy7K2MgAfdQURDw==",
       "dev": true
+    },
+    "node_modules/katex": {
+      "version": "0.16.9",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.9.tgz",
+      "integrity": "sha512-fsSYjWS0EEOwvy81j3vRA8TEAhQhKiqO+FQaKWp0m39qwOzHVBgAUBIXWj1pB+O2W3fIpNa6Y9KSKCVbfPhyAQ==",
+      "funding": [
+        "https://opencollective.com/katex",
+        "https://github.com/sponsors/katex"
+      ],
+      "dependencies": {
+        "commander": "^8.3.0"
+      },
+      "bin": {
+        "katex": "cli.js"
+      }
+    },
+    "node_modules/katex/node_modules/commander": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/kdbush": {
       "version": "3.0.0",
@@ -21639,6 +24544,17 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/mathjax-full": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/mathjax-full/-/mathjax-full-3.2.2.tgz",
+      "integrity": "sha512-+LfG9Fik+OuI8SLwsiR02IVdjcnRCy5MufYLi0C3TdMT56L/pjB0alMVGgoWJF8pN9Rc7FESycZB9BMNWIid5w==",
+      "dependencies": {
+        "esm": "^3.2.25",
+        "mhchemparser": "^4.1.0",
+        "mj-context-menu": "^0.6.1",
+        "speech-rule-engine": "^4.0.6"
+      }
+    },
     "node_modules/mathml-tag-names": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/mathml-tag-names/-/mathml-tag-names-2.1.3.tgz",
@@ -21733,6 +24649,260 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/mdast-util-gfm-footnote": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.0.0.tgz",
+      "integrity": "sha512-5jOT2boTSVkMnQ7LTrd6n/18kqwjmuYqo7JUPe+tRCY6O7dAuTFMtTPauYYrMPpox9hlN0uOx/FL8XvEfG9/mQ==",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-footnote/node_modules/@types/mdast": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.3.tgz",
+      "integrity": "sha512-LsjtqsyF+d2/yFOYaN22dHZI1Cpwkrj+g06G8+qtUKlhovPW89YhqSnfKtMbkgmEtYpH2gydRNULd6y8mciAFg==",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/mdast-util-gfm-footnote/node_modules/@types/unist": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.2.tgz",
+      "integrity": "sha512-dqId9J8K/vGi5Zr7oo212BGii5m3q5Hxlkwy3WpYuKPklmBEvsbMYYyLxAQpSffdLl/gdW0XUpKWFvYmyoWCoQ=="
+    },
+    "node_modules/mdast-util-gfm-footnote/node_modules/longest-streak": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+      "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/mdast-util-gfm-footnote/node_modules/mdast-util-from-markdown": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.0.tgz",
+      "integrity": "sha512-n7MTOr/z+8NAX/wmhhDji8O3bRvPTV/U0oTCaZJkjhPSKTPhS3xufVhKGF8s1pJ7Ox4QgoIU7KHseh09S+9rTA==",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark": "^4.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-footnote/node_modules/mdast-util-to-markdown": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.0.tgz",
+      "integrity": "sha512-SR2VnIEdVNCJbP6y7kVTJgPLifdr8WEU440fQec7qHoHOUz/oJ2jmNRqdDQ3rbiStOXb2mCDGTuwsK5OPUgYlQ==",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-phrasing": "^4.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "unist-util-visit": "^5.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-footnote/node_modules/mdast-util-to-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+      "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+      "dependencies": {
+        "@types/mdast": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-footnote/node_modules/micromark": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.0.tgz",
+      "integrity": "sha512-o/sd0nMof8kYff+TqcDx3VSrgBTcZpSvYcAHIfHhv5VAuNmisCxjhx6YmxS8PFEpb9z5WKWKPdzf0jM23ro3RQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "@types/debug": "^4.0.0",
+        "debug": "^4.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/mdast-util-gfm-footnote/node_modules/micromark-factory-space": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.0.tgz",
+      "integrity": "sha512-TKr+LIDX2pkBJXFLzpyPyljzYK3MtmllMUMODTQJIUfDGncESaqB90db9IAUcz4AZAJFdd8U9zOp9ty1458rxg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/mdast-util-gfm-footnote/node_modules/micromark-util-character": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.0.tgz",
+      "integrity": "sha512-KvOVV+X1yLBfs9dCBSopq/+G1PcgT3lAK07mC4BzXi5E7ahzMAF8oIupDDJ6mievI6F+lAATkbQQlQixJfT3aQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/mdast-util-gfm-footnote/node_modules/micromark-util-symbol": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.0.tgz",
+      "integrity": "sha512-8JZt9ElZ5kyTnO94muPxIGS8oyElRJaiJO8EzV6ZSyGQ1Is8xwl4Q45qU5UOg+bGH4AikWziz0iN4sFLWs8PGw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ]
+    },
+    "node_modules/mdast-util-gfm-footnote/node_modules/micromark-util-types": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.0.tgz",
+      "integrity": "sha512-oNh6S2WMHWRZrmutsRmDDfkzKtxF+bc2VxLC9dvtrDIRFln627VsFP6fLMgTryGDljgLPjkrzQSDcPrjPyDJ5w==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ]
+    },
+    "node_modules/mdast-util-gfm-footnote/node_modules/unist-util-is": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.0.tgz",
+      "integrity": "sha512-2qCTHimwdxLfz+YzdGfkqNlH0tLi9xjTnHddPmJwtIG9MGsdbutfTc4P+haPD7l7Cjxf/WZj+we5qfVPvvxfYw==",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-footnote/node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-footnote/node_modules/unist-util-visit": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.0.0.tgz",
+      "integrity": "sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-footnote/node_modules/unist-util-visit-parents": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.1.tgz",
+      "integrity": "sha512-L/PqWzfTP9lzzEa6CKs0k2nARxTdZduw3zyh8d2NVBnsyvHjSX4TWse388YrrQKbvI8w20fGjGlhgT96WwKykw==",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-footnote/node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/mdast-util-gfm-strikethrough": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-0.2.3.tgz",
@@ -21764,6 +24934,198 @@
       "integrity": "sha512-/d51FFIfPsSmCIRNp7E6pozM9z1GYPIkSy1urQ8s/o4TC22BZ7DqfHFWiqBD23bc7J3vV1Fc9O4QIHBlfuit8A==",
       "dependencies": {
         "mdast-util-to-markdown": "~0.6.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-math": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-math/-/mdast-util-math-2.0.2.tgz",
+      "integrity": "sha512-8gmkKVp9v6+Tgjtq6SYx9kGPpTf6FVYRa53/DLh479aldR9AyP48qeVOgNZ5X7QUK7nOy4yw7vg6mbiGcs9jWQ==",
+      "dependencies": {
+        "@types/mdast": "^3.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-to-markdown": "^1.3.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-math/node_modules/longest-streak": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+      "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/mdast-util-math/node_modules/mdast-util-phrasing": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-3.0.1.tgz",
+      "integrity": "sha512-WmI1gTXUBJo4/ZmSk79Wcb2HcjPJBzM1nlI/OUWA8yk2X9ik3ffNbBGsU+09BFmXaL1IBb9fiuvq6/KMiNycSg==",
+      "dependencies": {
+        "@types/mdast": "^3.0.0",
+        "unist-util-is": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-math/node_modules/mdast-util-to-markdown": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-1.5.0.tgz",
+      "integrity": "sha512-bbv7TPv/WC49thZPg3jXuqzuvI45IL2EVAr/KxF0BSdHsU0ceFHOmwQn6evxAh1GaoK/6GQ1wp4R4oW2+LFL/A==",
+      "dependencies": {
+        "@types/mdast": "^3.0.0",
+        "@types/unist": "^2.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-phrasing": "^3.0.0",
+        "mdast-util-to-string": "^3.0.0",
+        "micromark-util-decode-string": "^1.0.0",
+        "unist-util-visit": "^4.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-math/node_modules/mdast-util-to-string": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-3.2.0.tgz",
+      "integrity": "sha512-V4Zn/ncyN1QNSqSBxTrMOLpjr+IKdHl2v3KVLoWmDPscP4r9GcCi71gjgvUV1SFSKh92AjAG4peFuBl2/YgCJg==",
+      "dependencies": {
+        "@types/mdast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-math/node_modules/micromark-util-decode-numeric-character-reference": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-1.1.0.tgz",
+      "integrity": "sha512-m9V0ExGv0jB1OT21mrWcuf4QhP46pH1KkfWy9ZEezqHKAxkj4mPCy3nIH1rkbdMlChLHX531eOrymlwyZIf2iw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-symbol": "^1.0.0"
+      }
+    },
+    "node_modules/mdast-util-math/node_modules/micromark-util-decode-string": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-1.1.0.tgz",
+      "integrity": "sha512-YphLGCK8gM1tG1bd54azwyrQRjCFcmgj2S2GoJDNnh4vYtnL38JS8M4gpxzOPNyHdNEpheyWXCTnnTDY3N+NVQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-decode-numeric-character-reference": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0"
+      }
+    },
+    "node_modules/mdast-util-math/node_modules/unist-util-is": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-5.2.1.tgz",
+      "integrity": "sha512-u9njyyfEh43npf1M+yGKDGVPbY/JWEemg5nH05ncKPfi+kBbKBJoTdsogMu33uhytuLlv9y0O7GH7fEdwLdLQw==",
+      "dependencies": {
+        "@types/unist": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-math/node_modules/unist-util-visit": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-4.1.2.tgz",
+      "integrity": "sha512-MSd8OUGISqHdVvfY9TPhyK2VdUrPgxkUtWSuMHF6XAAFuL4LokseigBnZtPnJMu+FbynTkFNnFlyjxpVKujMRg==",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "unist-util-is": "^5.0.0",
+        "unist-util-visit-parents": "^5.1.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-math/node_modules/unist-util-visit-parents": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-5.1.3.tgz",
+      "integrity": "sha512-x6+y8g7wWMyQhL1iZfhIPhDAs7Xwbn9nRosDXl7qoPTSCy0yNxnKc+hWokFifWQIDGi154rdUqKvbCa4+1kLhg==",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "unist-util-is": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-math/node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/mdast-util-phrasing": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
+      "integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-phrasing/node_modules/@types/mdast": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.3.tgz",
+      "integrity": "sha512-LsjtqsyF+d2/yFOYaN22dHZI1Cpwkrj+g06G8+qtUKlhovPW89YhqSnfKtMbkgmEtYpH2gydRNULd6y8mciAFg==",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/mdast-util-phrasing/node_modules/@types/unist": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.2.tgz",
+      "integrity": "sha512-dqId9J8K/vGi5Zr7oo212BGii5m3q5Hxlkwy3WpYuKPklmBEvsbMYYyLxAQpSffdLl/gdW0XUpKWFvYmyoWCoQ=="
+    },
+    "node_modules/mdast-util-phrasing/node_modules/unist-util-is": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.0.tgz",
+      "integrity": "sha512-2qCTHimwdxLfz+YzdGfkqNlH0tLi9xjTnHddPmJwtIG9MGsdbutfTc4P+haPD7l7Cjxf/WZj+we5qfVPvvxfYw==",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -22097,6 +25459,11 @@
         "node": ">= 8"
       }
     },
+    "node_modules/mhchemparser": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/mhchemparser/-/mhchemparser-4.2.1.tgz",
+      "integrity": "sha512-kYmyrCirqJf3zZ9t/0wGgRZ4/ZJw//VwaRVGA75C4nhE60vtnIzhl9J9ndkX/h6hxSN7pjg/cE0VxbnNM+bnDQ=="
+    },
     "node_modules/micromark": {
       "version": "2.11.4",
       "resolved": "https://registry.npmjs.org/micromark/-/micromark-2.11.4.tgz",
@@ -22115,6 +25482,107 @@
         "debug": "^4.0.0",
         "parse-entities": "^2.0.0"
       }
+    },
+    "node_modules/micromark-core-commonmark": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.0.tgz",
+      "integrity": "sha512-jThOz/pVmAYUtkroV3D5c1osFXAMv9e0ypGDOIZuCeAe91/sD6BoE2Sjzt30yuXtwOYUmySOhMas/PVyh02itA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-destination": "^2.0.0",
+        "micromark-factory-label": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-title": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-html-tag-name": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-core-commonmark/node_modules/micromark-factory-space": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.0.tgz",
+      "integrity": "sha512-TKr+LIDX2pkBJXFLzpyPyljzYK3MtmllMUMODTQJIUfDGncESaqB90db9IAUcz4AZAJFdd8U9zOp9ty1458rxg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-core-commonmark/node_modules/micromark-util-character": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.0.tgz",
+      "integrity": "sha512-KvOVV+X1yLBfs9dCBSopq/+G1PcgT3lAK07mC4BzXi5E7ahzMAF8oIupDDJ6mievI6F+lAATkbQQlQixJfT3aQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-core-commonmark/node_modules/micromark-util-symbol": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.0.tgz",
+      "integrity": "sha512-8JZt9ElZ5kyTnO94muPxIGS8oyElRJaiJO8EzV6ZSyGQ1Is8xwl4Q45qU5UOg+bGH4AikWziz0iN4sFLWs8PGw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ]
+    },
+    "node_modules/micromark-core-commonmark/node_modules/micromark-util-types": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.0.tgz",
+      "integrity": "sha512-oNh6S2WMHWRZrmutsRmDDfkzKtxF+bc2VxLC9dvtrDIRFln627VsFP6fLMgTryGDljgLPjkrzQSDcPrjPyDJ5w==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ]
     },
     "node_modules/micromark-extension-gfm": {
       "version": "0.3.3",
@@ -22144,6 +25612,93 @@
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
+    },
+    "node_modules/micromark-extension-gfm-footnote": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.0.0.tgz",
+      "integrity": "sha512-6Rzu0CYRKDv3BfLAUnZsSlzx3ak6HAoI85KTiijuKIz5UxZxbUI+pD6oHgw+6UtQuiRwnGRhzMmPRv4smcz0fg==",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-footnote/node_modules/micromark-factory-space": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.0.tgz",
+      "integrity": "sha512-TKr+LIDX2pkBJXFLzpyPyljzYK3MtmllMUMODTQJIUfDGncESaqB90db9IAUcz4AZAJFdd8U9zOp9ty1458rxg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-gfm-footnote/node_modules/micromark-util-character": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.0.tgz",
+      "integrity": "sha512-KvOVV+X1yLBfs9dCBSopq/+G1PcgT3lAK07mC4BzXi5E7ahzMAF8oIupDDJ6mievI6F+lAATkbQQlQixJfT3aQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-gfm-footnote/node_modules/micromark-util-symbol": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.0.tgz",
+      "integrity": "sha512-8JZt9ElZ5kyTnO94muPxIGS8oyElRJaiJO8EzV6ZSyGQ1Is8xwl4Q45qU5UOg+bGH4AikWziz0iN4sFLWs8PGw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ]
+    },
+    "node_modules/micromark-extension-gfm-footnote/node_modules/micromark-util-types": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.0.tgz",
+      "integrity": "sha512-oNh6S2WMHWRZrmutsRmDDfkzKtxF+bc2VxLC9dvtrDIRFln627VsFP6fLMgTryGDljgLPjkrzQSDcPrjPyDJ5w==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ]
     },
     "node_modules/micromark-extension-gfm-strikethrough": {
       "version": "0.6.5",
@@ -22190,6 +25745,864 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/micromark-extension-math": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/micromark-extension-math/-/micromark-extension-math-2.1.2.tgz",
+      "integrity": "sha512-es0CcOV89VNS9wFmyn+wyFTKweXGW4CEvdaAca6SWRWPyYCbBisnjaHLjWO4Nszuiud84jCpkHsqAJoa768Pvg==",
+      "dependencies": {
+        "@types/katex": "^0.16.0",
+        "katex": "^0.16.0",
+        "micromark-factory-space": "^1.0.0",
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0",
+        "uvu": "^0.5.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-factory-destination": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.0.tgz",
+      "integrity": "sha512-j9DGrQLm/Uhl2tCzcbLhy5kXsgkHUrjJHg4fFAeoMRwJmJerT9aw4FEhIbZStWN8A3qMwOp1uzHr4UL8AInxtA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-destination/node_modules/micromark-util-character": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.0.tgz",
+      "integrity": "sha512-KvOVV+X1yLBfs9dCBSopq/+G1PcgT3lAK07mC4BzXi5E7ahzMAF8oIupDDJ6mievI6F+lAATkbQQlQixJfT3aQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-destination/node_modules/micromark-util-symbol": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.0.tgz",
+      "integrity": "sha512-8JZt9ElZ5kyTnO94muPxIGS8oyElRJaiJO8EzV6ZSyGQ1Is8xwl4Q45qU5UOg+bGH4AikWziz0iN4sFLWs8PGw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ]
+    },
+    "node_modules/micromark-factory-destination/node_modules/micromark-util-types": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.0.tgz",
+      "integrity": "sha512-oNh6S2WMHWRZrmutsRmDDfkzKtxF+bc2VxLC9dvtrDIRFln627VsFP6fLMgTryGDljgLPjkrzQSDcPrjPyDJ5w==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ]
+    },
+    "node_modules/micromark-factory-label": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.0.tgz",
+      "integrity": "sha512-RR3i96ohZGde//4WSe/dJsxOX6vxIg9TimLAS3i4EhBAFx8Sm5SmqVfR8E87DPSR31nEAjZfbt91OMZWcNgdZw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-label/node_modules/micromark-util-character": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.0.tgz",
+      "integrity": "sha512-KvOVV+X1yLBfs9dCBSopq/+G1PcgT3lAK07mC4BzXi5E7ahzMAF8oIupDDJ6mievI6F+lAATkbQQlQixJfT3aQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-label/node_modules/micromark-util-symbol": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.0.tgz",
+      "integrity": "sha512-8JZt9ElZ5kyTnO94muPxIGS8oyElRJaiJO8EzV6ZSyGQ1Is8xwl4Q45qU5UOg+bGH4AikWziz0iN4sFLWs8PGw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ]
+    },
+    "node_modules/micromark-factory-label/node_modules/micromark-util-types": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.0.tgz",
+      "integrity": "sha512-oNh6S2WMHWRZrmutsRmDDfkzKtxF+bc2VxLC9dvtrDIRFln627VsFP6fLMgTryGDljgLPjkrzQSDcPrjPyDJ5w==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ]
+    },
+    "node_modules/micromark-factory-space": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-1.1.0.tgz",
+      "integrity": "sha512-cRzEj7c0OL4Mw2v6nwzttyOZe8XY/Z8G0rzmWQZTBi/jjwyw/U4uqKtUORXQrR5bAZZnbTI/feRV/R7hc4jQYQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-types": "^1.0.0"
+      }
+    },
+    "node_modules/micromark-factory-title": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.0.tgz",
+      "integrity": "sha512-jY8CSxmpWLOxS+t8W+FG3Xigc0RDQA9bKMY/EwILvsesiRniiVMejYTE4wumNc2f4UbAa4WsHqe3J1QS1sli+A==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-title/node_modules/micromark-factory-space": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.0.tgz",
+      "integrity": "sha512-TKr+LIDX2pkBJXFLzpyPyljzYK3MtmllMUMODTQJIUfDGncESaqB90db9IAUcz4AZAJFdd8U9zOp9ty1458rxg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-title/node_modules/micromark-util-character": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.0.tgz",
+      "integrity": "sha512-KvOVV+X1yLBfs9dCBSopq/+G1PcgT3lAK07mC4BzXi5E7ahzMAF8oIupDDJ6mievI6F+lAATkbQQlQixJfT3aQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-title/node_modules/micromark-util-symbol": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.0.tgz",
+      "integrity": "sha512-8JZt9ElZ5kyTnO94muPxIGS8oyElRJaiJO8EzV6ZSyGQ1Is8xwl4Q45qU5UOg+bGH4AikWziz0iN4sFLWs8PGw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ]
+    },
+    "node_modules/micromark-factory-title/node_modules/micromark-util-types": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.0.tgz",
+      "integrity": "sha512-oNh6S2WMHWRZrmutsRmDDfkzKtxF+bc2VxLC9dvtrDIRFln627VsFP6fLMgTryGDljgLPjkrzQSDcPrjPyDJ5w==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ]
+    },
+    "node_modules/micromark-factory-whitespace": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.0.tgz",
+      "integrity": "sha512-28kbwaBjc5yAI1XadbdPYHX/eDnqaUFVikLwrO7FDnKG7lpgxnvk/XGRhX/PN0mOZ+dBSZ+LgunHS+6tYQAzhA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-whitespace/node_modules/micromark-factory-space": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.0.tgz",
+      "integrity": "sha512-TKr+LIDX2pkBJXFLzpyPyljzYK3MtmllMUMODTQJIUfDGncESaqB90db9IAUcz4AZAJFdd8U9zOp9ty1458rxg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-whitespace/node_modules/micromark-util-character": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.0.tgz",
+      "integrity": "sha512-KvOVV+X1yLBfs9dCBSopq/+G1PcgT3lAK07mC4BzXi5E7ahzMAF8oIupDDJ6mievI6F+lAATkbQQlQixJfT3aQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-whitespace/node_modules/micromark-util-symbol": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.0.tgz",
+      "integrity": "sha512-8JZt9ElZ5kyTnO94muPxIGS8oyElRJaiJO8EzV6ZSyGQ1Is8xwl4Q45qU5UOg+bGH4AikWziz0iN4sFLWs8PGw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ]
+    },
+    "node_modules/micromark-factory-whitespace/node_modules/micromark-util-types": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.0.tgz",
+      "integrity": "sha512-oNh6S2WMHWRZrmutsRmDDfkzKtxF+bc2VxLC9dvtrDIRFln627VsFP6fLMgTryGDljgLPjkrzQSDcPrjPyDJ5w==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ]
+    },
+    "node_modules/micromark-util-character": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-1.2.0.tgz",
+      "integrity": "sha512-lXraTwcX3yH/vMDaFWCQJP1uIszLVebzUa3ZHdrgxr7KEU/9mL4mVgCpGbyhvNLNlauROiNUq7WN5u7ndbY6xg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0"
+      }
+    },
+    "node_modules/micromark-util-chunked": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.0.tgz",
+      "integrity": "sha512-anK8SWmNphkXdaKgz5hJvGa7l00qmcaUQoMYsBwDlSKFKjc6gjGXPDw3FNL3Nbwq5L8gE+RCbGqTw49FK5Qyvg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-chunked/node_modules/micromark-util-symbol": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.0.tgz",
+      "integrity": "sha512-8JZt9ElZ5kyTnO94muPxIGS8oyElRJaiJO8EzV6ZSyGQ1Is8xwl4Q45qU5UOg+bGH4AikWziz0iN4sFLWs8PGw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ]
+    },
+    "node_modules/micromark-util-classify-character": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.0.tgz",
+      "integrity": "sha512-S0ze2R9GH+fu41FA7pbSqNWObo/kzwf8rN/+IGlW/4tC6oACOs8B++bh+i9bVyNnwCcuksbFwsBme5OCKXCwIw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-classify-character/node_modules/micromark-util-character": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.0.tgz",
+      "integrity": "sha512-KvOVV+X1yLBfs9dCBSopq/+G1PcgT3lAK07mC4BzXi5E7ahzMAF8oIupDDJ6mievI6F+lAATkbQQlQixJfT3aQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-classify-character/node_modules/micromark-util-symbol": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.0.tgz",
+      "integrity": "sha512-8JZt9ElZ5kyTnO94muPxIGS8oyElRJaiJO8EzV6ZSyGQ1Is8xwl4Q45qU5UOg+bGH4AikWziz0iN4sFLWs8PGw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ]
+    },
+    "node_modules/micromark-util-classify-character/node_modules/micromark-util-types": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.0.tgz",
+      "integrity": "sha512-oNh6S2WMHWRZrmutsRmDDfkzKtxF+bc2VxLC9dvtrDIRFln627VsFP6fLMgTryGDljgLPjkrzQSDcPrjPyDJ5w==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ]
+    },
+    "node_modules/micromark-util-combine-extensions": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.0.tgz",
+      "integrity": "sha512-vZZio48k7ON0fVS3CUgFatWHoKbbLTK/rT7pzpJ4Bjp5JjkZeasRfrS9wsBdDJK2cJLHMckXZdzPSSr1B8a4oQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-combine-extensions/node_modules/micromark-util-types": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.0.tgz",
+      "integrity": "sha512-oNh6S2WMHWRZrmutsRmDDfkzKtxF+bc2VxLC9dvtrDIRFln627VsFP6fLMgTryGDljgLPjkrzQSDcPrjPyDJ5w==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ]
+    },
+    "node_modules/micromark-util-decode-numeric-character-reference": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.1.tgz",
+      "integrity": "sha512-bmkNc7z8Wn6kgjZmVHOX3SowGmVdhYS7yBpMnuMnPzDq/6xwVA604DuOXMZTO1lvq01g+Adfa0pE2UKGlxL1XQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-numeric-character-reference/node_modules/micromark-util-symbol": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.0.tgz",
+      "integrity": "sha512-8JZt9ElZ5kyTnO94muPxIGS8oyElRJaiJO8EzV6ZSyGQ1Is8xwl4Q45qU5UOg+bGH4AikWziz0iN4sFLWs8PGw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ]
+    },
+    "node_modules/micromark-util-decode-string": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.0.tgz",
+      "integrity": "sha512-r4Sc6leeUTn3P6gk20aFMj2ntPwn6qpDZqWvYmAG6NgvFTIlj4WtrAudLi65qYoaGdXYViXYw2pkmn7QnIFasA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-string/node_modules/micromark-util-character": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.0.tgz",
+      "integrity": "sha512-KvOVV+X1yLBfs9dCBSopq/+G1PcgT3lAK07mC4BzXi5E7ahzMAF8oIupDDJ6mievI6F+lAATkbQQlQixJfT3aQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-string/node_modules/micromark-util-symbol": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.0.tgz",
+      "integrity": "sha512-8JZt9ElZ5kyTnO94muPxIGS8oyElRJaiJO8EzV6ZSyGQ1Is8xwl4Q45qU5UOg+bGH4AikWziz0iN4sFLWs8PGw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ]
+    },
+    "node_modules/micromark-util-decode-string/node_modules/micromark-util-types": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.0.tgz",
+      "integrity": "sha512-oNh6S2WMHWRZrmutsRmDDfkzKtxF+bc2VxLC9dvtrDIRFln627VsFP6fLMgTryGDljgLPjkrzQSDcPrjPyDJ5w==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ]
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.0.tgz",
+      "integrity": "sha512-pS+ROfCXAGLWCOc8egcBvT0kf27GoWMqtdarNfDcjb6YLuV5cM3ioG45Ys2qOVqeqSbjaKg72vU+Wby3eddPsA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ]
+    },
+    "node_modules/micromark-util-html-tag-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.0.tgz",
+      "integrity": "sha512-xNn4Pqkj2puRhKdKTm8t1YHC/BAjx6CEwRFXntTaRf/x16aqka6ouVoutm+QdkISTlT7e2zU7U4ZdlDLJd2Mcw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ]
+    },
+    "node_modules/micromark-util-normalize-identifier": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.0.tgz",
+      "integrity": "sha512-2xhYT0sfo85FMrUPtHcPo2rrp1lwbDEEzpx7jiH2xXJLqBuy4H0GgXk5ToU8IEwoROtXuL8ND0ttVa4rNqYK3w==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-normalize-identifier/node_modules/micromark-util-symbol": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.0.tgz",
+      "integrity": "sha512-8JZt9ElZ5kyTnO94muPxIGS8oyElRJaiJO8EzV6ZSyGQ1Is8xwl4Q45qU5UOg+bGH4AikWziz0iN4sFLWs8PGw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ]
+    },
+    "node_modules/micromark-util-resolve-all": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.0.tgz",
+      "integrity": "sha512-6KU6qO7DZ7GJkaCgwBNtplXCvGkJToU86ybBAUdavvgsCiG8lSSvYxr9MhwmQ+udpzywHsl4RpGJsYWG1pDOcA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-resolve-all/node_modules/micromark-util-types": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.0.tgz",
+      "integrity": "sha512-oNh6S2WMHWRZrmutsRmDDfkzKtxF+bc2VxLC9dvtrDIRFln627VsFP6fLMgTryGDljgLPjkrzQSDcPrjPyDJ5w==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ]
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.0.tgz",
+      "integrity": "sha512-WhYv5UEcZrbAtlsnPuChHUAsu/iBPOVaEVsntLBIdpibO0ddy8OzavZz3iL2xVvBZOpolujSliP65Kq0/7KIYw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-sanitize-uri/node_modules/micromark-util-character": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.0.tgz",
+      "integrity": "sha512-KvOVV+X1yLBfs9dCBSopq/+G1PcgT3lAK07mC4BzXi5E7ahzMAF8oIupDDJ6mievI6F+lAATkbQQlQixJfT3aQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-sanitize-uri/node_modules/micromark-util-symbol": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.0.tgz",
+      "integrity": "sha512-8JZt9ElZ5kyTnO94muPxIGS8oyElRJaiJO8EzV6ZSyGQ1Is8xwl4Q45qU5UOg+bGH4AikWziz0iN4sFLWs8PGw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ]
+    },
+    "node_modules/micromark-util-sanitize-uri/node_modules/micromark-util-types": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.0.tgz",
+      "integrity": "sha512-oNh6S2WMHWRZrmutsRmDDfkzKtxF+bc2VxLC9dvtrDIRFln627VsFP6fLMgTryGDljgLPjkrzQSDcPrjPyDJ5w==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ]
+    },
+    "node_modules/micromark-util-subtokenize": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.0.0.tgz",
+      "integrity": "sha512-vc93L1t+gpR3p8jxeVdaYlbV2jTYteDje19rNSS/H5dlhxUYll5Fy6vJ2cDwP8RnsXi818yGty1ayP55y3W6fg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-subtokenize/node_modules/micromark-util-symbol": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.0.tgz",
+      "integrity": "sha512-8JZt9ElZ5kyTnO94muPxIGS8oyElRJaiJO8EzV6ZSyGQ1Is8xwl4Q45qU5UOg+bGH4AikWziz0iN4sFLWs8PGw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ]
+    },
+    "node_modules/micromark-util-subtokenize/node_modules/micromark-util-types": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.0.tgz",
+      "integrity": "sha512-oNh6S2WMHWRZrmutsRmDDfkzKtxF+bc2VxLC9dvtrDIRFln627VsFP6fLMgTryGDljgLPjkrzQSDcPrjPyDJ5w==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ]
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-1.1.0.tgz",
+      "integrity": "sha512-uEjpEYY6KMs1g7QfJ2eX1SQEV+ZT4rUD3UcF6l57acZvLNK7PBZL+ty82Z1qhK1/yXIY4bdx04FKMgR0g4IAag==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ]
+    },
+    "node_modules/micromark-util-types": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-1.1.0.tgz",
+      "integrity": "sha512-ukRBgie8TIAcacscVHSiddHjO4k/q3pnedmzMQ4iwDcK0FtFCohKOlFbaOL/mPgfnPsL3C1ZyxJa4sbWrBl3jg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ]
+    },
     "node_modules/micromatch": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
@@ -22207,7 +26620,6 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -22216,7 +26628,6 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
       "dependencies": {
         "mime-db": "1.52.0"
       },
@@ -22499,6 +26910,11 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
     },
+    "node_modules/mj-context-menu": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/mj-context-menu/-/mj-context-menu-0.6.1.tgz",
+      "integrity": "sha512-7NO5s6n10TIV96d4g2uDpG7ZDpIhMh0QNfGdJw/W47JswFcosz457wqz/b5sAKvl12sxINGFCn80NZHKwxQEXA=="
+    },
     "node_modules/mkdirp": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
@@ -22580,6 +26996,14 @@
         "right-now": "^1.0.0",
         "signum": "^1.0.0",
         "to-px": "^1.0.1"
+      }
+    },
+    "node_modules/mri": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
+      "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/ms": {
@@ -23537,8 +27961,7 @@
     "node_modules/nwsapi": {
       "version": "2.2.7",
       "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.7.tgz",
-      "integrity": "sha512-ub5E4+FBPKwAZx0UwIQOjYWGHTEq5sPqHQNRN8Z9e4A7u3Tj1weLJsL59yH9vmvqEtBHaOmT6cYQKIZOxp35FQ==",
-      "dev": true
+      "integrity": "sha512-ub5E4+FBPKwAZx0UwIQOjYWGHTEq5sPqHQNRN8Z9e4A7u3Tj1weLJsL59yH9vmvqEtBHaOmT6cYQKIZOxp35FQ=="
     },
     "node_modules/nx": {
       "version": "15.9.2",
@@ -24610,7 +29033,6 @@
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
       "integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
-      "dev": true,
       "dependencies": {
         "entities": "^4.4.0"
       },
@@ -25195,14 +29617,12 @@
     "node_modules/psl": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
-      "integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag==",
-      "dev": true
+      "integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag=="
     },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -25241,8 +29661,7 @@
     "node_modules/querystringify": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
-      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
-      "dev": true
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
@@ -26100,6 +30519,151 @@
         "regl-scatter2d": "^3.2.3"
       }
     },
+    "node_modules/rehype-mathjax": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/rehype-mathjax/-/rehype-mathjax-4.0.3.tgz",
+      "integrity": "sha512-QIwWH9U+r54nMQklVkT1qluxhKyzdPWz9dFwgel3BrseQsWZafRTDTUj8VR8/14nFuRIV2ChuCMz4zpACPoYvg==",
+      "dependencies": {
+        "@types/hast": "^2.0.0",
+        "@types/mathjax": "^0.0.37",
+        "hast-util-from-dom": "^4.0.0",
+        "hast-util-to-text": "^3.1.0",
+        "jsdom": "^20.0.0",
+        "mathjax-full": "^3.0.0",
+        "unified": "^10.0.0",
+        "unist-util-visit": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-mathjax/node_modules/bail": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+      "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/rehype-mathjax/node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/rehype-mathjax/node_modules/trough": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+      "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/rehype-mathjax/node_modules/unified": {
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-10.1.2.tgz",
+      "integrity": "sha512-pUSWAi/RAnVy1Pif2kAoeWNBa3JVrx0MId2LASj8G+7AiHWoKZNTomq6LG326T68U7/e263X6fTdcXIy7XnF7Q==",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "bail": "^2.0.0",
+        "extend": "^3.0.0",
+        "is-buffer": "^2.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-mathjax/node_modules/unist-util-is": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-5.2.1.tgz",
+      "integrity": "sha512-u9njyyfEh43npf1M+yGKDGVPbY/JWEemg5nH05ncKPfi+kBbKBJoTdsogMu33uhytuLlv9y0O7GH7fEdwLdLQw==",
+      "dependencies": {
+        "@types/unist": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-mathjax/node_modules/unist-util-stringify-position": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-3.0.3.tgz",
+      "integrity": "sha512-k5GzIBZ/QatR8N5X2y+drfpWG8IDBzdnVj6OInRNWm1oXrzydiaAT2OQiA8DPRRZyAKb9b6I2a6PxYklZD0gKg==",
+      "dependencies": {
+        "@types/unist": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-mathjax/node_modules/unist-util-visit": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-4.1.2.tgz",
+      "integrity": "sha512-MSd8OUGISqHdVvfY9TPhyK2VdUrPgxkUtWSuMHF6XAAFuL4LokseigBnZtPnJMu+FbynTkFNnFlyjxpVKujMRg==",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "unist-util-is": "^5.0.0",
+        "unist-util-visit-parents": "^5.1.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-mathjax/node_modules/unist-util-visit-parents": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-5.1.3.tgz",
+      "integrity": "sha512-x6+y8g7wWMyQhL1iZfhIPhDAs7Xwbn9nRosDXl7qoPTSCy0yNxnKc+hWokFifWQIDGi154rdUqKvbCa4+1kLhg==",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "unist-util-is": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-mathjax/node_modules/vfile": {
+      "version": "5.3.7",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-5.3.7.tgz",
+      "integrity": "sha512-r7qlzkgErKjobAmyNIkkSpizsFPYiUPuJb5pNW1RB4JcYVZhs4lIbVqk8XPk033CV/1z8ss5pkax8SuhGpcG8g==",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "is-buffer": "^2.0.0",
+        "unist-util-stringify-position": "^3.0.0",
+        "vfile-message": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-mathjax/node_modules/vfile-message": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-3.1.4.tgz",
+      "integrity": "sha512-fa0Z6P8HUrQN4BZaX05SIVXic+7kE3b05PWAtPuYP9QLHsLKYR7/AlLW3NtOrpXRLeawpDLMsVkmk5DG0NXgWw==",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "unist-util-stringify-position": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/remark-gfm": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-1.0.0.tgz",
@@ -26107,6 +30671,108 @@
       "dependencies": {
         "mdast-util-gfm": "^0.1.0",
         "micromark-extension-gfm": "^0.3.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-math": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/remark-math/-/remark-math-5.1.1.tgz",
+      "integrity": "sha512-cE5T2R/xLVtfFI4cCePtiRn+e6jKMtFDR3P8V3qpv8wpKjwvHoBA4eJzvX+nVrnlNy0911bdGmuspCSwetfYHw==",
+      "dependencies": {
+        "@types/mdast": "^3.0.0",
+        "mdast-util-math": "^2.0.0",
+        "micromark-extension-math": "^2.0.0",
+        "unified": "^10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-math/node_modules/bail": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+      "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/remark-math/node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/remark-math/node_modules/trough": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+      "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/remark-math/node_modules/unified": {
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-10.1.2.tgz",
+      "integrity": "sha512-pUSWAi/RAnVy1Pif2kAoeWNBa3JVrx0MId2LASj8G+7AiHWoKZNTomq6LG326T68U7/e263X6fTdcXIy7XnF7Q==",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "bail": "^2.0.0",
+        "extend": "^3.0.0",
+        "is-buffer": "^2.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-math/node_modules/unist-util-stringify-position": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-3.0.3.tgz",
+      "integrity": "sha512-k5GzIBZ/QatR8N5X2y+drfpWG8IDBzdnVj6OInRNWm1oXrzydiaAT2OQiA8DPRRZyAKb9b6I2a6PxYklZD0gKg==",
+      "dependencies": {
+        "@types/unist": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-math/node_modules/vfile": {
+      "version": "5.3.7",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-5.3.7.tgz",
+      "integrity": "sha512-r7qlzkgErKjobAmyNIkkSpizsFPYiUPuJb5pNW1RB4JcYVZhs4lIbVqk8XPk033CV/1z8ss5pkax8SuhGpcG8g==",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "is-buffer": "^2.0.0",
+        "unist-util-stringify-position": "^3.0.0",
+        "vfile-message": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-math/node_modules/vfile-message": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-3.1.4.tgz",
+      "integrity": "sha512-fa0Z6P8HUrQN4BZaX05SIVXic+7kE3b05PWAtPuYP9QLHsLKYR7/AlLW3NtOrpXRLeawpDLMsVkmk5DG0NXgWw==",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "unist-util-stringify-position": "^3.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -26135,6 +30801,207 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-stringify": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
+      "integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-stringify/node_modules/@types/mdast": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.3.tgz",
+      "integrity": "sha512-LsjtqsyF+d2/yFOYaN22dHZI1Cpwkrj+g06G8+qtUKlhovPW89YhqSnfKtMbkgmEtYpH2gydRNULd6y8mciAFg==",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/remark-stringify/node_modules/@types/unist": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.2.tgz",
+      "integrity": "sha512-dqId9J8K/vGi5Zr7oo212BGii5m3q5Hxlkwy3WpYuKPklmBEvsbMYYyLxAQpSffdLl/gdW0XUpKWFvYmyoWCoQ=="
+    },
+    "node_modules/remark-stringify/node_modules/bail": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+      "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/remark-stringify/node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/remark-stringify/node_modules/longest-streak": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+      "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/remark-stringify/node_modules/mdast-util-to-markdown": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.0.tgz",
+      "integrity": "sha512-SR2VnIEdVNCJbP6y7kVTJgPLifdr8WEU440fQec7qHoHOUz/oJ2jmNRqdDQ3rbiStOXb2mCDGTuwsK5OPUgYlQ==",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-phrasing": "^4.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "unist-util-visit": "^5.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-stringify/node_modules/mdast-util-to-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+      "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+      "dependencies": {
+        "@types/mdast": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-stringify/node_modules/trough": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+      "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/remark-stringify/node_modules/unified": {
+      "version": "11.0.4",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.4.tgz",
+      "integrity": "sha512-apMPnyLjAX+ty4OrNap7yumyVAMlKx5IWU2wlzzUdYJO9A8f1p9m/gywF/GM2ZDFcjQPrx59Mc90KwmxsoklxQ==",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "bail": "^2.0.0",
+        "devlop": "^1.0.0",
+        "extend": "^3.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-stringify/node_modules/unist-util-is": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.0.tgz",
+      "integrity": "sha512-2qCTHimwdxLfz+YzdGfkqNlH0tLi9xjTnHddPmJwtIG9MGsdbutfTc4P+haPD7l7Cjxf/WZj+we5qfVPvvxfYw==",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-stringify/node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-stringify/node_modules/unist-util-visit": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.0.0.tgz",
+      "integrity": "sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-stringify/node_modules/unist-util-visit-parents": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.1.tgz",
+      "integrity": "sha512-L/PqWzfTP9lzzEa6CKs0k2nARxTdZduw3zyh8d2NVBnsyvHjSX4TWse388YrrQKbvI8w20fGjGlhgT96WwKykw==",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-stringify/node_modules/vfile": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.1.tgz",
+      "integrity": "sha512-1bYqc7pt6NIADBJ98UiG0Bn/CHIVOoZ/IyEkqIruLg0mE1BKzkOXY2D6CSqQIcKqgadppE5lrxgWXJmXd7zZJw==",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-stringify/node_modules/vfile-message": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.2.tgz",
+      "integrity": "sha512-jRDZ1IMLttGj41KcZvlrYAaI3CfqpLpfpf+Mfig13viT6NKvRzWZ+lXz0Y5D60w6uJIBAOGq9mSHf0gktF0duw==",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-stringify/node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/repeat-string": {
@@ -26167,8 +31034,7 @@
     "node_modules/requires-port": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
-      "dev": true
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="
     },
     "node_modules/resolve": {
       "version": "1.22.8",
@@ -26357,6 +31223,17 @@
         "tslib": "^2.1.0"
       }
     },
+    "node_modules/sade": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/sade/-/sade-1.8.1.tgz",
+      "integrity": "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==",
+      "dependencies": {
+        "mri": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/safe-array-concat": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.0.1.tgz",
@@ -26440,7 +31317,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
       "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
-      "dev": true,
       "dependencies": {
         "xmlchars": "^2.2.0"
       },
@@ -26885,6 +31761,27 @@
       "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.16.tgz",
       "integrity": "sha512-eWN+LnM3GR6gPu35WxNgbGl8rmY1AEmoMDvL/QD6zYmPWgywxWqJWNdLGT+ke8dKNWrcYgYjPpG5gbTfghP8rw==",
       "dev": true
+    },
+    "node_modules/speech-rule-engine": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/speech-rule-engine/-/speech-rule-engine-4.0.7.tgz",
+      "integrity": "sha512-sJrL3/wHzNwJRLBdf6CjJWIlxC04iYKkyXvYSVsWVOiC2DSkHmxsqOhEeMsBA9XK+CHuNcsdkbFDnoUfAsmp9g==",
+      "dependencies": {
+        "commander": "9.2.0",
+        "wicked-good-xpath": "1.3.0",
+        "xmldom-sre": "0.1.31"
+      },
+      "bin": {
+        "sre": "bin/sre"
+      }
+    },
+    "node_modules/speech-rule-engine/node_modules/commander": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.2.0.tgz",
+      "integrity": "sha512-e2i4wANQiSXgnrBlIatyHtP1odfUp0BbV5Y5nEGbxtIrStkEOAAzCUirvLBNXHLr7kwLvJl6V+4V3XV9x7Wd9w==",
+      "engines": {
+        "node": "^12.20.0 || >=14"
+      }
     },
     "node_modules/split": {
       "version": "1.0.1",
@@ -27887,8 +32784,7 @@
     "node_modules/symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
-      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
-      "dev": true
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="
     },
     "node_modules/table": {
       "version": "6.8.1",
@@ -28196,7 +33092,6 @@
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.3.tgz",
       "integrity": "sha512-aX/y5pVRkfRnfmuX+OdbSdXvPe6ieKX/G2s7e98f4poJHnqH3281gDPm/metm6E/WRamfx7WC4HUqkWHfQHprw==",
-      "dev": true,
       "dependencies": {
         "psl": "^1.1.33",
         "punycode": "^2.1.1",
@@ -28211,7 +33106,6 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
       "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
-      "dev": true,
       "engines": {
         "node": ">= 4.0.0"
       }
@@ -28220,7 +33114,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
       "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
-      "dev": true,
       "dependencies": {
         "punycode": "^2.1.1"
       },
@@ -28235,6 +33128,15 @@
       "dev": true,
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/trim-lines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/trim-newlines": {
@@ -28715,6 +33617,31 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/unist-util-find-after": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-find-after/-/unist-util-find-after-4.0.1.tgz",
+      "integrity": "sha512-QO/PuPMm2ERxC6vFXEPtmAutOopy5PknD+Oq64gGwxKtk4xwo9Z97t9Av1obPmGU0IyTa6EKYUfTrK2QJS3Ozw==",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "unist-util-is": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-find-after/node_modules/unist-util-is": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-5.2.1.tgz",
+      "integrity": "sha512-u9njyyfEh43npf1M+yGKDGVPbY/JWEemg5nH05ncKPfi+kBbKBJoTdsogMu33uhytuLlv9y0O7GH7fEdwLdLQw==",
+      "dependencies": {
+        "@types/unist": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/unist-util-generated": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/unist-util-generated/-/unist-util-generated-1.1.6.tgz",
@@ -28859,7 +33786,6 @@
       "version": "1.5.10",
       "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
       "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
-      "dev": true,
       "dependencies": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
@@ -28922,6 +33848,31 @@
       "dev": true,
       "bin": {
         "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/uvu": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/uvu/-/uvu-0.5.6.tgz",
+      "integrity": "sha512-+g8ENReyr8YsOc6fv/NVJs2vFdHBnBNdfE49rshrTzDWOlUx4Gq7KOS2GD8eqhy2j+Ejq29+SbKH8yjkAqXqoA==",
+      "dependencies": {
+        "dequal": "^2.0.0",
+        "diff": "^5.0.0",
+        "kleur": "^4.0.3",
+        "sade": "^1.7.3"
+      },
+      "bin": {
+        "uvu": "bin.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/uvu/node_modules/kleur": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/v8-compile-cache": {
@@ -29057,7 +34008,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-4.0.0.tgz",
       "integrity": "sha512-d+BFHzbiCx6zGfz0HyQ6Rg69w9k19nviJspaj4yNscGjrHu94sVP+aRm75yEbCh+r2/yR+7q6hux9LVtbuTGBw==",
-      "dev": true,
       "dependencies": {
         "xml-name-validator": "^4.0.0"
       },
@@ -29094,6 +34044,15 @@
       "resolved": "https://registry.npmjs.org/weak-map/-/weak-map-1.0.8.tgz",
       "integrity": "sha512-lNR9aAefbGPpHO7AEnY0hCFjz1eTkWCXYvkTRrTHs9qv8zJp+SkVYpzfLIFXQQiG3tVvbNFQgVg2bQS8YGgxyw=="
     },
+    "node_modules/web-namespaces": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
+      "integrity": "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/webgl-context": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/webgl-context/-/webgl-context-2.2.0.tgz",
@@ -29106,7 +34065,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
       "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
-      "dev": true,
       "engines": {
         "node": ">=12"
       }
@@ -29115,7 +34073,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-2.0.0.tgz",
       "integrity": "sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==",
-      "dev": true,
       "dependencies": {
         "iconv-lite": "0.6.3"
       },
@@ -29127,7 +34084,6 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "dev": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
@@ -29139,7 +34095,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
       "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
-      "dev": true,
       "engines": {
         "node": ">=12"
       }
@@ -29148,7 +34103,6 @@
       "version": "11.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
       "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
-      "dev": true,
       "dependencies": {
         "tr46": "^3.0.0",
         "webidl-conversions": "^7.0.0"
@@ -29244,6 +34198,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/wicked-good-xpath": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/wicked-good-xpath/-/wicked-good-xpath-1.3.0.tgz",
+      "integrity": "sha512-Gd9+TUn5nXdwj/hFsPVx5cuHHiF5Bwuc30jZ4+ronF1qHK5O7HD0sgmXWSEgwKquT3ClLoKPVbO6qGwVwLzvAw=="
     },
     "node_modules/wide-align": {
       "version": "1.1.5",
@@ -29478,7 +34437,6 @@
       "version": "8.14.2",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.14.2.tgz",
       "integrity": "sha512-wEBG1ftX4jcglPxgFCMJmZ2PLtSbJ2Peg6TmpJFTbe9GZYOQCDPdMYu/Tm0/bGZkw8paZnJY45J4K2PZrLYq8g==",
-      "dev": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -29499,7 +34457,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-4.0.0.tgz",
       "integrity": "sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==",
-      "dev": true,
       "engines": {
         "node": ">=12"
       }
@@ -29507,8 +34464,15 @@
     "node_modules/xmlchars": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
-      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
-      "dev": true
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="
+    },
+    "node_modules/xmldom-sre": {
+      "version": "0.1.31",
+      "resolved": "https://registry.npmjs.org/xmldom-sre/-/xmldom-sre-0.1.31.tgz",
+      "integrity": "sha512-f9s+fUkX04BxQf+7mMWAp5zk61pciie+fFLC9hX9UVvCeJQfNHRHXpeo5MPcR0EUf57PYLdt+ZO4f3Ipk2oZUw==",
+      "engines": {
+        "node": ">=0.1"
+      }
     },
     "node_modules/xtend": {
       "version": "4.0.2",
@@ -30991,15 +35955,15 @@
       "version": "0.4.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@deephaven/chart": "0.62.0",
-        "@deephaven/components": "0.62.0",
-        "@deephaven/dashboard": "0.62.0",
-        "@deephaven/dashboard-core-plugins": "0.62.0",
-        "@deephaven/icons": "0.62.0",
-        "@deephaven/jsapi-bootstrap": "0.62.0",
-        "@deephaven/log": "0.62.0",
-        "@deephaven/plugin": "0.62.0",
-        "@deephaven/utils": "0.62.0",
+        "@deephaven/chart": "0.64.0",
+        "@deephaven/components": "0.64.0",
+        "@deephaven/dashboard": "0.64.0",
+        "@deephaven/dashboard-core-plugins": "0.64.0",
+        "@deephaven/icons": "0.64.0",
+        "@deephaven/jsapi-bootstrap": "0.64.0",
+        "@deephaven/log": "0.64.0",
+        "@deephaven/plugin": "0.64.0",
+        "@deephaven/utils": "0.64.0",
         "deep-equal": "^2.2.1",
         "plotly.js": "^2.23.0",
         "plotly.js-dist-min": "^2.23.0",
@@ -31008,7 +35972,7 @@
         "shortid": "^2.2.16"
       },
       "devDependencies": {
-        "@deephaven/jsapi-types": "0.62.0",
+        "@deephaven/jsapi-types": "0.64.0",
         "@types/deep-equal": "^1.0.1",
         "@types/plotly.js": "^2.12.18",
         "@types/plotly.js-dist-min": "^2.3.1",
@@ -31023,44 +35987,16 @@
         "react": "^17.0.2"
       }
     },
-    "plugins/plotly-express/src/js/node_modules/@deephaven/chart": {
-      "version": "0.62.0",
-      "resolved": "https://registry.npmjs.org/@deephaven/chart/-/chart-0.62.0.tgz",
-      "integrity": "sha512-zakQjG0V+QYdHsr01ThQS2ffhaCnF2a9GtlUDhw43qYfHeEiC2IkkinizY2pYgSJf2CPLNe7ibiIBflifQSBMQ==",
-      "dependencies": {
-        "@deephaven/components": "^0.62.0",
-        "@deephaven/icons": "^0.62.0",
-        "@deephaven/jsapi-types": "^0.62.0",
-        "@deephaven/jsapi-utils": "^0.62.0",
-        "@deephaven/log": "^0.62.0",
-        "@deephaven/react-hooks": "^0.62.0",
-        "@deephaven/utils": "^0.62.0",
-        "deep-equal": "^2.0.5",
-        "lodash.debounce": "^4.0.8",
-        "lodash.set": "^4.3.2",
-        "memoize-one": "^5.1.1",
-        "memoizee": "^0.4.15",
-        "plotly.js": "^2.18.2",
-        "prop-types": "^15.7.2",
-        "react-plotly.js": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "peerDependencies": {
-        "react": "^17.x"
-      }
-    },
     "plugins/plotly-express/src/js/node_modules/@deephaven/components": {
-      "version": "0.62.0",
-      "resolved": "https://registry.npmjs.org/@deephaven/components/-/components-0.62.0.tgz",
-      "integrity": "sha512-VKHZgsOO/VL1o9CS794eeRAa28lMQCLRrFbp3KgMBGvZVC68+rtuNpxWnc4zRZLZJxFiAxJbyJcleZS6QyW5Vg==",
+      "version": "0.64.0",
+      "resolved": "https://registry.npmjs.org/@deephaven/components/-/components-0.64.0.tgz",
+      "integrity": "sha512-L/G3r94eoHx7OzZM5DpbshGFgvmXyBi0SdmPKp872zfrWu/rcSTrsB2Mz3/QmJIBaO2wn8U5tw5pTKGoML8IfQ==",
       "dependencies": {
         "@adobe/react-spectrum": "^3.29.0",
-        "@deephaven/icons": "^0.62.0",
-        "@deephaven/log": "^0.62.0",
-        "@deephaven/react-hooks": "^0.62.0",
-        "@deephaven/utils": "^0.62.0",
+        "@deephaven/icons": "^0.64.0",
+        "@deephaven/log": "^0.64.0",
+        "@deephaven/react-hooks": "^0.64.0",
+        "@deephaven/utils": "^0.64.0",
         "@fortawesome/fontawesome-svg-core": "^6.2.1",
         "@fortawesome/react-fontawesome": "^0.2.0",
         "@react-spectrum/theme-default": "^3.5.1",
@@ -31087,53 +36023,17 @@
         "react-dom": "^17.x"
       }
     },
-    "plugins/plotly-express/src/js/node_modules/@deephaven/console": {
-      "version": "0.62.0",
-      "resolved": "https://registry.npmjs.org/@deephaven/console/-/console-0.62.0.tgz",
-      "integrity": "sha512-9jDywMHxiNpUjMMXQhQwI6vwnhEseG1Jf+RreZuTKVFJ4VTmhRg/xG14Bd6p/D6ichVQ4jGtMSLHKmYFYZ9HZg==",
-      "dependencies": {
-        "@deephaven/chart": "^0.62.0",
-        "@deephaven/components": "^0.62.0",
-        "@deephaven/icons": "^0.62.0",
-        "@deephaven/jsapi-bootstrap": "^0.62.0",
-        "@deephaven/jsapi-types": "^0.62.0",
-        "@deephaven/log": "^0.62.0",
-        "@deephaven/react-hooks": "^0.62.0",
-        "@deephaven/storage": "^0.62.0",
-        "@deephaven/utils": "^0.62.0",
-        "@fortawesome/react-fontawesome": "^0.2.0",
-        "classnames": "^2.3.1",
-        "linkifyjs": "^4.1.0",
-        "lodash.debounce": "^4.0.8",
-        "lodash.throttle": "^4.1.1",
-        "memoize-one": "^5.1.1",
-        "memoizee": "^0.4.15",
-        "monaco-editor": "^0.41.0",
-        "papaparse": "5.3.2",
-        "popper.js": "^1.16.1",
-        "prop-types": "^15.7.2",
-        "shell-quote": "^1.7.2",
-        "shortid": "^2.2.16"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "peerDependencies": {
-        "react": "^17.x",
-        "react-dom": "^17.x"
-      }
-    },
     "plugins/plotly-express/src/js/node_modules/@deephaven/dashboard": {
-      "version": "0.62.0",
-      "resolved": "https://registry.npmjs.org/@deephaven/dashboard/-/dashboard-0.62.0.tgz",
-      "integrity": "sha512-tBrpe52cl+UK2jtGGz7lIAJdxNm1givhquz4JKEBDJ/k8rqWwucXsxLgJ22nGASzct14xBk2Gb5IeuH/swkUDg==",
+      "version": "0.64.0",
+      "resolved": "https://registry.npmjs.org/@deephaven/dashboard/-/dashboard-0.64.0.tgz",
+      "integrity": "sha512-/8jd2XjSLzm8DP9dCIZD9I+cF5W9qAvxoXT7x4FQ7oUPP8Mog3FHSQSD/xB+6SHlzJTf7YhdDqdCEf1kPLa7IQ==",
       "dependencies": {
-        "@deephaven/components": "^0.62.0",
-        "@deephaven/golden-layout": "^0.62.0",
-        "@deephaven/log": "^0.62.0",
-        "@deephaven/react-hooks": "^0.62.0",
-        "@deephaven/redux": "^0.62.0",
-        "@deephaven/utils": "^0.62.0",
+        "@deephaven/components": "^0.64.0",
+        "@deephaven/golden-layout": "^0.64.0",
+        "@deephaven/log": "^0.64.0",
+        "@deephaven/react-hooks": "^0.64.0",
+        "@deephaven/redux": "^0.64.0",
+        "@deephaven/utils": "^0.64.0",
         "deep-equal": "^2.0.5",
         "lodash.ismatch": "^4.1.1",
         "lodash.throttle": "^4.1.1",
@@ -31150,93 +36050,12 @@
         "react-redux": "^7.2.4"
       }
     },
-    "plugins/plotly-express/src/js/node_modules/@deephaven/dashboard-core-plugins": {
-      "version": "0.62.0",
-      "resolved": "https://registry.npmjs.org/@deephaven/dashboard-core-plugins/-/dashboard-core-plugins-0.62.0.tgz",
-      "integrity": "sha512-c5pULTIPABzEJJSZRPBnCmt6OKxt9Vcy4riI0WX7wj+ZDvfo+Sg59ErBpSoY3bHgDsUzV28bmh2Vn+RBQNN8vQ==",
-      "dependencies": {
-        "@deephaven/chart": "^0.62.0",
-        "@deephaven/components": "^0.62.0",
-        "@deephaven/console": "^0.62.0",
-        "@deephaven/dashboard": "^0.62.0",
-        "@deephaven/file-explorer": "^0.62.0",
-        "@deephaven/filters": "^0.62.0",
-        "@deephaven/golden-layout": "^0.62.0",
-        "@deephaven/grid": "^0.62.0",
-        "@deephaven/icons": "^0.62.0",
-        "@deephaven/iris-grid": "^0.62.0",
-        "@deephaven/jsapi-bootstrap": "^0.62.0",
-        "@deephaven/jsapi-components": "^0.62.0",
-        "@deephaven/jsapi-types": "^0.62.0",
-        "@deephaven/jsapi-utils": "^0.62.0",
-        "@deephaven/log": "^0.62.0",
-        "@deephaven/plugin": "^0.62.0",
-        "@deephaven/react-hooks": "^0.62.0",
-        "@deephaven/redux": "^0.62.0",
-        "@deephaven/storage": "^0.62.0",
-        "@deephaven/utils": "^0.62.0",
-        "@fortawesome/react-fontawesome": "^0.2.0",
-        "classnames": "^2.3.1",
-        "deep-equal": "^2.0.5",
-        "lodash.clamp": "^4.0.3",
-        "lodash.debounce": "^4.0.8",
-        "lodash.throttle": "^4.1.1",
-        "memoize-one": "^5.1.1",
-        "memoizee": "^0.4.15",
-        "prop-types": "^15.7.2",
-        "react-markdown": "^6.0.2",
-        "react-transition-group": "^4.4.2",
-        "redux": "^4.2.0",
-        "redux-thunk": "^2.4.1",
-        "remark-gfm": "1.0.0",
-        "shortid": "^2.2.16"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "peerDependencies": {
-        "react": "^17.0.0",
-        "react-dom": "^17.0.0",
-        "react-redux": "^7.2.4"
-      }
-    },
-    "plugins/plotly-express/src/js/node_modules/@deephaven/file-explorer": {
-      "version": "0.62.0",
-      "resolved": "https://registry.npmjs.org/@deephaven/file-explorer/-/file-explorer-0.62.0.tgz",
-      "integrity": "sha512-pc6cH34DNkRxeWgy2ofGv/HUIGpI57LWLxVlnPqX7El/Q+Ma3cSBqj1sQH0uz5uNwP5WHv8q0L32JrJXJef0/Q==",
-      "dependencies": {
-        "@deephaven/components": "^0.62.0",
-        "@deephaven/icons": "^0.62.0",
-        "@deephaven/log": "^0.62.0",
-        "@deephaven/storage": "^0.62.0",
-        "@deephaven/utils": "^0.62.0",
-        "@fortawesome/fontawesome-svg-core": "^6.2.1",
-        "@fortawesome/react-fontawesome": "^0.2.0",
-        "classnames": "^2.3.1",
-        "lodash.throttle": "^4.1.1",
-        "prop-types": "^15.7.2"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "peerDependencies": {
-        "react": "^17.0.0"
-      }
-    },
-    "plugins/plotly-express/src/js/node_modules/@deephaven/filters": {
-      "version": "0.62.0",
-      "resolved": "https://registry.npmjs.org/@deephaven/filters/-/filters-0.62.0.tgz",
-      "integrity": "sha512-WTa3z250SRoh8xYmL3gdfddPOwqZBj95sVKaj3LBGGepcTO0Me3vCp9nODl8MyUBaOGBsCXIsrnWX6DFjkiGLQ==",
-      "engines": {
-        "node": ">=16"
-      }
-    },
     "plugins/plotly-express/src/js/node_modules/@deephaven/golden-layout": {
-      "version": "0.62.0",
-      "resolved": "https://registry.npmjs.org/@deephaven/golden-layout/-/golden-layout-0.62.0.tgz",
-      "integrity": "sha512-eeXz4GHm3JO8S8GNr5SGrdoeyuktwsH8cFwDy5V3WOVut1QwGVkPiTNb63Lt7F55rdLeuOHVdsXDYNDnDUcZtQ==",
+      "version": "0.64.0",
+      "resolved": "https://registry.npmjs.org/@deephaven/golden-layout/-/golden-layout-0.64.0.tgz",
+      "integrity": "sha512-MP5H8EvhdVEJzJKDPEp5xO1kBjqbv8hg/PMkR7EcFJJjxvTcJXcx24prfqBDeHVHbcWzDce5HeI56j6I93iFwQ==",
       "dependencies": {
-        "@deephaven/components": "^0.62.0",
+        "@deephaven/components": "^0.64.0",
         "jquery": "^3.6.0"
       },
       "peerDependencies": {
@@ -31244,116 +36063,15 @@
         "react-dom": "^17.x"
       }
     },
-    "plugins/plotly-express/src/js/node_modules/@deephaven/grid": {
-      "version": "0.62.0",
-      "resolved": "https://registry.npmjs.org/@deephaven/grid/-/grid-0.62.0.tgz",
-      "integrity": "sha512-rqCfJUtu83ApSSBJPOFx6bUyZG+5PMb+CGx74xg8QQ1OO61whfNOW5+A1DWRPnpK3GdOqmu+KMH39KPCXKVLTg==",
-      "dependencies": {
-        "@deephaven/utils": "^0.62.0",
-        "classnames": "^2.3.1",
-        "color-convert": "^2.0.1",
-        "event-target-shim": "^6.0.2",
-        "linkifyjs": "^4.1.0",
-        "lodash.clamp": "^4.0.3",
-        "memoize-one": "^5.1.1",
-        "memoizee": "^0.4.15",
-        "prop-types": "^15.7.2"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "peerDependencies": {
-        "react": "^17.x"
-      }
-    },
-    "plugins/plotly-express/src/js/node_modules/@deephaven/icons": {
-      "version": "0.62.0",
-      "resolved": "https://registry.npmjs.org/@deephaven/icons/-/icons-0.62.0.tgz",
-      "integrity": "sha512-KQUftXbKj5Oww+Fxjto+wDcr8sFUP1ghhl6ZlynfbIx7KJg6QM6LDwyHIfMv+RX1MQID+i9gcGLnPfBYak7d6A==",
-      "dependencies": {
-        "@fortawesome/fontawesome-common-types": "^6.1.1"
-      },
-      "peerDependencies": {
-        "@fortawesome/fontawesome-svg-core": "^6.2.1",
-        "@fortawesome/react-fontawesome": "^0.2.0"
-      }
-    },
-    "plugins/plotly-express/src/js/node_modules/@deephaven/iris-grid": {
-      "version": "0.62.0",
-      "resolved": "https://registry.npmjs.org/@deephaven/iris-grid/-/iris-grid-0.62.0.tgz",
-      "integrity": "sha512-LkEbiCEE7MlBC0coaA6gw0tTG77+sV2FDmmK4MuTf0R6PE+EwXCtRdRPrknbBq4DsZynAsWRKB5PIBszQdt3Cw==",
-      "dependencies": {
-        "@deephaven/components": "^0.62.0",
-        "@deephaven/console": "^0.62.0",
-        "@deephaven/filters": "^0.62.0",
-        "@deephaven/grid": "^0.62.0",
-        "@deephaven/icons": "^0.62.0",
-        "@deephaven/jsapi-components": "^0.62.0",
-        "@deephaven/jsapi-types": "^0.62.0",
-        "@deephaven/jsapi-utils": "^0.62.0",
-        "@deephaven/log": "^0.62.0",
-        "@deephaven/react-hooks": "^0.62.0",
-        "@deephaven/storage": "^0.62.0",
-        "@deephaven/utils": "^0.62.0",
-        "@dnd-kit/core": "^6.0.5",
-        "@dnd-kit/sortable": "^7.0.0",
-        "@dnd-kit/utilities": "^3.2.0",
-        "@fortawesome/react-fontawesome": "^0.2.0",
-        "classnames": "^2.3.1",
-        "deep-equal": "^2.0.5",
-        "lodash.clamp": "^4.0.3",
-        "lodash.debounce": "^4.0.8",
-        "lodash.throttle": "^4.1.1",
-        "memoize-one": "^5.1.1",
-        "memoizee": "^0.4.15",
-        "monaco-editor": "^0.41.0",
-        "prop-types": "^15.7.2",
-        "react-beautiful-dnd": "^13.1.0",
-        "react-transition-group": "^4.4.2",
-        "shortid": "^2.2.16"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "react": "^17.x",
-        "react-dom": "^17.x"
-      }
-    },
     "plugins/plotly-express/src/js/node_modules/@deephaven/jsapi-bootstrap": {
-      "version": "0.62.0",
-      "resolved": "https://registry.npmjs.org/@deephaven/jsapi-bootstrap/-/jsapi-bootstrap-0.62.0.tgz",
-      "integrity": "sha512-LjXAn2nIyjiIyV7zsjAp921IPrknori6Yzh3RhgqTh8fWLF2x8RNWFpk7AGF/WKfzDJbMrpQ36u3B79PecmTaw==",
+      "version": "0.64.0",
+      "resolved": "https://registry.npmjs.org/@deephaven/jsapi-bootstrap/-/jsapi-bootstrap-0.64.0.tgz",
+      "integrity": "sha512-EGTYR1koWlG0nebD/7/1vCnA/McJqFCjIf+uL8y/2D945WMED3CalM3EwCLmXkYlQep0wtm9KgFyIhwenlwaCQ==",
       "dependencies": {
-        "@deephaven/components": "^0.62.0",
-        "@deephaven/jsapi-types": "^0.62.0",
-        "@deephaven/log": "^0.62.0",
-        "@deephaven/react-hooks": "^0.62.0"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "peerDependencies": {
-        "react": "^17.x"
-      }
-    },
-    "plugins/plotly-express/src/js/node_modules/@deephaven/jsapi-components": {
-      "version": "0.62.0",
-      "resolved": "https://registry.npmjs.org/@deephaven/jsapi-components/-/jsapi-components-0.62.0.tgz",
-      "integrity": "sha512-S1zouiD9Imd6g+UsSmrRRykA3IbHw7LLWxoG26sA6ITuNCXw76vpM++mPWsHkAau3WQNxI9QVEUuhHEWkrnK+g==",
-      "dependencies": {
-        "@deephaven/components": "^0.62.0",
-        "@deephaven/jsapi-bootstrap": "^0.62.0",
-        "@deephaven/jsapi-types": "^0.62.0",
-        "@deephaven/jsapi-utils": "^0.62.0",
-        "@deephaven/log": "^0.62.0",
-        "@deephaven/react-hooks": "^0.62.0",
-        "@deephaven/utils": "^0.62.0",
-        "@types/js-cookie": "^3.0.3",
-        "classnames": "^2.3.2",
-        "js-cookie": "^3.0.5",
-        "lodash.debounce": "^4.0.8",
-        "prop-types": "^15.8.1"
+        "@deephaven/components": "^0.64.0",
+        "@deephaven/jsapi-types": "^0.64.0",
+        "@deephaven/log": "^0.64.0",
+        "@deephaven/react-hooks": "^0.64.0"
       },
       "engines": {
         "node": ">=16"
@@ -31363,22 +36081,22 @@
       }
     },
     "plugins/plotly-express/src/js/node_modules/@deephaven/jsapi-types": {
-      "version": "0.62.0",
-      "resolved": "https://registry.npmjs.org/@deephaven/jsapi-types/-/jsapi-types-0.62.0.tgz",
-      "integrity": "sha512-5R/SdTsID37S+tn+l62xOeecSccmnhJtn0/+VOP1taPAZGRcOak36gVJnEos/4hJruiJK1Dri3v9M8P/GfLn8g==",
+      "version": "0.64.0",
+      "resolved": "https://registry.npmjs.org/@deephaven/jsapi-types/-/jsapi-types-0.64.0.tgz",
+      "integrity": "sha512-8e1YzqRPtRg0bhqUC4R3nZ9ICE/3ITRaLgFOmw8yjtGnp+VWG+RvYp/5EELIizrklfUkuWv/+Z5uxMbQYQNQRQ==",
       "engines": {
         "node": ">=16"
       }
     },
     "plugins/plotly-express/src/js/node_modules/@deephaven/jsapi-utils": {
-      "version": "0.62.0",
-      "resolved": "https://registry.npmjs.org/@deephaven/jsapi-utils/-/jsapi-utils-0.62.0.tgz",
-      "integrity": "sha512-yWAk+zo2DOViROdpWRmA56xDwZotskIgyJCSO+9wFNxIo2YMUJNydtkB0vLWxXj/+lWWo0qTnbbDD+wNFoFTtg==",
+      "version": "0.64.0",
+      "resolved": "https://registry.npmjs.org/@deephaven/jsapi-utils/-/jsapi-utils-0.64.0.tgz",
+      "integrity": "sha512-U+cCICH8hcehbwqMlgG5+sGS3bcvm4GiY0SB+N15M3spLU3iAbWB5pMYo1lv8hf20TTnIYsJjF52MNp3R+F2FQ==",
       "dependencies": {
-        "@deephaven/filters": "^0.62.0",
-        "@deephaven/jsapi-types": "^0.62.0",
-        "@deephaven/log": "^0.62.0",
-        "@deephaven/utils": "^0.62.0",
+        "@deephaven/filters": "^0.64.0",
+        "@deephaven/jsapi-types": "^0.64.0",
+        "@deephaven/log": "^0.64.0",
+        "@deephaven/utils": "^0.64.0",
         "lodash.clamp": "^4.0.3",
         "shortid": "^2.2.16"
       },
@@ -31387,9 +36105,9 @@
       }
     },
     "plugins/plotly-express/src/js/node_modules/@deephaven/log": {
-      "version": "0.62.0",
-      "resolved": "https://registry.npmjs.org/@deephaven/log/-/log-0.62.0.tgz",
-      "integrity": "sha512-k3CDUJ21u1MzEb/C15qQCGKkXuVzO4Pc3KUTHSYMCyRDyskKbpcyQM88rYiQKFtp2Igyb6mvAdKIj7uubPc8Aw==",
+      "version": "0.64.0",
+      "resolved": "https://registry.npmjs.org/@deephaven/log/-/log-0.64.0.tgz",
+      "integrity": "sha512-E2/gUb/lfFIGxM/bm0Wimpu+EUVY1xNubItiedMKDEp/dfmVKMVng6XdF2pPw73kaeGAs7NoCbdnWnXdns5QdA==",
       "dependencies": {
         "event-target-shim": "^6.0.2"
       },
@@ -31397,55 +36115,15 @@
         "node": ">=16"
       }
     },
-    "plugins/plotly-express/src/js/node_modules/@deephaven/plugin": {
-      "version": "0.62.0",
-      "resolved": "https://registry.npmjs.org/@deephaven/plugin/-/plugin-0.62.0.tgz",
-      "integrity": "sha512-IokazAXbWLoITsAlnK+VM3HXtL5zpjH1DWY0mETpJwlMP6kAolhbc/UfDC2bRFYlQzTTHEPjVPVtRskse4JRAA==",
-      "dependencies": {
-        "@deephaven/components": "^0.62.0",
-        "@deephaven/golden-layout": "^0.62.0",
-        "@deephaven/icons": "^0.62.0",
-        "@deephaven/iris-grid": "^0.62.0",
-        "@deephaven/jsapi-types": "^0.62.0",
-        "@deephaven/log": "^0.62.0",
-        "@deephaven/react-hooks": "^0.62.0",
-        "@fortawesome/fontawesome-common-types": "^6.1.1",
-        "@fortawesome/react-fontawesome": "^0.2.0"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "peerDependencies": {
-        "react": "^17.x"
-      }
-    },
-    "plugins/plotly-express/src/js/node_modules/@deephaven/react-hooks": {
-      "version": "0.62.0",
-      "resolved": "https://registry.npmjs.org/@deephaven/react-hooks/-/react-hooks-0.62.0.tgz",
-      "integrity": "sha512-jlCqhSWa9V/jyfynZjPc+WlbQQAnhIilpQvI7bdU9q4fTRDfQvd0nSqr0sA0xODgGq8kBgz+6yzZ9yVWsg7IIA==",
-      "dependencies": {
-        "@adobe/react-spectrum": "^3.29.0",
-        "@deephaven/log": "^0.62.0",
-        "@deephaven/utils": "^0.62.0",
-        "lodash.debounce": "^4.0.8",
-        "shortid": "^2.2.16"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "peerDependencies": {
-        "react": "^17.x"
-      }
-    },
     "plugins/plotly-express/src/js/node_modules/@deephaven/redux": {
-      "version": "0.62.0",
-      "resolved": "https://registry.npmjs.org/@deephaven/redux/-/redux-0.62.0.tgz",
-      "integrity": "sha512-vmbSAKymKrPlgo3NJ8S/fl/ifjBv3R9pC0Ms/1HqsfNOftXKVlUKSRv/crZPcNWoLsD7fSufPs2lLVQijgXvjg==",
+      "version": "0.64.0",
+      "resolved": "https://registry.npmjs.org/@deephaven/redux/-/redux-0.64.0.tgz",
+      "integrity": "sha512-mnBMzJCUhBKDnA7yJGY49lJickgqDGb4ck2FpQEUtpzSsquOmjtz4glxBOgaNN3vLbm1bfXJyKUqkT08Hjknfw==",
       "dependencies": {
-        "@deephaven/jsapi-types": "^0.62.0",
-        "@deephaven/jsapi-utils": "^0.62.0",
-        "@deephaven/log": "^0.62.0",
-        "@deephaven/plugin": "^0.62.0",
+        "@deephaven/jsapi-types": "^0.64.0",
+        "@deephaven/jsapi-utils": "^0.64.0",
+        "@deephaven/log": "^0.64.0",
+        "@deephaven/plugin": "^0.64.0",
         "deep-equal": "^2.0.5",
         "redux-thunk": "2.4.1"
       },
@@ -31456,45 +36134,13 @@
         "redux": "^4.2.0"
       }
     },
-    "plugins/plotly-express/src/js/node_modules/@deephaven/storage": {
-      "version": "0.62.0",
-      "resolved": "https://registry.npmjs.org/@deephaven/storage/-/storage-0.62.0.tgz",
-      "integrity": "sha512-4ALHUPLTkNxmI3rxtjQ46631SIMQZlCI4lwamjQufg06f/KNPOkS2VIp2ZRoyiHhha0pnGADaOWqB6bAdKMMFA==",
-      "dependencies": {
-        "@deephaven/filters": "^0.62.0",
-        "@deephaven/log": "^0.62.0",
-        "lodash.throttle": "^4.1.1"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "peerDependencies": {
-        "react": "^17.x"
-      }
-    },
     "plugins/plotly-express/src/js/node_modules/@deephaven/utils": {
-      "version": "0.62.0",
-      "resolved": "https://registry.npmjs.org/@deephaven/utils/-/utils-0.62.0.tgz",
-      "integrity": "sha512-faAhWYpMBSXNVD9hw9VP88pIbNkcPqQkodTdSEitc5MguYg65pP2a63ylYkR0xCgWM5jViy797LY1w3c8ZGgIA==",
+      "version": "0.64.0",
+      "resolved": "https://registry.npmjs.org/@deephaven/utils/-/utils-0.64.0.tgz",
+      "integrity": "sha512-lt9cXEw0j2KMmUvR/+jmrpmWihrkYxNmhClW778WLFf0oi6Y4V/hsJxiNz+QvFvNbg3HqU6ZBMPHOtCNjKe7bQ==",
       "engines": {
         "node": ">=16"
       }
-    },
-    "plugins/plotly-express/src/js/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "plugins/plotly-express/src/js/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "plugins/plotly-express/src/js/node_modules/event-target-shim": {
       "version": "6.0.2",
@@ -33677,6 +38323,95 @@
         "babel-plugin-transform-rename-import": "^2.3.0"
       }
     },
+    "@deephaven/chart": {
+      "version": "0.64.0",
+      "resolved": "https://registry.npmjs.org/@deephaven/chart/-/chart-0.64.0.tgz",
+      "integrity": "sha512-mlwSBSA5BsckUf/6hULyW0MWmWXqfgB17MaI2f0Kmcdzmw2By6zWSkqM1vB/esKYOLhKkofoI5NhymeryS+uDg==",
+      "requires": {
+        "@deephaven/components": "^0.64.0",
+        "@deephaven/icons": "^0.64.0",
+        "@deephaven/jsapi-types": "^0.64.0",
+        "@deephaven/jsapi-utils": "^0.64.0",
+        "@deephaven/log": "^0.64.0",
+        "@deephaven/react-hooks": "^0.64.0",
+        "@deephaven/utils": "^0.64.0",
+        "deep-equal": "^2.0.5",
+        "lodash.debounce": "^4.0.8",
+        "lodash.set": "^4.3.2",
+        "memoize-one": "^5.1.1",
+        "memoizee": "^0.4.15",
+        "plotly.js": "^2.18.2",
+        "prop-types": "^15.7.2",
+        "react-plotly.js": "^2.6.0"
+      },
+      "dependencies": {
+        "@deephaven/components": {
+          "version": "0.64.0",
+          "resolved": "https://registry.npmjs.org/@deephaven/components/-/components-0.64.0.tgz",
+          "integrity": "sha512-L/G3r94eoHx7OzZM5DpbshGFgvmXyBi0SdmPKp872zfrWu/rcSTrsB2Mz3/QmJIBaO2wn8U5tw5pTKGoML8IfQ==",
+          "requires": {
+            "@adobe/react-spectrum": "^3.29.0",
+            "@deephaven/icons": "^0.64.0",
+            "@deephaven/log": "^0.64.0",
+            "@deephaven/react-hooks": "^0.64.0",
+            "@deephaven/utils": "^0.64.0",
+            "@fortawesome/fontawesome-svg-core": "^6.2.1",
+            "@fortawesome/react-fontawesome": "^0.2.0",
+            "@react-spectrum/theme-default": "^3.5.1",
+            "bootstrap": "4.6.2",
+            "classnames": "^2.3.1",
+            "event-target-shim": "^6.0.2",
+            "lodash.clamp": "^4.0.3",
+            "lodash.debounce": "^4.0.8",
+            "lodash.flatten": "^4.4.0",
+            "memoizee": "^0.4.15",
+            "popper.js": "^1.16.1",
+            "prop-types": "^15.7.2",
+            "react-beautiful-dnd": "^13.1.0",
+            "react-transition-group": "^4.4.2",
+            "react-virtualized-auto-sizer": "1.0.6",
+            "react-window": "^1.8.6",
+            "shortid": "^2.2.16"
+          }
+        },
+        "@deephaven/jsapi-types": {
+          "version": "0.64.0",
+          "resolved": "https://registry.npmjs.org/@deephaven/jsapi-types/-/jsapi-types-0.64.0.tgz",
+          "integrity": "sha512-8e1YzqRPtRg0bhqUC4R3nZ9ICE/3ITRaLgFOmw8yjtGnp+VWG+RvYp/5EELIizrklfUkuWv/+Z5uxMbQYQNQRQ=="
+        },
+        "@deephaven/jsapi-utils": {
+          "version": "0.64.0",
+          "resolved": "https://registry.npmjs.org/@deephaven/jsapi-utils/-/jsapi-utils-0.64.0.tgz",
+          "integrity": "sha512-U+cCICH8hcehbwqMlgG5+sGS3bcvm4GiY0SB+N15M3spLU3iAbWB5pMYo1lv8hf20TTnIYsJjF52MNp3R+F2FQ==",
+          "requires": {
+            "@deephaven/filters": "^0.64.0",
+            "@deephaven/jsapi-types": "^0.64.0",
+            "@deephaven/log": "^0.64.0",
+            "@deephaven/utils": "^0.64.0",
+            "lodash.clamp": "^4.0.3",
+            "shortid": "^2.2.16"
+          }
+        },
+        "@deephaven/log": {
+          "version": "0.64.0",
+          "resolved": "https://registry.npmjs.org/@deephaven/log/-/log-0.64.0.tgz",
+          "integrity": "sha512-E2/gUb/lfFIGxM/bm0Wimpu+EUVY1xNubItiedMKDEp/dfmVKMVng6XdF2pPw73kaeGAs7NoCbdnWnXdns5QdA==",
+          "requires": {
+            "event-target-shim": "^6.0.2"
+          }
+        },
+        "@deephaven/utils": {
+          "version": "0.64.0",
+          "resolved": "https://registry.npmjs.org/@deephaven/utils/-/utils-0.64.0.tgz",
+          "integrity": "sha512-lt9cXEw0j2KMmUvR/+jmrpmWihrkYxNmhClW778WLFf0oi6Y4V/hsJxiNz+QvFvNbg3HqU6ZBMPHOtCNjKe7bQ=="
+        },
+        "event-target-shim": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-6.0.2.tgz",
+          "integrity": "sha512-8q3LsZjRezbFZ2PN+uP+Q7pnHUMmAOziU2vA2OwoFaKIXxlxl38IylhSSgUorWu/rf4er67w0ikBqjBFk/pomA=="
+        }
+      }
+    },
     "@deephaven/components": {
       "version": "0.40.1",
       "resolved": "https://registry.npmjs.org/@deephaven/components/-/components-0.40.1.tgz",
@@ -33730,6 +38465,100 @@
         }
       }
     },
+    "@deephaven/console": {
+      "version": "0.64.0",
+      "resolved": "https://registry.npmjs.org/@deephaven/console/-/console-0.64.0.tgz",
+      "integrity": "sha512-2uOMS+JruIFtJXQww19a8I9GoGM7rF/rNowF9Dv2xXNF85TR+TXineo39yw8U6n/OfLUonhS90LIShlo4USU1w==",
+      "requires": {
+        "@deephaven/chart": "^0.64.0",
+        "@deephaven/components": "^0.64.0",
+        "@deephaven/icons": "^0.64.0",
+        "@deephaven/jsapi-bootstrap": "^0.64.0",
+        "@deephaven/jsapi-types": "^0.64.0",
+        "@deephaven/log": "^0.64.0",
+        "@deephaven/react-hooks": "^0.64.0",
+        "@deephaven/storage": "^0.64.0",
+        "@deephaven/utils": "^0.64.0",
+        "@fortawesome/react-fontawesome": "^0.2.0",
+        "classnames": "^2.3.1",
+        "linkifyjs": "^4.1.0",
+        "lodash.debounce": "^4.0.8",
+        "lodash.throttle": "^4.1.1",
+        "memoize-one": "^5.1.1",
+        "memoizee": "^0.4.15",
+        "monaco-editor": "^0.41.0",
+        "papaparse": "5.3.2",
+        "popper.js": "^1.16.1",
+        "prop-types": "^15.7.2",
+        "shell-quote": "^1.7.2",
+        "shortid": "^2.2.16"
+      },
+      "dependencies": {
+        "@deephaven/components": {
+          "version": "0.64.0",
+          "resolved": "https://registry.npmjs.org/@deephaven/components/-/components-0.64.0.tgz",
+          "integrity": "sha512-L/G3r94eoHx7OzZM5DpbshGFgvmXyBi0SdmPKp872zfrWu/rcSTrsB2Mz3/QmJIBaO2wn8U5tw5pTKGoML8IfQ==",
+          "requires": {
+            "@adobe/react-spectrum": "^3.29.0",
+            "@deephaven/icons": "^0.64.0",
+            "@deephaven/log": "^0.64.0",
+            "@deephaven/react-hooks": "^0.64.0",
+            "@deephaven/utils": "^0.64.0",
+            "@fortawesome/fontawesome-svg-core": "^6.2.1",
+            "@fortawesome/react-fontawesome": "^0.2.0",
+            "@react-spectrum/theme-default": "^3.5.1",
+            "bootstrap": "4.6.2",
+            "classnames": "^2.3.1",
+            "event-target-shim": "^6.0.2",
+            "lodash.clamp": "^4.0.3",
+            "lodash.debounce": "^4.0.8",
+            "lodash.flatten": "^4.4.0",
+            "memoizee": "^0.4.15",
+            "popper.js": "^1.16.1",
+            "prop-types": "^15.7.2",
+            "react-beautiful-dnd": "^13.1.0",
+            "react-transition-group": "^4.4.2",
+            "react-virtualized-auto-sizer": "1.0.6",
+            "react-window": "^1.8.6",
+            "shortid": "^2.2.16"
+          }
+        },
+        "@deephaven/jsapi-bootstrap": {
+          "version": "0.64.0",
+          "resolved": "https://registry.npmjs.org/@deephaven/jsapi-bootstrap/-/jsapi-bootstrap-0.64.0.tgz",
+          "integrity": "sha512-EGTYR1koWlG0nebD/7/1vCnA/McJqFCjIf+uL8y/2D945WMED3CalM3EwCLmXkYlQep0wtm9KgFyIhwenlwaCQ==",
+          "requires": {
+            "@deephaven/components": "^0.64.0",
+            "@deephaven/jsapi-types": "^0.64.0",
+            "@deephaven/log": "^0.64.0",
+            "@deephaven/react-hooks": "^0.64.0"
+          }
+        },
+        "@deephaven/jsapi-types": {
+          "version": "0.64.0",
+          "resolved": "https://registry.npmjs.org/@deephaven/jsapi-types/-/jsapi-types-0.64.0.tgz",
+          "integrity": "sha512-8e1YzqRPtRg0bhqUC4R3nZ9ICE/3ITRaLgFOmw8yjtGnp+VWG+RvYp/5EELIizrklfUkuWv/+Z5uxMbQYQNQRQ=="
+        },
+        "@deephaven/log": {
+          "version": "0.64.0",
+          "resolved": "https://registry.npmjs.org/@deephaven/log/-/log-0.64.0.tgz",
+          "integrity": "sha512-E2/gUb/lfFIGxM/bm0Wimpu+EUVY1xNubItiedMKDEp/dfmVKMVng6XdF2pPw73kaeGAs7NoCbdnWnXdns5QdA==",
+          "requires": {
+            "event-target-shim": "^6.0.2"
+          }
+        },
+        "@deephaven/utils": {
+          "version": "0.64.0",
+          "resolved": "https://registry.npmjs.org/@deephaven/utils/-/utils-0.64.0.tgz",
+          "integrity": "sha512-lt9cXEw0j2KMmUvR/+jmrpmWihrkYxNmhClW778WLFf0oi6Y4V/hsJxiNz+QvFvNbg3HqU6ZBMPHOtCNjKe7bQ=="
+        },
+        "event-target-shim": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-6.0.2.tgz",
+          "integrity": "sha512-8q3LsZjRezbFZ2PN+uP+Q7pnHUMmAOziU2vA2OwoFaKIXxlxl38IylhSSgUorWu/rf4er67w0ikBqjBFk/pomA=="
+        }
+      }
+    },
     "@deephaven/dashboard": {
       "version": "0.40.4",
       "resolved": "https://registry.npmjs.org/@deephaven/dashboard/-/dashboard-0.40.4.tgz",
@@ -33761,6 +38590,1266 @@
         }
       }
     },
+    "@deephaven/dashboard-core-plugins": {
+      "version": "0.64.0",
+      "resolved": "https://registry.npmjs.org/@deephaven/dashboard-core-plugins/-/dashboard-core-plugins-0.64.0.tgz",
+      "integrity": "sha512-3YQ5ZvIR8OFetwB7+GGEnXxBlwRp+ow0I/918k+nlNyEGUDHIkTck4Ntvlj4ind1GKHZ/RpFOpY237cA75M34g==",
+      "requires": {
+        "@deephaven/chart": "^0.64.0",
+        "@deephaven/components": "^0.64.0",
+        "@deephaven/console": "^0.64.0",
+        "@deephaven/dashboard": "^0.64.0",
+        "@deephaven/file-explorer": "^0.64.0",
+        "@deephaven/filters": "^0.64.0",
+        "@deephaven/golden-layout": "^0.64.0",
+        "@deephaven/grid": "^0.64.0",
+        "@deephaven/icons": "^0.64.0",
+        "@deephaven/iris-grid": "^0.64.0",
+        "@deephaven/jsapi-bootstrap": "^0.64.0",
+        "@deephaven/jsapi-components": "^0.64.0",
+        "@deephaven/jsapi-types": "^0.64.0",
+        "@deephaven/jsapi-utils": "^0.64.0",
+        "@deephaven/log": "^0.64.0",
+        "@deephaven/plugin": "^0.64.0",
+        "@deephaven/react-hooks": "^0.64.0",
+        "@deephaven/redux": "^0.64.0",
+        "@deephaven/storage": "^0.64.0",
+        "@deephaven/utils": "^0.64.0",
+        "@fortawesome/react-fontawesome": "^0.2.0",
+        "classnames": "^2.3.1",
+        "deep-equal": "^2.0.5",
+        "lodash.clamp": "^4.0.3",
+        "lodash.debounce": "^4.0.8",
+        "lodash.throttle": "^4.1.1",
+        "memoize-one": "^5.1.1",
+        "memoizee": "^0.4.15",
+        "prop-types": "^15.7.2",
+        "react-markdown": "^8.0.7",
+        "react-transition-group": "^4.4.2",
+        "redux": "^4.2.0",
+        "redux-thunk": "^2.4.1",
+        "rehype-mathjax": "^4.0.3",
+        "remark-gfm": "^4.0.0",
+        "remark-math": "^5.1.1",
+        "shortid": "^2.2.16"
+      },
+      "dependencies": {
+        "@deephaven/components": {
+          "version": "0.64.0",
+          "resolved": "https://registry.npmjs.org/@deephaven/components/-/components-0.64.0.tgz",
+          "integrity": "sha512-L/G3r94eoHx7OzZM5DpbshGFgvmXyBi0SdmPKp872zfrWu/rcSTrsB2Mz3/QmJIBaO2wn8U5tw5pTKGoML8IfQ==",
+          "requires": {
+            "@adobe/react-spectrum": "^3.29.0",
+            "@deephaven/icons": "^0.64.0",
+            "@deephaven/log": "^0.64.0",
+            "@deephaven/react-hooks": "^0.64.0",
+            "@deephaven/utils": "^0.64.0",
+            "@fortawesome/fontawesome-svg-core": "^6.2.1",
+            "@fortawesome/react-fontawesome": "^0.2.0",
+            "@react-spectrum/theme-default": "^3.5.1",
+            "bootstrap": "4.6.2",
+            "classnames": "^2.3.1",
+            "event-target-shim": "^6.0.2",
+            "lodash.clamp": "^4.0.3",
+            "lodash.debounce": "^4.0.8",
+            "lodash.flatten": "^4.4.0",
+            "memoizee": "^0.4.15",
+            "popper.js": "^1.16.1",
+            "prop-types": "^15.7.2",
+            "react-beautiful-dnd": "^13.1.0",
+            "react-transition-group": "^4.4.2",
+            "react-virtualized-auto-sizer": "1.0.6",
+            "react-window": "^1.8.6",
+            "shortid": "^2.2.16"
+          }
+        },
+        "@deephaven/dashboard": {
+          "version": "0.64.0",
+          "resolved": "https://registry.npmjs.org/@deephaven/dashboard/-/dashboard-0.64.0.tgz",
+          "integrity": "sha512-/8jd2XjSLzm8DP9dCIZD9I+cF5W9qAvxoXT7x4FQ7oUPP8Mog3FHSQSD/xB+6SHlzJTf7YhdDqdCEf1kPLa7IQ==",
+          "requires": {
+            "@deephaven/components": "^0.64.0",
+            "@deephaven/golden-layout": "^0.64.0",
+            "@deephaven/log": "^0.64.0",
+            "@deephaven/react-hooks": "^0.64.0",
+            "@deephaven/redux": "^0.64.0",
+            "@deephaven/utils": "^0.64.0",
+            "deep-equal": "^2.0.5",
+            "lodash.ismatch": "^4.1.1",
+            "lodash.throttle": "^4.1.1",
+            "prop-types": "^15.7.2",
+            "shortid": "^2.2.16"
+          }
+        },
+        "@deephaven/golden-layout": {
+          "version": "0.64.0",
+          "resolved": "https://registry.npmjs.org/@deephaven/golden-layout/-/golden-layout-0.64.0.tgz",
+          "integrity": "sha512-MP5H8EvhdVEJzJKDPEp5xO1kBjqbv8hg/PMkR7EcFJJjxvTcJXcx24prfqBDeHVHbcWzDce5HeI56j6I93iFwQ==",
+          "requires": {
+            "@deephaven/components": "^0.64.0",
+            "jquery": "^3.6.0"
+          }
+        },
+        "@deephaven/jsapi-bootstrap": {
+          "version": "0.64.0",
+          "resolved": "https://registry.npmjs.org/@deephaven/jsapi-bootstrap/-/jsapi-bootstrap-0.64.0.tgz",
+          "integrity": "sha512-EGTYR1koWlG0nebD/7/1vCnA/McJqFCjIf+uL8y/2D945WMED3CalM3EwCLmXkYlQep0wtm9KgFyIhwenlwaCQ==",
+          "requires": {
+            "@deephaven/components": "^0.64.0",
+            "@deephaven/jsapi-types": "^0.64.0",
+            "@deephaven/log": "^0.64.0",
+            "@deephaven/react-hooks": "^0.64.0"
+          }
+        },
+        "@deephaven/jsapi-components": {
+          "version": "0.64.0",
+          "resolved": "https://registry.npmjs.org/@deephaven/jsapi-components/-/jsapi-components-0.64.0.tgz",
+          "integrity": "sha512-2WeV8IbHbgwAXRIiLM7H2iXTmVd53UKiC9BSdFCynH59o/+CApbinthtS5/e8R7fF2m/DBIe8MrWpCQbPikI8Q==",
+          "requires": {
+            "@deephaven/components": "^0.64.0",
+            "@deephaven/jsapi-bootstrap": "^0.64.0",
+            "@deephaven/jsapi-types": "^0.64.0",
+            "@deephaven/jsapi-utils": "^0.64.0",
+            "@deephaven/log": "^0.64.0",
+            "@deephaven/react-hooks": "^0.64.0",
+            "@deephaven/utils": "^0.64.0",
+            "@types/js-cookie": "^3.0.3",
+            "classnames": "^2.3.2",
+            "js-cookie": "^3.0.5",
+            "lodash.debounce": "^4.0.8",
+            "prop-types": "^15.8.1"
+          }
+        },
+        "@deephaven/jsapi-types": {
+          "version": "0.64.0",
+          "resolved": "https://registry.npmjs.org/@deephaven/jsapi-types/-/jsapi-types-0.64.0.tgz",
+          "integrity": "sha512-8e1YzqRPtRg0bhqUC4R3nZ9ICE/3ITRaLgFOmw8yjtGnp+VWG+RvYp/5EELIizrklfUkuWv/+Z5uxMbQYQNQRQ=="
+        },
+        "@deephaven/jsapi-utils": {
+          "version": "0.64.0",
+          "resolved": "https://registry.npmjs.org/@deephaven/jsapi-utils/-/jsapi-utils-0.64.0.tgz",
+          "integrity": "sha512-U+cCICH8hcehbwqMlgG5+sGS3bcvm4GiY0SB+N15M3spLU3iAbWB5pMYo1lv8hf20TTnIYsJjF52MNp3R+F2FQ==",
+          "requires": {
+            "@deephaven/filters": "^0.64.0",
+            "@deephaven/jsapi-types": "^0.64.0",
+            "@deephaven/log": "^0.64.0",
+            "@deephaven/utils": "^0.64.0",
+            "lodash.clamp": "^4.0.3",
+            "shortid": "^2.2.16"
+          }
+        },
+        "@deephaven/log": {
+          "version": "0.64.0",
+          "resolved": "https://registry.npmjs.org/@deephaven/log/-/log-0.64.0.tgz",
+          "integrity": "sha512-E2/gUb/lfFIGxM/bm0Wimpu+EUVY1xNubItiedMKDEp/dfmVKMVng6XdF2pPw73kaeGAs7NoCbdnWnXdns5QdA==",
+          "requires": {
+            "event-target-shim": "^6.0.2"
+          }
+        },
+        "@deephaven/redux": {
+          "version": "0.64.0",
+          "resolved": "https://registry.npmjs.org/@deephaven/redux/-/redux-0.64.0.tgz",
+          "integrity": "sha512-mnBMzJCUhBKDnA7yJGY49lJickgqDGb4ck2FpQEUtpzSsquOmjtz4glxBOgaNN3vLbm1bfXJyKUqkT08Hjknfw==",
+          "requires": {
+            "@deephaven/jsapi-types": "^0.64.0",
+            "@deephaven/jsapi-utils": "^0.64.0",
+            "@deephaven/log": "^0.64.0",
+            "@deephaven/plugin": "^0.64.0",
+            "deep-equal": "^2.0.5",
+            "redux-thunk": "2.4.1"
+          }
+        },
+        "@deephaven/utils": {
+          "version": "0.64.0",
+          "resolved": "https://registry.npmjs.org/@deephaven/utils/-/utils-0.64.0.tgz",
+          "integrity": "sha512-lt9cXEw0j2KMmUvR/+jmrpmWihrkYxNmhClW778WLFf0oi6Y4V/hsJxiNz+QvFvNbg3HqU6ZBMPHOtCNjKe7bQ=="
+        },
+        "bail": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+          "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw=="
+        },
+        "ccount": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+          "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg=="
+        },
+        "comma-separated-tokens": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+          "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg=="
+        },
+        "escape-string-regexp": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+          "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="
+        },
+        "event-target-shim": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-6.0.2.tgz",
+          "integrity": "sha512-8q3LsZjRezbFZ2PN+uP+Q7pnHUMmAOziU2vA2OwoFaKIXxlxl38IylhSSgUorWu/rf4er67w0ikBqjBFk/pomA=="
+        },
+        "is-plain-obj": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+          "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg=="
+        },
+        "longest-streak": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+          "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g=="
+        },
+        "markdown-table": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.3.tgz",
+          "integrity": "sha512-Z1NL3Tb1M9wH4XESsCDEksWoKTdlUafKc4pt0GRwjUyXaCFZ+dc3g2erqB6zm3szA2IUSi7VnPI+o/9jnxh9hw=="
+        },
+        "mdast-util-definitions": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/mdast-util-definitions/-/mdast-util-definitions-5.1.2.tgz",
+          "integrity": "sha512-8SVPMuHqlPME/z3gqVwWY4zVXn8lqKv/pAhC57FuJ40ImXyBpmO5ukh98zB2v7Blql2FiHjHv9LVztSIqjY+MA==",
+          "requires": {
+            "@types/mdast": "^3.0.0",
+            "@types/unist": "^2.0.0",
+            "unist-util-visit": "^4.0.0"
+          }
+        },
+        "mdast-util-find-and-replace": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.1.tgz",
+          "integrity": "sha512-SG21kZHGC3XRTSUhtofZkBzZTJNM5ecCi0SK2IMKmSXR8vO3peL+kb1O0z7Zl83jKtutG4k5Wv/W7V3/YHvzPA==",
+          "requires": {
+            "@types/mdast": "^4.0.0",
+            "escape-string-regexp": "^5.0.0",
+            "unist-util-is": "^6.0.0",
+            "unist-util-visit-parents": "^6.0.0"
+          },
+          "dependencies": {
+            "@types/mdast": {
+              "version": "4.0.3",
+              "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.3.tgz",
+              "integrity": "sha512-LsjtqsyF+d2/yFOYaN22dHZI1Cpwkrj+g06G8+qtUKlhovPW89YhqSnfKtMbkgmEtYpH2gydRNULd6y8mciAFg==",
+              "requires": {
+                "@types/unist": "*"
+              }
+            }
+          }
+        },
+        "mdast-util-from-markdown": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.0.tgz",
+          "integrity": "sha512-n7MTOr/z+8NAX/wmhhDji8O3bRvPTV/U0oTCaZJkjhPSKTPhS3xufVhKGF8s1pJ7Ox4QgoIU7KHseh09S+9rTA==",
+          "requires": {
+            "@types/mdast": "^4.0.0",
+            "@types/unist": "^3.0.0",
+            "decode-named-character-reference": "^1.0.0",
+            "devlop": "^1.0.0",
+            "mdast-util-to-string": "^4.0.0",
+            "micromark": "^4.0.0",
+            "micromark-util-decode-numeric-character-reference": "^2.0.0",
+            "micromark-util-decode-string": "^2.0.0",
+            "micromark-util-normalize-identifier": "^2.0.0",
+            "micromark-util-symbol": "^2.0.0",
+            "micromark-util-types": "^2.0.0",
+            "unist-util-stringify-position": "^4.0.0"
+          },
+          "dependencies": {
+            "@types/mdast": {
+              "version": "4.0.3",
+              "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.3.tgz",
+              "integrity": "sha512-LsjtqsyF+d2/yFOYaN22dHZI1Cpwkrj+g06G8+qtUKlhovPW89YhqSnfKtMbkgmEtYpH2gydRNULd6y8mciAFg==",
+              "requires": {
+                "@types/unist": "*"
+              }
+            },
+            "@types/unist": {
+              "version": "3.0.2",
+              "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.2.tgz",
+              "integrity": "sha512-dqId9J8K/vGi5Zr7oo212BGii5m3q5Hxlkwy3WpYuKPklmBEvsbMYYyLxAQpSffdLl/gdW0XUpKWFvYmyoWCoQ=="
+            }
+          }
+        },
+        "mdast-util-gfm": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.0.0.tgz",
+          "integrity": "sha512-dgQEX5Amaq+DuUqf26jJqSK9qgixgd6rYDHAv4aTBuA92cTknZlKpPfa86Z/s8Dj8xsAQpFfBmPUHWJBWqS4Bw==",
+          "requires": {
+            "mdast-util-from-markdown": "^2.0.0",
+            "mdast-util-gfm-autolink-literal": "^2.0.0",
+            "mdast-util-gfm-footnote": "^2.0.0",
+            "mdast-util-gfm-strikethrough": "^2.0.0",
+            "mdast-util-gfm-table": "^2.0.0",
+            "mdast-util-gfm-task-list-item": "^2.0.0",
+            "mdast-util-to-markdown": "^2.0.0"
+          }
+        },
+        "mdast-util-gfm-autolink-literal": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.0.tgz",
+          "integrity": "sha512-FyzMsduZZHSc3i0Px3PQcBT4WJY/X/RCtEJKuybiC6sjPqLv7h1yqAkmILZtuxMSsUyaLUWNp71+vQH2zqp5cg==",
+          "requires": {
+            "@types/mdast": "^4.0.0",
+            "ccount": "^2.0.0",
+            "devlop": "^1.0.0",
+            "mdast-util-find-and-replace": "^3.0.0",
+            "micromark-util-character": "^2.0.0"
+          },
+          "dependencies": {
+            "@types/mdast": {
+              "version": "4.0.3",
+              "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.3.tgz",
+              "integrity": "sha512-LsjtqsyF+d2/yFOYaN22dHZI1Cpwkrj+g06G8+qtUKlhovPW89YhqSnfKtMbkgmEtYpH2gydRNULd6y8mciAFg==",
+              "requires": {
+                "@types/unist": "*"
+              }
+            }
+          }
+        },
+        "mdast-util-gfm-strikethrough": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
+          "integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
+          "requires": {
+            "@types/mdast": "^4.0.0",
+            "mdast-util-from-markdown": "^2.0.0",
+            "mdast-util-to-markdown": "^2.0.0"
+          },
+          "dependencies": {
+            "@types/mdast": {
+              "version": "4.0.3",
+              "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.3.tgz",
+              "integrity": "sha512-LsjtqsyF+d2/yFOYaN22dHZI1Cpwkrj+g06G8+qtUKlhovPW89YhqSnfKtMbkgmEtYpH2gydRNULd6y8mciAFg==",
+              "requires": {
+                "@types/unist": "*"
+              }
+            }
+          }
+        },
+        "mdast-util-gfm-table": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
+          "integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
+          "requires": {
+            "@types/mdast": "^4.0.0",
+            "devlop": "^1.0.0",
+            "markdown-table": "^3.0.0",
+            "mdast-util-from-markdown": "^2.0.0",
+            "mdast-util-to-markdown": "^2.0.0"
+          },
+          "dependencies": {
+            "@types/mdast": {
+              "version": "4.0.3",
+              "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.3.tgz",
+              "integrity": "sha512-LsjtqsyF+d2/yFOYaN22dHZI1Cpwkrj+g06G8+qtUKlhovPW89YhqSnfKtMbkgmEtYpH2gydRNULd6y8mciAFg==",
+              "requires": {
+                "@types/unist": "*"
+              }
+            }
+          }
+        },
+        "mdast-util-gfm-task-list-item": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
+          "integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
+          "requires": {
+            "@types/mdast": "^4.0.0",
+            "devlop": "^1.0.0",
+            "mdast-util-from-markdown": "^2.0.0",
+            "mdast-util-to-markdown": "^2.0.0"
+          },
+          "dependencies": {
+            "@types/mdast": {
+              "version": "4.0.3",
+              "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.3.tgz",
+              "integrity": "sha512-LsjtqsyF+d2/yFOYaN22dHZI1Cpwkrj+g06G8+qtUKlhovPW89YhqSnfKtMbkgmEtYpH2gydRNULd6y8mciAFg==",
+              "requires": {
+                "@types/unist": "*"
+              }
+            }
+          }
+        },
+        "mdast-util-to-hast": {
+          "version": "12.3.0",
+          "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-12.3.0.tgz",
+          "integrity": "sha512-pits93r8PhnIoU4Vy9bjW39M2jJ6/tdHyja9rrot9uujkN7UTU9SDnE6WNJz/IGyQk3XHX6yNNtrBH6cQzm8Hw==",
+          "requires": {
+            "@types/hast": "^2.0.0",
+            "@types/mdast": "^3.0.0",
+            "mdast-util-definitions": "^5.0.0",
+            "micromark-util-sanitize-uri": "^1.1.0",
+            "trim-lines": "^3.0.0",
+            "unist-util-generated": "^2.0.0",
+            "unist-util-position": "^4.0.0",
+            "unist-util-visit": "^4.0.0"
+          },
+          "dependencies": {
+            "micromark-util-character": {
+              "version": "1.2.0",
+              "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-1.2.0.tgz",
+              "integrity": "sha512-lXraTwcX3yH/vMDaFWCQJP1uIszLVebzUa3ZHdrgxr7KEU/9mL4mVgCpGbyhvNLNlauROiNUq7WN5u7ndbY6xg==",
+              "requires": {
+                "micromark-util-symbol": "^1.0.0",
+                "micromark-util-types": "^1.0.0"
+              }
+            },
+            "micromark-util-encode": {
+              "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-1.1.0.tgz",
+              "integrity": "sha512-EuEzTWSTAj9PA5GOAs992GzNh2dGQO52UvAbtSOMvXTxv3Criqb6IOzJUBCmEqrrXSblJIJBbFFv6zPxpreiJw=="
+            },
+            "micromark-util-sanitize-uri": {
+              "version": "1.2.0",
+              "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-1.2.0.tgz",
+              "integrity": "sha512-QO4GXv0XZfWey4pYFndLUKEAktKkG5kZTdUNaTAkzbuJxn2tNBOr+QtxR2XpWaMhbImT2dPzyLrPXLlPhph34A==",
+              "requires": {
+                "micromark-util-character": "^1.0.0",
+                "micromark-util-encode": "^1.0.0",
+                "micromark-util-symbol": "^1.0.0"
+              }
+            },
+            "micromark-util-symbol": {
+              "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-1.1.0.tgz",
+              "integrity": "sha512-uEjpEYY6KMs1g7QfJ2eX1SQEV+ZT4rUD3UcF6l57acZvLNK7PBZL+ty82Z1qhK1/yXIY4bdx04FKMgR0g4IAag=="
+            },
+            "micromark-util-types": {
+              "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-1.1.0.tgz",
+              "integrity": "sha512-ukRBgie8TIAcacscVHSiddHjO4k/q3pnedmzMQ4iwDcK0FtFCohKOlFbaOL/mPgfnPsL3C1ZyxJa4sbWrBl3jg=="
+            }
+          }
+        },
+        "mdast-util-to-markdown": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.0.tgz",
+          "integrity": "sha512-SR2VnIEdVNCJbP6y7kVTJgPLifdr8WEU440fQec7qHoHOUz/oJ2jmNRqdDQ3rbiStOXb2mCDGTuwsK5OPUgYlQ==",
+          "requires": {
+            "@types/mdast": "^4.0.0",
+            "@types/unist": "^3.0.0",
+            "longest-streak": "^3.0.0",
+            "mdast-util-phrasing": "^4.0.0",
+            "mdast-util-to-string": "^4.0.0",
+            "micromark-util-decode-string": "^2.0.0",
+            "unist-util-visit": "^5.0.0",
+            "zwitch": "^2.0.0"
+          },
+          "dependencies": {
+            "@types/mdast": {
+              "version": "4.0.3",
+              "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.3.tgz",
+              "integrity": "sha512-LsjtqsyF+d2/yFOYaN22dHZI1Cpwkrj+g06G8+qtUKlhovPW89YhqSnfKtMbkgmEtYpH2gydRNULd6y8mciAFg==",
+              "requires": {
+                "@types/unist": "*"
+              }
+            },
+            "@types/unist": {
+              "version": "3.0.2",
+              "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.2.tgz",
+              "integrity": "sha512-dqId9J8K/vGi5Zr7oo212BGii5m3q5Hxlkwy3WpYuKPklmBEvsbMYYyLxAQpSffdLl/gdW0XUpKWFvYmyoWCoQ=="
+            },
+            "unist-util-visit": {
+              "version": "5.0.0",
+              "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.0.0.tgz",
+              "integrity": "sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==",
+              "requires": {
+                "@types/unist": "^3.0.0",
+                "unist-util-is": "^6.0.0",
+                "unist-util-visit-parents": "^6.0.0"
+              }
+            }
+          }
+        },
+        "mdast-util-to-string": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+          "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+          "requires": {
+            "@types/mdast": "^4.0.0"
+          },
+          "dependencies": {
+            "@types/mdast": {
+              "version": "4.0.3",
+              "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.3.tgz",
+              "integrity": "sha512-LsjtqsyF+d2/yFOYaN22dHZI1Cpwkrj+g06G8+qtUKlhovPW89YhqSnfKtMbkgmEtYpH2gydRNULd6y8mciAFg==",
+              "requires": {
+                "@types/unist": "*"
+              }
+            }
+          }
+        },
+        "micromark": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.0.tgz",
+          "integrity": "sha512-o/sd0nMof8kYff+TqcDx3VSrgBTcZpSvYcAHIfHhv5VAuNmisCxjhx6YmxS8PFEpb9z5WKWKPdzf0jM23ro3RQ==",
+          "requires": {
+            "@types/debug": "^4.0.0",
+            "debug": "^4.0.0",
+            "decode-named-character-reference": "^1.0.0",
+            "devlop": "^1.0.0",
+            "micromark-core-commonmark": "^2.0.0",
+            "micromark-factory-space": "^2.0.0",
+            "micromark-util-character": "^2.0.0",
+            "micromark-util-chunked": "^2.0.0",
+            "micromark-util-combine-extensions": "^2.0.0",
+            "micromark-util-decode-numeric-character-reference": "^2.0.0",
+            "micromark-util-encode": "^2.0.0",
+            "micromark-util-normalize-identifier": "^2.0.0",
+            "micromark-util-resolve-all": "^2.0.0",
+            "micromark-util-sanitize-uri": "^2.0.0",
+            "micromark-util-subtokenize": "^2.0.0",
+            "micromark-util-symbol": "^2.0.0",
+            "micromark-util-types": "^2.0.0"
+          }
+        },
+        "micromark-extension-gfm": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
+          "integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
+          "requires": {
+            "micromark-extension-gfm-autolink-literal": "^2.0.0",
+            "micromark-extension-gfm-footnote": "^2.0.0",
+            "micromark-extension-gfm-strikethrough": "^2.0.0",
+            "micromark-extension-gfm-table": "^2.0.0",
+            "micromark-extension-gfm-tagfilter": "^2.0.0",
+            "micromark-extension-gfm-task-list-item": "^2.0.0",
+            "micromark-util-combine-extensions": "^2.0.0",
+            "micromark-util-types": "^2.0.0"
+          }
+        },
+        "micromark-extension-gfm-autolink-literal": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.0.0.tgz",
+          "integrity": "sha512-rTHfnpt/Q7dEAK1Y5ii0W8bhfJlVJFnJMHIPisfPK3gpVNuOP0VnRl96+YJ3RYWV/P4gFeQoGKNlT3RhuvpqAg==",
+          "requires": {
+            "micromark-util-character": "^2.0.0",
+            "micromark-util-sanitize-uri": "^2.0.0",
+            "micromark-util-symbol": "^2.0.0",
+            "micromark-util-types": "^2.0.0"
+          }
+        },
+        "micromark-extension-gfm-strikethrough": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.0.0.tgz",
+          "integrity": "sha512-c3BR1ClMp5fxxmwP6AoOY2fXO9U8uFMKs4ADD66ahLTNcwzSCyRVU4k7LPV5Nxo/VJiR4TdzxRQY2v3qIUceCw==",
+          "requires": {
+            "devlop": "^1.0.0",
+            "micromark-util-chunked": "^2.0.0",
+            "micromark-util-classify-character": "^2.0.0",
+            "micromark-util-resolve-all": "^2.0.0",
+            "micromark-util-symbol": "^2.0.0",
+            "micromark-util-types": "^2.0.0"
+          }
+        },
+        "micromark-extension-gfm-table": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.0.0.tgz",
+          "integrity": "sha512-PoHlhypg1ItIucOaHmKE8fbin3vTLpDOUg8KAr8gRCF1MOZI9Nquq2i/44wFvviM4WuxJzc3demT8Y3dkfvYrw==",
+          "requires": {
+            "devlop": "^1.0.0",
+            "micromark-factory-space": "^2.0.0",
+            "micromark-util-character": "^2.0.0",
+            "micromark-util-symbol": "^2.0.0",
+            "micromark-util-types": "^2.0.0"
+          }
+        },
+        "micromark-extension-gfm-tagfilter": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
+          "integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
+          "requires": {
+            "micromark-util-types": "^2.0.0"
+          }
+        },
+        "micromark-extension-gfm-task-list-item": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.0.1.tgz",
+          "integrity": "sha512-cY5PzGcnULaN5O7T+cOzfMoHjBW7j+T9D2sucA5d/KbsBTPcYdebm9zUd9zzdgJGCwahV+/W78Z3nbulBYVbTw==",
+          "requires": {
+            "devlop": "^1.0.0",
+            "micromark-factory-space": "^2.0.0",
+            "micromark-util-character": "^2.0.0",
+            "micromark-util-symbol": "^2.0.0",
+            "micromark-util-types": "^2.0.0"
+          }
+        },
+        "micromark-factory-destination": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-1.1.0.tgz",
+          "integrity": "sha512-XaNDROBgx9SgSChd69pjiGKbV+nfHGDPVYFs5dOoDd7ZnMAE+Cuu91BCpsY8RT2NP9vo/B8pds2VQNCLiu0zhg==",
+          "requires": {
+            "micromark-util-character": "^1.0.0",
+            "micromark-util-symbol": "^1.0.0",
+            "micromark-util-types": "^1.0.0"
+          },
+          "dependencies": {
+            "micromark-util-character": {
+              "version": "1.2.0",
+              "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-1.2.0.tgz",
+              "integrity": "sha512-lXraTwcX3yH/vMDaFWCQJP1uIszLVebzUa3ZHdrgxr7KEU/9mL4mVgCpGbyhvNLNlauROiNUq7WN5u7ndbY6xg==",
+              "requires": {
+                "micromark-util-symbol": "^1.0.0",
+                "micromark-util-types": "^1.0.0"
+              }
+            },
+            "micromark-util-symbol": {
+              "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-1.1.0.tgz",
+              "integrity": "sha512-uEjpEYY6KMs1g7QfJ2eX1SQEV+ZT4rUD3UcF6l57acZvLNK7PBZL+ty82Z1qhK1/yXIY4bdx04FKMgR0g4IAag=="
+            },
+            "micromark-util-types": {
+              "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-1.1.0.tgz",
+              "integrity": "sha512-ukRBgie8TIAcacscVHSiddHjO4k/q3pnedmzMQ4iwDcK0FtFCohKOlFbaOL/mPgfnPsL3C1ZyxJa4sbWrBl3jg=="
+            }
+          }
+        },
+        "micromark-factory-label": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-1.1.0.tgz",
+          "integrity": "sha512-OLtyez4vZo/1NjxGhcpDSbHQ+m0IIGnT8BoPamh+7jVlzLJBH98zzuCoUeMxvM6WsNeh8wx8cKvqLiPHEACn0w==",
+          "requires": {
+            "micromark-util-character": "^1.0.0",
+            "micromark-util-symbol": "^1.0.0",
+            "micromark-util-types": "^1.0.0",
+            "uvu": "^0.5.0"
+          },
+          "dependencies": {
+            "micromark-util-character": {
+              "version": "1.2.0",
+              "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-1.2.0.tgz",
+              "integrity": "sha512-lXraTwcX3yH/vMDaFWCQJP1uIszLVebzUa3ZHdrgxr7KEU/9mL4mVgCpGbyhvNLNlauROiNUq7WN5u7ndbY6xg==",
+              "requires": {
+                "micromark-util-symbol": "^1.0.0",
+                "micromark-util-types": "^1.0.0"
+              }
+            },
+            "micromark-util-symbol": {
+              "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-1.1.0.tgz",
+              "integrity": "sha512-uEjpEYY6KMs1g7QfJ2eX1SQEV+ZT4rUD3UcF6l57acZvLNK7PBZL+ty82Z1qhK1/yXIY4bdx04FKMgR0g4IAag=="
+            },
+            "micromark-util-types": {
+              "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-1.1.0.tgz",
+              "integrity": "sha512-ukRBgie8TIAcacscVHSiddHjO4k/q3pnedmzMQ4iwDcK0FtFCohKOlFbaOL/mPgfnPsL3C1ZyxJa4sbWrBl3jg=="
+            }
+          }
+        },
+        "micromark-factory-space": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.0.tgz",
+          "integrity": "sha512-TKr+LIDX2pkBJXFLzpyPyljzYK3MtmllMUMODTQJIUfDGncESaqB90db9IAUcz4AZAJFdd8U9zOp9ty1458rxg==",
+          "requires": {
+            "micromark-util-character": "^2.0.0",
+            "micromark-util-types": "^2.0.0"
+          }
+        },
+        "micromark-factory-title": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-1.1.0.tgz",
+          "integrity": "sha512-J7n9R3vMmgjDOCY8NPw55jiyaQnH5kBdV2/UXCtZIpnHH3P6nHUKaH7XXEYuWwx/xUJcawa8plLBEjMPU24HzQ==",
+          "requires": {
+            "micromark-factory-space": "^1.0.0",
+            "micromark-util-character": "^1.0.0",
+            "micromark-util-symbol": "^1.0.0",
+            "micromark-util-types": "^1.0.0"
+          },
+          "dependencies": {
+            "micromark-factory-space": {
+              "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-1.1.0.tgz",
+              "integrity": "sha512-cRzEj7c0OL4Mw2v6nwzttyOZe8XY/Z8G0rzmWQZTBi/jjwyw/U4uqKtUORXQrR5bAZZnbTI/feRV/R7hc4jQYQ==",
+              "requires": {
+                "micromark-util-character": "^1.0.0",
+                "micromark-util-types": "^1.0.0"
+              }
+            },
+            "micromark-util-character": {
+              "version": "1.2.0",
+              "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-1.2.0.tgz",
+              "integrity": "sha512-lXraTwcX3yH/vMDaFWCQJP1uIszLVebzUa3ZHdrgxr7KEU/9mL4mVgCpGbyhvNLNlauROiNUq7WN5u7ndbY6xg==",
+              "requires": {
+                "micromark-util-symbol": "^1.0.0",
+                "micromark-util-types": "^1.0.0"
+              }
+            },
+            "micromark-util-symbol": {
+              "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-1.1.0.tgz",
+              "integrity": "sha512-uEjpEYY6KMs1g7QfJ2eX1SQEV+ZT4rUD3UcF6l57acZvLNK7PBZL+ty82Z1qhK1/yXIY4bdx04FKMgR0g4IAag=="
+            },
+            "micromark-util-types": {
+              "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-1.1.0.tgz",
+              "integrity": "sha512-ukRBgie8TIAcacscVHSiddHjO4k/q3pnedmzMQ4iwDcK0FtFCohKOlFbaOL/mPgfnPsL3C1ZyxJa4sbWrBl3jg=="
+            }
+          }
+        },
+        "micromark-factory-whitespace": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-1.1.0.tgz",
+          "integrity": "sha512-v2WlmiymVSp5oMg+1Q0N1Lxmt6pMhIHD457whWM7/GUlEks1hI9xj5w3zbc4uuMKXGisksZk8DzP2UyGbGqNsQ==",
+          "requires": {
+            "micromark-factory-space": "^1.0.0",
+            "micromark-util-character": "^1.0.0",
+            "micromark-util-symbol": "^1.0.0",
+            "micromark-util-types": "^1.0.0"
+          },
+          "dependencies": {
+            "micromark-factory-space": {
+              "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-1.1.0.tgz",
+              "integrity": "sha512-cRzEj7c0OL4Mw2v6nwzttyOZe8XY/Z8G0rzmWQZTBi/jjwyw/U4uqKtUORXQrR5bAZZnbTI/feRV/R7hc4jQYQ==",
+              "requires": {
+                "micromark-util-character": "^1.0.0",
+                "micromark-util-types": "^1.0.0"
+              }
+            },
+            "micromark-util-character": {
+              "version": "1.2.0",
+              "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-1.2.0.tgz",
+              "integrity": "sha512-lXraTwcX3yH/vMDaFWCQJP1uIszLVebzUa3ZHdrgxr7KEU/9mL4mVgCpGbyhvNLNlauROiNUq7WN5u7ndbY6xg==",
+              "requires": {
+                "micromark-util-symbol": "^1.0.0",
+                "micromark-util-types": "^1.0.0"
+              }
+            },
+            "micromark-util-symbol": {
+              "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-1.1.0.tgz",
+              "integrity": "sha512-uEjpEYY6KMs1g7QfJ2eX1SQEV+ZT4rUD3UcF6l57acZvLNK7PBZL+ty82Z1qhK1/yXIY4bdx04FKMgR0g4IAag=="
+            },
+            "micromark-util-types": {
+              "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-1.1.0.tgz",
+              "integrity": "sha512-ukRBgie8TIAcacscVHSiddHjO4k/q3pnedmzMQ4iwDcK0FtFCohKOlFbaOL/mPgfnPsL3C1ZyxJa4sbWrBl3jg=="
+            }
+          }
+        },
+        "micromark-util-character": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.0.tgz",
+          "integrity": "sha512-KvOVV+X1yLBfs9dCBSopq/+G1PcgT3lAK07mC4BzXi5E7ahzMAF8oIupDDJ6mievI6F+lAATkbQQlQixJfT3aQ==",
+          "requires": {
+            "micromark-util-symbol": "^2.0.0",
+            "micromark-util-types": "^2.0.0"
+          }
+        },
+        "micromark-util-html-tag-name": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-1.2.0.tgz",
+          "integrity": "sha512-VTQzcuQgFUD7yYztuQFKXT49KghjtETQ+Wv/zUjGSGBioZnkA4P1XXZPT1FHeJA6RwRXSF47yvJ1tsJdoxwO+Q=="
+        },
+        "micromark-util-symbol": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.0.tgz",
+          "integrity": "sha512-8JZt9ElZ5kyTnO94muPxIGS8oyElRJaiJO8EzV6ZSyGQ1Is8xwl4Q45qU5UOg+bGH4AikWziz0iN4sFLWs8PGw=="
+        },
+        "micromark-util-types": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.0.tgz",
+          "integrity": "sha512-oNh6S2WMHWRZrmutsRmDDfkzKtxF+bc2VxLC9dvtrDIRFln627VsFP6fLMgTryGDljgLPjkrzQSDcPrjPyDJ5w=="
+        },
+        "property-information": {
+          "version": "6.4.1",
+          "resolved": "https://registry.npmjs.org/property-information/-/property-information-6.4.1.tgz",
+          "integrity": "sha512-OHYtXfu5aI2sS2LWFSN5rgJjrQ4pCy8i1jubJLe2QvMF8JJ++HXTUIVWFLfXJoaOfvYYjk2SN8J2wFUWIGXT4w=="
+        },
+        "react-markdown": {
+          "version": "8.0.7",
+          "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-8.0.7.tgz",
+          "integrity": "sha512-bvWbzG4MtOU62XqBx3Xx+zB2raaFFsq4mYiAzfjXJMEz2sixgeAfraA3tvzULF02ZdOMUOKTBFFaZJDDrq+BJQ==",
+          "requires": {
+            "@types/hast": "^2.0.0",
+            "@types/prop-types": "^15.0.0",
+            "@types/unist": "^2.0.0",
+            "comma-separated-tokens": "^2.0.0",
+            "hast-util-whitespace": "^2.0.0",
+            "prop-types": "^15.0.0",
+            "property-information": "^6.0.0",
+            "react-is": "^18.0.0",
+            "remark-parse": "^10.0.0",
+            "remark-rehype": "^10.0.0",
+            "space-separated-tokens": "^2.0.0",
+            "style-to-object": "^0.4.0",
+            "unified": "^10.0.0",
+            "unist-util-visit": "^4.0.0",
+            "vfile": "^5.0.0"
+          },
+          "dependencies": {
+            "react-is": {
+              "version": "18.2.0",
+              "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+              "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
+            }
+          }
+        },
+        "redux-thunk": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.4.1.tgz",
+          "integrity": "sha512-OOYGNY5Jy2TWvTL1KgAlVy6dcx3siPJ1wTq741EPyUKfn6W6nChdICjZwCd0p8AZBs5kWpZlbkXW2nE/zjUa+Q==",
+          "requires": {}
+        },
+        "remark-gfm": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.0.tgz",
+          "integrity": "sha512-U92vJgBPkbw4Zfu/IiW2oTZLSL3Zpv+uI7My2eq8JxKgqraFdU8YUGicEJCEgSbeaG+QDFqIcwwfMTOEelPxuA==",
+          "requires": {
+            "@types/mdast": "^4.0.0",
+            "mdast-util-gfm": "^3.0.0",
+            "micromark-extension-gfm": "^3.0.0",
+            "remark-parse": "^11.0.0",
+            "remark-stringify": "^11.0.0",
+            "unified": "^11.0.0"
+          },
+          "dependencies": {
+            "@types/mdast": {
+              "version": "4.0.3",
+              "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.3.tgz",
+              "integrity": "sha512-LsjtqsyF+d2/yFOYaN22dHZI1Cpwkrj+g06G8+qtUKlhovPW89YhqSnfKtMbkgmEtYpH2gydRNULd6y8mciAFg==",
+              "requires": {
+                "@types/unist": "*"
+              }
+            },
+            "@types/unist": {
+              "version": "3.0.2",
+              "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.2.tgz",
+              "integrity": "sha512-dqId9J8K/vGi5Zr7oo212BGii5m3q5Hxlkwy3WpYuKPklmBEvsbMYYyLxAQpSffdLl/gdW0XUpKWFvYmyoWCoQ=="
+            },
+            "remark-parse": {
+              "version": "11.0.0",
+              "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
+              "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
+              "requires": {
+                "@types/mdast": "^4.0.0",
+                "mdast-util-from-markdown": "^2.0.0",
+                "micromark-util-types": "^2.0.0",
+                "unified": "^11.0.0"
+              }
+            },
+            "unified": {
+              "version": "11.0.4",
+              "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.4.tgz",
+              "integrity": "sha512-apMPnyLjAX+ty4OrNap7yumyVAMlKx5IWU2wlzzUdYJO9A8f1p9m/gywF/GM2ZDFcjQPrx59Mc90KwmxsoklxQ==",
+              "requires": {
+                "@types/unist": "^3.0.0",
+                "bail": "^2.0.0",
+                "devlop": "^1.0.0",
+                "extend": "^3.0.0",
+                "is-plain-obj": "^4.0.0",
+                "trough": "^2.0.0",
+                "vfile": "^6.0.0"
+              }
+            },
+            "vfile": {
+              "version": "6.0.1",
+              "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.1.tgz",
+              "integrity": "sha512-1bYqc7pt6NIADBJ98UiG0Bn/CHIVOoZ/IyEkqIruLg0mE1BKzkOXY2D6CSqQIcKqgadppE5lrxgWXJmXd7zZJw==",
+              "requires": {
+                "@types/unist": "^3.0.0",
+                "unist-util-stringify-position": "^4.0.0",
+                "vfile-message": "^4.0.0"
+              }
+            },
+            "vfile-message": {
+              "version": "4.0.2",
+              "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.2.tgz",
+              "integrity": "sha512-jRDZ1IMLttGj41KcZvlrYAaI3CfqpLpfpf+Mfig13viT6NKvRzWZ+lXz0Y5D60w6uJIBAOGq9mSHf0gktF0duw==",
+              "requires": {
+                "@types/unist": "^3.0.0",
+                "unist-util-stringify-position": "^4.0.0"
+              }
+            }
+          }
+        },
+        "remark-parse": {
+          "version": "10.0.2",
+          "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-10.0.2.tgz",
+          "integrity": "sha512-3ydxgHa/ZQzG8LvC7jTXccARYDcRld3VfcgIIFs7bI6vbRSxJJmzgLEIIoYKyrfhaY+ujuWaf/PJiMZXoiCXgw==",
+          "requires": {
+            "@types/mdast": "^3.0.0",
+            "mdast-util-from-markdown": "^1.0.0",
+            "unified": "^10.0.0"
+          },
+          "dependencies": {
+            "mdast-util-from-markdown": {
+              "version": "1.3.1",
+              "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-1.3.1.tgz",
+              "integrity": "sha512-4xTO/M8c82qBcnQc1tgpNtubGUW/Y1tBQ1B0i5CtSoelOLKFYlElIr3bvgREYYO5iRqbMY1YuqZng0GVOI8Qww==",
+              "requires": {
+                "@types/mdast": "^3.0.0",
+                "@types/unist": "^2.0.0",
+                "decode-named-character-reference": "^1.0.0",
+                "mdast-util-to-string": "^3.1.0",
+                "micromark": "^3.0.0",
+                "micromark-util-decode-numeric-character-reference": "^1.0.0",
+                "micromark-util-decode-string": "^1.0.0",
+                "micromark-util-normalize-identifier": "^1.0.0",
+                "micromark-util-symbol": "^1.0.0",
+                "micromark-util-types": "^1.0.0",
+                "unist-util-stringify-position": "^3.0.0",
+                "uvu": "^0.5.0"
+              }
+            },
+            "mdast-util-to-string": {
+              "version": "3.2.0",
+              "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-3.2.0.tgz",
+              "integrity": "sha512-V4Zn/ncyN1QNSqSBxTrMOLpjr+IKdHl2v3KVLoWmDPscP4r9GcCi71gjgvUV1SFSKh92AjAG4peFuBl2/YgCJg==",
+              "requires": {
+                "@types/mdast": "^3.0.0"
+              }
+            },
+            "micromark": {
+              "version": "3.2.0",
+              "resolved": "https://registry.npmjs.org/micromark/-/micromark-3.2.0.tgz",
+              "integrity": "sha512-uD66tJj54JLYq0De10AhWycZWGQNUvDI55xPgk2sQM5kn1JYlhbCMTtEeT27+vAhW2FBQxLlOmS3pmA7/2z4aA==",
+              "requires": {
+                "@types/debug": "^4.0.0",
+                "debug": "^4.0.0",
+                "decode-named-character-reference": "^1.0.0",
+                "micromark-core-commonmark": "^1.0.1",
+                "micromark-factory-space": "^1.0.0",
+                "micromark-util-character": "^1.0.0",
+                "micromark-util-chunked": "^1.0.0",
+                "micromark-util-combine-extensions": "^1.0.0",
+                "micromark-util-decode-numeric-character-reference": "^1.0.0",
+                "micromark-util-encode": "^1.0.0",
+                "micromark-util-normalize-identifier": "^1.0.0",
+                "micromark-util-resolve-all": "^1.0.0",
+                "micromark-util-sanitize-uri": "^1.0.0",
+                "micromark-util-subtokenize": "^1.0.0",
+                "micromark-util-symbol": "^1.0.0",
+                "micromark-util-types": "^1.0.1",
+                "uvu": "^0.5.0"
+              }
+            },
+            "micromark-core-commonmark": {
+              "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-1.1.0.tgz",
+              "integrity": "sha512-BgHO1aRbolh2hcrzL2d1La37V0Aoz73ymF8rAcKnohLy93titmv62E0gP8Hrx9PKcKrqCZ1BbLGbP3bEhoXYlw==",
+              "requires": {
+                "decode-named-character-reference": "^1.0.0",
+                "micromark-factory-destination": "^1.0.0",
+                "micromark-factory-label": "^1.0.0",
+                "micromark-factory-space": "^1.0.0",
+                "micromark-factory-title": "^1.0.0",
+                "micromark-factory-whitespace": "^1.0.0",
+                "micromark-util-character": "^1.0.0",
+                "micromark-util-chunked": "^1.0.0",
+                "micromark-util-classify-character": "^1.0.0",
+                "micromark-util-html-tag-name": "^1.0.0",
+                "micromark-util-normalize-identifier": "^1.0.0",
+                "micromark-util-resolve-all": "^1.0.0",
+                "micromark-util-subtokenize": "^1.0.0",
+                "micromark-util-symbol": "^1.0.0",
+                "micromark-util-types": "^1.0.1",
+                "uvu": "^0.5.0"
+              }
+            },
+            "micromark-factory-space": {
+              "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-1.1.0.tgz",
+              "integrity": "sha512-cRzEj7c0OL4Mw2v6nwzttyOZe8XY/Z8G0rzmWQZTBi/jjwyw/U4uqKtUORXQrR5bAZZnbTI/feRV/R7hc4jQYQ==",
+              "requires": {
+                "micromark-util-character": "^1.0.0",
+                "micromark-util-types": "^1.0.0"
+              }
+            },
+            "micromark-util-character": {
+              "version": "1.2.0",
+              "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-1.2.0.tgz",
+              "integrity": "sha512-lXraTwcX3yH/vMDaFWCQJP1uIszLVebzUa3ZHdrgxr7KEU/9mL4mVgCpGbyhvNLNlauROiNUq7WN5u7ndbY6xg==",
+              "requires": {
+                "micromark-util-symbol": "^1.0.0",
+                "micromark-util-types": "^1.0.0"
+              }
+            },
+            "micromark-util-chunked": {
+              "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-1.1.0.tgz",
+              "integrity": "sha512-Ye01HXpkZPNcV6FiyoW2fGZDUw4Yc7vT0E9Sad83+bEDiCJ1uXu0S3mr8WLpsz3HaG3x2q0HM6CTuPdcZcluFQ==",
+              "requires": {
+                "micromark-util-symbol": "^1.0.0"
+              }
+            },
+            "micromark-util-classify-character": {
+              "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-1.1.0.tgz",
+              "integrity": "sha512-SL0wLxtKSnklKSUplok1WQFoGhUdWYKggKUiqhX+Swala+BtptGCu5iPRc+xvzJ4PXE/hwM3FNXsfEVgoZsWbw==",
+              "requires": {
+                "micromark-util-character": "^1.0.0",
+                "micromark-util-symbol": "^1.0.0",
+                "micromark-util-types": "^1.0.0"
+              }
+            },
+            "micromark-util-combine-extensions": {
+              "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-1.1.0.tgz",
+              "integrity": "sha512-Q20sp4mfNf9yEqDL50WwuWZHUrCO4fEyeDCnMGmG5Pr0Cz15Uo7KBs6jq+dq0EgX4DPwwrh9m0X+zPV1ypFvUA==",
+              "requires": {
+                "micromark-util-chunked": "^1.0.0",
+                "micromark-util-types": "^1.0.0"
+              }
+            },
+            "micromark-util-decode-numeric-character-reference": {
+              "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-1.1.0.tgz",
+              "integrity": "sha512-m9V0ExGv0jB1OT21mrWcuf4QhP46pH1KkfWy9ZEezqHKAxkj4mPCy3nIH1rkbdMlChLHX531eOrymlwyZIf2iw==",
+              "requires": {
+                "micromark-util-symbol": "^1.0.0"
+              }
+            },
+            "micromark-util-decode-string": {
+              "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-1.1.0.tgz",
+              "integrity": "sha512-YphLGCK8gM1tG1bd54azwyrQRjCFcmgj2S2GoJDNnh4vYtnL38JS8M4gpxzOPNyHdNEpheyWXCTnnTDY3N+NVQ==",
+              "requires": {
+                "decode-named-character-reference": "^1.0.0",
+                "micromark-util-character": "^1.0.0",
+                "micromark-util-decode-numeric-character-reference": "^1.0.0",
+                "micromark-util-symbol": "^1.0.0"
+              }
+            },
+            "micromark-util-encode": {
+              "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-1.1.0.tgz",
+              "integrity": "sha512-EuEzTWSTAj9PA5GOAs992GzNh2dGQO52UvAbtSOMvXTxv3Criqb6IOzJUBCmEqrrXSblJIJBbFFv6zPxpreiJw=="
+            },
+            "micromark-util-normalize-identifier": {
+              "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-1.1.0.tgz",
+              "integrity": "sha512-N+w5vhqrBihhjdpM8+5Xsxy71QWqGn7HYNUvch71iV2PM7+E3uWGox1Qp90loa1ephtCxG2ftRV/Conitc6P2Q==",
+              "requires": {
+                "micromark-util-symbol": "^1.0.0"
+              }
+            },
+            "micromark-util-resolve-all": {
+              "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-1.1.0.tgz",
+              "integrity": "sha512-b/G6BTMSg+bX+xVCshPTPyAu2tmA0E4X98NSR7eIbeC6ycCqCeE7wjfDIgzEbkzdEVJXRtOG4FbEm/uGbCRouA==",
+              "requires": {
+                "micromark-util-types": "^1.0.0"
+              }
+            },
+            "micromark-util-sanitize-uri": {
+              "version": "1.2.0",
+              "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-1.2.0.tgz",
+              "integrity": "sha512-QO4GXv0XZfWey4pYFndLUKEAktKkG5kZTdUNaTAkzbuJxn2tNBOr+QtxR2XpWaMhbImT2dPzyLrPXLlPhph34A==",
+              "requires": {
+                "micromark-util-character": "^1.0.0",
+                "micromark-util-encode": "^1.0.0",
+                "micromark-util-symbol": "^1.0.0"
+              }
+            },
+            "micromark-util-subtokenize": {
+              "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-1.1.0.tgz",
+              "integrity": "sha512-kUQHyzRoxvZO2PuLzMt2P/dwVsTiivCK8icYTeR+3WgbuPqfHgPPy7nFKbeqRivBvn/3N3GBiNC+JRTMSxEC7A==",
+              "requires": {
+                "micromark-util-chunked": "^1.0.0",
+                "micromark-util-symbol": "^1.0.0",
+                "micromark-util-types": "^1.0.0",
+                "uvu": "^0.5.0"
+              }
+            },
+            "micromark-util-symbol": {
+              "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-1.1.0.tgz",
+              "integrity": "sha512-uEjpEYY6KMs1g7QfJ2eX1SQEV+ZT4rUD3UcF6l57acZvLNK7PBZL+ty82Z1qhK1/yXIY4bdx04FKMgR0g4IAag=="
+            },
+            "micromark-util-types": {
+              "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-1.1.0.tgz",
+              "integrity": "sha512-ukRBgie8TIAcacscVHSiddHjO4k/q3pnedmzMQ4iwDcK0FtFCohKOlFbaOL/mPgfnPsL3C1ZyxJa4sbWrBl3jg=="
+            },
+            "unist-util-stringify-position": {
+              "version": "3.0.3",
+              "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-3.0.3.tgz",
+              "integrity": "sha512-k5GzIBZ/QatR8N5X2y+drfpWG8IDBzdnVj6OInRNWm1oXrzydiaAT2OQiA8DPRRZyAKb9b6I2a6PxYklZD0gKg==",
+              "requires": {
+                "@types/unist": "^2.0.0"
+              }
+            }
+          }
+        },
+        "remark-rehype": {
+          "version": "10.1.0",
+          "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-10.1.0.tgz",
+          "integrity": "sha512-EFmR5zppdBp0WQeDVZ/b66CWJipB2q2VLNFMabzDSGR66Z2fQii83G5gTBbgGEnEEA0QRussvrFHxk1HWGJskw==",
+          "requires": {
+            "@types/hast": "^2.0.0",
+            "@types/mdast": "^3.0.0",
+            "mdast-util-to-hast": "^12.1.0",
+            "unified": "^10.0.0"
+          }
+        },
+        "space-separated-tokens": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+          "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q=="
+        },
+        "style-to-object": {
+          "version": "0.4.4",
+          "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-0.4.4.tgz",
+          "integrity": "sha512-HYNoHZa2GorYNyqiCaBgsxvcJIn7OHq6inEga+E6Ke3m5JkoqpQbnFssk4jwe+K7AhGa2fcha4wSOf1Kn01dMg==",
+          "requires": {
+            "inline-style-parser": "0.1.1"
+          }
+        },
+        "trough": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+          "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw=="
+        },
+        "unified": {
+          "version": "10.1.2",
+          "resolved": "https://registry.npmjs.org/unified/-/unified-10.1.2.tgz",
+          "integrity": "sha512-pUSWAi/RAnVy1Pif2kAoeWNBa3JVrx0MId2LASj8G+7AiHWoKZNTomq6LG326T68U7/e263X6fTdcXIy7XnF7Q==",
+          "requires": {
+            "@types/unist": "^2.0.0",
+            "bail": "^2.0.0",
+            "extend": "^3.0.0",
+            "is-buffer": "^2.0.0",
+            "is-plain-obj": "^4.0.0",
+            "trough": "^2.0.0",
+            "vfile": "^5.0.0"
+          }
+        },
+        "unist-util-generated": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/unist-util-generated/-/unist-util-generated-2.0.1.tgz",
+          "integrity": "sha512-qF72kLmPxAw0oN2fwpWIqbXAVyEqUzDHMsbtPvOudIlUzXYFIeQIuxXQCRCFh22B7cixvU0MG7m3MW8FTq/S+A=="
+        },
+        "unist-util-is": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.0.tgz",
+          "integrity": "sha512-2qCTHimwdxLfz+YzdGfkqNlH0tLi9xjTnHddPmJwtIG9MGsdbutfTc4P+haPD7l7Cjxf/WZj+we5qfVPvvxfYw==",
+          "requires": {
+            "@types/unist": "^3.0.0"
+          },
+          "dependencies": {
+            "@types/unist": {
+              "version": "3.0.2",
+              "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.2.tgz",
+              "integrity": "sha512-dqId9J8K/vGi5Zr7oo212BGii5m3q5Hxlkwy3WpYuKPklmBEvsbMYYyLxAQpSffdLl/gdW0XUpKWFvYmyoWCoQ=="
+            }
+          }
+        },
+        "unist-util-position": {
+          "version": "4.0.4",
+          "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-4.0.4.tgz",
+          "integrity": "sha512-kUBE91efOWfIVBo8xzh/uZQ7p9ffYRtUbMRZBNFYwf0RK8koUMx6dGUfwylLOKmaT2cs4wSW96QoYUSXAyEtpg==",
+          "requires": {
+            "@types/unist": "^2.0.0"
+          }
+        },
+        "unist-util-stringify-position": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+          "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+          "requires": {
+            "@types/unist": "^3.0.0"
+          },
+          "dependencies": {
+            "@types/unist": {
+              "version": "3.0.2",
+              "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.2.tgz",
+              "integrity": "sha512-dqId9J8K/vGi5Zr7oo212BGii5m3q5Hxlkwy3WpYuKPklmBEvsbMYYyLxAQpSffdLl/gdW0XUpKWFvYmyoWCoQ=="
+            }
+          }
+        },
+        "unist-util-visit": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-4.1.2.tgz",
+          "integrity": "sha512-MSd8OUGISqHdVvfY9TPhyK2VdUrPgxkUtWSuMHF6XAAFuL4LokseigBnZtPnJMu+FbynTkFNnFlyjxpVKujMRg==",
+          "requires": {
+            "@types/unist": "^2.0.0",
+            "unist-util-is": "^5.0.0",
+            "unist-util-visit-parents": "^5.1.1"
+          },
+          "dependencies": {
+            "unist-util-is": {
+              "version": "5.2.1",
+              "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-5.2.1.tgz",
+              "integrity": "sha512-u9njyyfEh43npf1M+yGKDGVPbY/JWEemg5nH05ncKPfi+kBbKBJoTdsogMu33uhytuLlv9y0O7GH7fEdwLdLQw==",
+              "requires": {
+                "@types/unist": "^2.0.0"
+              }
+            },
+            "unist-util-visit-parents": {
+              "version": "5.1.3",
+              "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-5.1.3.tgz",
+              "integrity": "sha512-x6+y8g7wWMyQhL1iZfhIPhDAs7Xwbn9nRosDXl7qoPTSCy0yNxnKc+hWokFifWQIDGi154rdUqKvbCa4+1kLhg==",
+              "requires": {
+                "@types/unist": "^2.0.0",
+                "unist-util-is": "^5.0.0"
+              }
+            }
+          }
+        },
+        "unist-util-visit-parents": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.1.tgz",
+          "integrity": "sha512-L/PqWzfTP9lzzEa6CKs0k2nARxTdZduw3zyh8d2NVBnsyvHjSX4TWse388YrrQKbvI8w20fGjGlhgT96WwKykw==",
+          "requires": {
+            "@types/unist": "^3.0.0",
+            "unist-util-is": "^6.0.0"
+          },
+          "dependencies": {
+            "@types/unist": {
+              "version": "3.0.2",
+              "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.2.tgz",
+              "integrity": "sha512-dqId9J8K/vGi5Zr7oo212BGii5m3q5Hxlkwy3WpYuKPklmBEvsbMYYyLxAQpSffdLl/gdW0XUpKWFvYmyoWCoQ=="
+            }
+          }
+        },
+        "vfile": {
+          "version": "5.3.7",
+          "resolved": "https://registry.npmjs.org/vfile/-/vfile-5.3.7.tgz",
+          "integrity": "sha512-r7qlzkgErKjobAmyNIkkSpizsFPYiUPuJb5pNW1RB4JcYVZhs4lIbVqk8XPk033CV/1z8ss5pkax8SuhGpcG8g==",
+          "requires": {
+            "@types/unist": "^2.0.0",
+            "is-buffer": "^2.0.0",
+            "unist-util-stringify-position": "^3.0.0",
+            "vfile-message": "^3.0.0"
+          },
+          "dependencies": {
+            "unist-util-stringify-position": {
+              "version": "3.0.3",
+              "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-3.0.3.tgz",
+              "integrity": "sha512-k5GzIBZ/QatR8N5X2y+drfpWG8IDBzdnVj6OInRNWm1oXrzydiaAT2OQiA8DPRRZyAKb9b6I2a6PxYklZD0gKg==",
+              "requires": {
+                "@types/unist": "^2.0.0"
+              }
+            }
+          }
+        },
+        "vfile-message": {
+          "version": "3.1.4",
+          "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-3.1.4.tgz",
+          "integrity": "sha512-fa0Z6P8HUrQN4BZaX05SIVXic+7kE3b05PWAtPuYP9QLHsLKYR7/AlLW3NtOrpXRLeawpDLMsVkmk5DG0NXgWw==",
+          "requires": {
+            "@types/unist": "^2.0.0",
+            "unist-util-stringify-position": "^3.0.0"
+          },
+          "dependencies": {
+            "unist-util-stringify-position": {
+              "version": "3.0.3",
+              "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-3.0.3.tgz",
+              "integrity": "sha512-k5GzIBZ/QatR8N5X2y+drfpWG8IDBzdnVj6OInRNWm1oXrzydiaAT2OQiA8DPRRZyAKb9b6I2a6PxYklZD0gKg==",
+              "requires": {
+                "@types/unist": "^2.0.0"
+              }
+            }
+          }
+        },
+        "zwitch": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+          "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="
+        }
+      }
+    },
     "@deephaven/eslint-config": {
       "version": "0.40.0",
       "resolved": "https://registry.npmjs.org/@deephaven/eslint-config/-/eslint-config-0.40.0.tgz",
@@ -33772,6 +39861,77 @@
         "eslint-config-react-app": "7.0.0"
       }
     },
+    "@deephaven/file-explorer": {
+      "version": "0.64.0",
+      "resolved": "https://registry.npmjs.org/@deephaven/file-explorer/-/file-explorer-0.64.0.tgz",
+      "integrity": "sha512-TSQTBgyO7XBzgi8sXILt5CWUMvT7NZhoFs/yiVVFT5ZPuaxLKmM2rW1SCw65eNcnnMswqTdfC8V9S6WQ62WrXw==",
+      "requires": {
+        "@deephaven/components": "^0.64.0",
+        "@deephaven/icons": "^0.64.0",
+        "@deephaven/log": "^0.64.0",
+        "@deephaven/storage": "^0.64.0",
+        "@deephaven/utils": "^0.64.0",
+        "@fortawesome/fontawesome-svg-core": "^6.2.1",
+        "@fortawesome/react-fontawesome": "^0.2.0",
+        "classnames": "^2.3.1",
+        "lodash.throttle": "^4.1.1",
+        "prop-types": "^15.7.2"
+      },
+      "dependencies": {
+        "@deephaven/components": {
+          "version": "0.64.0",
+          "resolved": "https://registry.npmjs.org/@deephaven/components/-/components-0.64.0.tgz",
+          "integrity": "sha512-L/G3r94eoHx7OzZM5DpbshGFgvmXyBi0SdmPKp872zfrWu/rcSTrsB2Mz3/QmJIBaO2wn8U5tw5pTKGoML8IfQ==",
+          "requires": {
+            "@adobe/react-spectrum": "^3.29.0",
+            "@deephaven/icons": "^0.64.0",
+            "@deephaven/log": "^0.64.0",
+            "@deephaven/react-hooks": "^0.64.0",
+            "@deephaven/utils": "^0.64.0",
+            "@fortawesome/fontawesome-svg-core": "^6.2.1",
+            "@fortawesome/react-fontawesome": "^0.2.0",
+            "@react-spectrum/theme-default": "^3.5.1",
+            "bootstrap": "4.6.2",
+            "classnames": "^2.3.1",
+            "event-target-shim": "^6.0.2",
+            "lodash.clamp": "^4.0.3",
+            "lodash.debounce": "^4.0.8",
+            "lodash.flatten": "^4.4.0",
+            "memoizee": "^0.4.15",
+            "popper.js": "^1.16.1",
+            "prop-types": "^15.7.2",
+            "react-beautiful-dnd": "^13.1.0",
+            "react-transition-group": "^4.4.2",
+            "react-virtualized-auto-sizer": "1.0.6",
+            "react-window": "^1.8.6",
+            "shortid": "^2.2.16"
+          }
+        },
+        "@deephaven/log": {
+          "version": "0.64.0",
+          "resolved": "https://registry.npmjs.org/@deephaven/log/-/log-0.64.0.tgz",
+          "integrity": "sha512-E2/gUb/lfFIGxM/bm0Wimpu+EUVY1xNubItiedMKDEp/dfmVKMVng6XdF2pPw73kaeGAs7NoCbdnWnXdns5QdA==",
+          "requires": {
+            "event-target-shim": "^6.0.2"
+          }
+        },
+        "@deephaven/utils": {
+          "version": "0.64.0",
+          "resolved": "https://registry.npmjs.org/@deephaven/utils/-/utils-0.64.0.tgz",
+          "integrity": "sha512-lt9cXEw0j2KMmUvR/+jmrpmWihrkYxNmhClW778WLFf0oi6Y4V/hsJxiNz+QvFvNbg3HqU6ZBMPHOtCNjKe7bQ=="
+        },
+        "event-target-shim": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-6.0.2.tgz",
+          "integrity": "sha512-8q3LsZjRezbFZ2PN+uP+Q7pnHUMmAOziU2vA2OwoFaKIXxlxl38IylhSSgUorWu/rf4er67w0ikBqjBFk/pomA=="
+        }
+      }
+    },
+    "@deephaven/filters": {
+      "version": "0.64.0",
+      "resolved": "https://registry.npmjs.org/@deephaven/filters/-/filters-0.64.0.tgz",
+      "integrity": "sha512-/CnrdetauiBmS6sMybMUQ9ssDFk36jAvhskzYVLGzxX5Rhya2pobZBjz5JfQcUKLkm9B+5GUc7Qa9R5x/EOzBw=="
+    },
     "@deephaven/golden-layout": {
       "version": "0.40.4",
       "resolved": "https://registry.npmjs.org/@deephaven/golden-layout/-/golden-layout-0.40.4.tgz",
@@ -33779,6 +39939,187 @@
       "requires": {
         "@deephaven/components": "^0.40.1",
         "jquery": "^3.6.0"
+      }
+    },
+    "@deephaven/grid": {
+      "version": "0.64.0",
+      "resolved": "https://registry.npmjs.org/@deephaven/grid/-/grid-0.64.0.tgz",
+      "integrity": "sha512-avMaYmVwvbmeY63SQzE6aGJb4nDuZlklJB3f4WWfLw7w86haJkg8Gv+R5jNCM6NCMXyvG3y2/GfPeH2sca+GyA==",
+      "requires": {
+        "@deephaven/utils": "^0.64.0",
+        "classnames": "^2.3.1",
+        "color-convert": "^2.0.1",
+        "event-target-shim": "^6.0.2",
+        "linkifyjs": "^4.1.0",
+        "lodash.clamp": "^4.0.3",
+        "memoize-one": "^5.1.1",
+        "memoizee": "^0.4.15",
+        "prop-types": "^15.7.2"
+      },
+      "dependencies": {
+        "@deephaven/utils": {
+          "version": "0.64.0",
+          "resolved": "https://registry.npmjs.org/@deephaven/utils/-/utils-0.64.0.tgz",
+          "integrity": "sha512-lt9cXEw0j2KMmUvR/+jmrpmWihrkYxNmhClW778WLFf0oi6Y4V/hsJxiNz+QvFvNbg3HqU6ZBMPHOtCNjKe7bQ=="
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "event-target-shim": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-6.0.2.tgz",
+          "integrity": "sha512-8q3LsZjRezbFZ2PN+uP+Q7pnHUMmAOziU2vA2OwoFaKIXxlxl38IylhSSgUorWu/rf4er67w0ikBqjBFk/pomA=="
+        }
+      }
+    },
+    "@deephaven/icons": {
+      "version": "0.64.0",
+      "resolved": "https://registry.npmjs.org/@deephaven/icons/-/icons-0.64.0.tgz",
+      "integrity": "sha512-p2ntfCFRi9F7G0eVX695ce6EeIiRQINSZP60ndRk0bmQkT4CL2Vm5Sx6ag0ErL8yr2M4e+VLJ9UPjrzTc6QSZg==",
+      "requires": {
+        "@fortawesome/fontawesome-common-types": "^6.1.1"
+      }
+    },
+    "@deephaven/iris-grid": {
+      "version": "0.64.0",
+      "resolved": "https://registry.npmjs.org/@deephaven/iris-grid/-/iris-grid-0.64.0.tgz",
+      "integrity": "sha512-w80DxEeAjjil/NUB4dHMHjieGpYZdbPki3HgKbQmbSHpZ0hZXRL4/DERFrFioHhPOrWD/4EBnzdCHtsyaJgrlg==",
+      "requires": {
+        "@deephaven/components": "^0.64.0",
+        "@deephaven/console": "^0.64.0",
+        "@deephaven/filters": "^0.64.0",
+        "@deephaven/grid": "^0.64.0",
+        "@deephaven/icons": "^0.64.0",
+        "@deephaven/jsapi-components": "^0.64.0",
+        "@deephaven/jsapi-types": "^0.64.0",
+        "@deephaven/jsapi-utils": "^0.64.0",
+        "@deephaven/log": "^0.64.0",
+        "@deephaven/react-hooks": "^0.64.0",
+        "@deephaven/storage": "^0.64.0",
+        "@deephaven/utils": "^0.64.0",
+        "@dnd-kit/core": "^6.0.5",
+        "@dnd-kit/sortable": "^7.0.0",
+        "@dnd-kit/utilities": "^3.2.0",
+        "@fortawesome/react-fontawesome": "^0.2.0",
+        "classnames": "^2.3.1",
+        "deep-equal": "^2.0.5",
+        "lodash.clamp": "^4.0.3",
+        "lodash.debounce": "^4.0.8",
+        "lodash.throttle": "^4.1.1",
+        "memoize-one": "^5.1.1",
+        "memoizee": "^0.4.15",
+        "monaco-editor": "^0.41.0",
+        "prop-types": "^15.7.2",
+        "react-beautiful-dnd": "^13.1.0",
+        "react-transition-group": "^4.4.2",
+        "shortid": "^2.2.16"
+      },
+      "dependencies": {
+        "@deephaven/components": {
+          "version": "0.64.0",
+          "resolved": "https://registry.npmjs.org/@deephaven/components/-/components-0.64.0.tgz",
+          "integrity": "sha512-L/G3r94eoHx7OzZM5DpbshGFgvmXyBi0SdmPKp872zfrWu/rcSTrsB2Mz3/QmJIBaO2wn8U5tw5pTKGoML8IfQ==",
+          "requires": {
+            "@adobe/react-spectrum": "^3.29.0",
+            "@deephaven/icons": "^0.64.0",
+            "@deephaven/log": "^0.64.0",
+            "@deephaven/react-hooks": "^0.64.0",
+            "@deephaven/utils": "^0.64.0",
+            "@fortawesome/fontawesome-svg-core": "^6.2.1",
+            "@fortawesome/react-fontawesome": "^0.2.0",
+            "@react-spectrum/theme-default": "^3.5.1",
+            "bootstrap": "4.6.2",
+            "classnames": "^2.3.1",
+            "event-target-shim": "^6.0.2",
+            "lodash.clamp": "^4.0.3",
+            "lodash.debounce": "^4.0.8",
+            "lodash.flatten": "^4.4.0",
+            "memoizee": "^0.4.15",
+            "popper.js": "^1.16.1",
+            "prop-types": "^15.7.2",
+            "react-beautiful-dnd": "^13.1.0",
+            "react-transition-group": "^4.4.2",
+            "react-virtualized-auto-sizer": "1.0.6",
+            "react-window": "^1.8.6",
+            "shortid": "^2.2.16"
+          }
+        },
+        "@deephaven/jsapi-bootstrap": {
+          "version": "0.64.0",
+          "resolved": "https://registry.npmjs.org/@deephaven/jsapi-bootstrap/-/jsapi-bootstrap-0.64.0.tgz",
+          "integrity": "sha512-EGTYR1koWlG0nebD/7/1vCnA/McJqFCjIf+uL8y/2D945WMED3CalM3EwCLmXkYlQep0wtm9KgFyIhwenlwaCQ==",
+          "requires": {
+            "@deephaven/components": "^0.64.0",
+            "@deephaven/jsapi-types": "^0.64.0",
+            "@deephaven/log": "^0.64.0",
+            "@deephaven/react-hooks": "^0.64.0"
+          }
+        },
+        "@deephaven/jsapi-components": {
+          "version": "0.64.0",
+          "resolved": "https://registry.npmjs.org/@deephaven/jsapi-components/-/jsapi-components-0.64.0.tgz",
+          "integrity": "sha512-2WeV8IbHbgwAXRIiLM7H2iXTmVd53UKiC9BSdFCynH59o/+CApbinthtS5/e8R7fF2m/DBIe8MrWpCQbPikI8Q==",
+          "requires": {
+            "@deephaven/components": "^0.64.0",
+            "@deephaven/jsapi-bootstrap": "^0.64.0",
+            "@deephaven/jsapi-types": "^0.64.0",
+            "@deephaven/jsapi-utils": "^0.64.0",
+            "@deephaven/log": "^0.64.0",
+            "@deephaven/react-hooks": "^0.64.0",
+            "@deephaven/utils": "^0.64.0",
+            "@types/js-cookie": "^3.0.3",
+            "classnames": "^2.3.2",
+            "js-cookie": "^3.0.5",
+            "lodash.debounce": "^4.0.8",
+            "prop-types": "^15.8.1"
+          }
+        },
+        "@deephaven/jsapi-types": {
+          "version": "0.64.0",
+          "resolved": "https://registry.npmjs.org/@deephaven/jsapi-types/-/jsapi-types-0.64.0.tgz",
+          "integrity": "sha512-8e1YzqRPtRg0bhqUC4R3nZ9ICE/3ITRaLgFOmw8yjtGnp+VWG+RvYp/5EELIizrklfUkuWv/+Z5uxMbQYQNQRQ=="
+        },
+        "@deephaven/jsapi-utils": {
+          "version": "0.64.0",
+          "resolved": "https://registry.npmjs.org/@deephaven/jsapi-utils/-/jsapi-utils-0.64.0.tgz",
+          "integrity": "sha512-U+cCICH8hcehbwqMlgG5+sGS3bcvm4GiY0SB+N15M3spLU3iAbWB5pMYo1lv8hf20TTnIYsJjF52MNp3R+F2FQ==",
+          "requires": {
+            "@deephaven/filters": "^0.64.0",
+            "@deephaven/jsapi-types": "^0.64.0",
+            "@deephaven/log": "^0.64.0",
+            "@deephaven/utils": "^0.64.0",
+            "lodash.clamp": "^4.0.3",
+            "shortid": "^2.2.16"
+          }
+        },
+        "@deephaven/log": {
+          "version": "0.64.0",
+          "resolved": "https://registry.npmjs.org/@deephaven/log/-/log-0.64.0.tgz",
+          "integrity": "sha512-E2/gUb/lfFIGxM/bm0Wimpu+EUVY1xNubItiedMKDEp/dfmVKMVng6XdF2pPw73kaeGAs7NoCbdnWnXdns5QdA==",
+          "requires": {
+            "event-target-shim": "^6.0.2"
+          }
+        },
+        "@deephaven/utils": {
+          "version": "0.64.0",
+          "resolved": "https://registry.npmjs.org/@deephaven/utils/-/utils-0.64.0.tgz",
+          "integrity": "sha512-lt9cXEw0j2KMmUvR/+jmrpmWihrkYxNmhClW778WLFf0oi6Y4V/hsJxiNz+QvFvNbg3HqU6ZBMPHOtCNjKe7bQ=="
+        },
+        "event-target-shim": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-6.0.2.tgz",
+          "integrity": "sha512-8q3LsZjRezbFZ2PN+uP+Q7pnHUMmAOziU2vA2OwoFaKIXxlxl38IylhSSgUorWu/rf4er67w0ikBqjBFk/pomA=="
+        }
       }
     },
     "@deephaven/js-plugin-auth-keycloak": {
@@ -34151,16 +40492,16 @@
     "@deephaven/js-plugin-plotly-express": {
       "version": "file:plugins/plotly-express/src/js",
       "requires": {
-        "@deephaven/chart": "0.62.0",
-        "@deephaven/components": "0.62.0",
-        "@deephaven/dashboard": "0.62.0",
-        "@deephaven/dashboard-core-plugins": "0.62.0",
-        "@deephaven/icons": "0.62.0",
-        "@deephaven/jsapi-bootstrap": "0.62.0",
-        "@deephaven/jsapi-types": "0.62.0",
-        "@deephaven/log": "0.62.0",
-        "@deephaven/plugin": "0.62.0",
-        "@deephaven/utils": "0.62.0",
+        "@deephaven/chart": "0.64.0",
+        "@deephaven/components": "0.64.0",
+        "@deephaven/dashboard": "0.64.0",
+        "@deephaven/dashboard-core-plugins": "0.64.0",
+        "@deephaven/icons": "0.64.0",
+        "@deephaven/jsapi-bootstrap": "0.64.0",
+        "@deephaven/jsapi-types": "0.64.0",
+        "@deephaven/log": "0.64.0",
+        "@deephaven/plugin": "0.64.0",
+        "@deephaven/utils": "0.64.0",
         "@types/deep-equal": "^1.0.1",
         "@types/plotly.js": "^2.12.18",
         "@types/plotly.js-dist-min": "^2.3.1",
@@ -34178,38 +40519,16 @@
         "vite": "~4.1.4"
       },
       "dependencies": {
-        "@deephaven/chart": {
-          "version": "0.62.0",
-          "resolved": "https://registry.npmjs.org/@deephaven/chart/-/chart-0.62.0.tgz",
-          "integrity": "sha512-zakQjG0V+QYdHsr01ThQS2ffhaCnF2a9GtlUDhw43qYfHeEiC2IkkinizY2pYgSJf2CPLNe7ibiIBflifQSBMQ==",
-          "requires": {
-            "@deephaven/components": "^0.62.0",
-            "@deephaven/icons": "^0.62.0",
-            "@deephaven/jsapi-types": "^0.62.0",
-            "@deephaven/jsapi-utils": "^0.62.0",
-            "@deephaven/log": "^0.62.0",
-            "@deephaven/react-hooks": "^0.62.0",
-            "@deephaven/utils": "^0.62.0",
-            "deep-equal": "^2.0.5",
-            "lodash.debounce": "^4.0.8",
-            "lodash.set": "^4.3.2",
-            "memoize-one": "^5.1.1",
-            "memoizee": "^0.4.15",
-            "plotly.js": "^2.18.2",
-            "prop-types": "^15.7.2",
-            "react-plotly.js": "^2.6.0"
-          }
-        },
         "@deephaven/components": {
-          "version": "0.62.0",
-          "resolved": "https://registry.npmjs.org/@deephaven/components/-/components-0.62.0.tgz",
-          "integrity": "sha512-VKHZgsOO/VL1o9CS794eeRAa28lMQCLRrFbp3KgMBGvZVC68+rtuNpxWnc4zRZLZJxFiAxJbyJcleZS6QyW5Vg==",
+          "version": "0.64.0",
+          "resolved": "https://registry.npmjs.org/@deephaven/components/-/components-0.64.0.tgz",
+          "integrity": "sha512-L/G3r94eoHx7OzZM5DpbshGFgvmXyBi0SdmPKp872zfrWu/rcSTrsB2Mz3/QmJIBaO2wn8U5tw5pTKGoML8IfQ==",
           "requires": {
             "@adobe/react-spectrum": "^3.29.0",
-            "@deephaven/icons": "^0.62.0",
-            "@deephaven/log": "^0.62.0",
-            "@deephaven/react-hooks": "^0.62.0",
-            "@deephaven/utils": "^0.62.0",
+            "@deephaven/icons": "^0.64.0",
+            "@deephaven/log": "^0.64.0",
+            "@deephaven/react-hooks": "^0.64.0",
+            "@deephaven/utils": "^0.64.0",
             "@fortawesome/fontawesome-svg-core": "^6.2.1",
             "@fortawesome/react-fontawesome": "^0.2.0",
             "@react-spectrum/theme-default": "^3.5.1",
@@ -34229,46 +40548,17 @@
             "shortid": "^2.2.16"
           }
         },
-        "@deephaven/console": {
-          "version": "0.62.0",
-          "resolved": "https://registry.npmjs.org/@deephaven/console/-/console-0.62.0.tgz",
-          "integrity": "sha512-9jDywMHxiNpUjMMXQhQwI6vwnhEseG1Jf+RreZuTKVFJ4VTmhRg/xG14Bd6p/D6ichVQ4jGtMSLHKmYFYZ9HZg==",
-          "requires": {
-            "@deephaven/chart": "^0.62.0",
-            "@deephaven/components": "^0.62.0",
-            "@deephaven/icons": "^0.62.0",
-            "@deephaven/jsapi-bootstrap": "^0.62.0",
-            "@deephaven/jsapi-types": "^0.62.0",
-            "@deephaven/log": "^0.62.0",
-            "@deephaven/react-hooks": "^0.62.0",
-            "@deephaven/storage": "^0.62.0",
-            "@deephaven/utils": "^0.62.0",
-            "@fortawesome/react-fontawesome": "^0.2.0",
-            "classnames": "^2.3.1",
-            "linkifyjs": "^4.1.0",
-            "lodash.debounce": "^4.0.8",
-            "lodash.throttle": "^4.1.1",
-            "memoize-one": "^5.1.1",
-            "memoizee": "^0.4.15",
-            "monaco-editor": "^0.41.0",
-            "papaparse": "5.3.2",
-            "popper.js": "^1.16.1",
-            "prop-types": "^15.7.2",
-            "shell-quote": "^1.7.2",
-            "shortid": "^2.2.16"
-          }
-        },
         "@deephaven/dashboard": {
-          "version": "0.62.0",
-          "resolved": "https://registry.npmjs.org/@deephaven/dashboard/-/dashboard-0.62.0.tgz",
-          "integrity": "sha512-tBrpe52cl+UK2jtGGz7lIAJdxNm1givhquz4JKEBDJ/k8rqWwucXsxLgJ22nGASzct14xBk2Gb5IeuH/swkUDg==",
+          "version": "0.64.0",
+          "resolved": "https://registry.npmjs.org/@deephaven/dashboard/-/dashboard-0.64.0.tgz",
+          "integrity": "sha512-/8jd2XjSLzm8DP9dCIZD9I+cF5W9qAvxoXT7x4FQ7oUPP8Mog3FHSQSD/xB+6SHlzJTf7YhdDqdCEf1kPLa7IQ==",
           "requires": {
-            "@deephaven/components": "^0.62.0",
-            "@deephaven/golden-layout": "^0.62.0",
-            "@deephaven/log": "^0.62.0",
-            "@deephaven/react-hooks": "^0.62.0",
-            "@deephaven/redux": "^0.62.0",
-            "@deephaven/utils": "^0.62.0",
+            "@deephaven/components": "^0.64.0",
+            "@deephaven/golden-layout": "^0.64.0",
+            "@deephaven/log": "^0.64.0",
+            "@deephaven/react-hooks": "^0.64.0",
+            "@deephaven/redux": "^0.64.0",
+            "@deephaven/utils": "^0.64.0",
             "deep-equal": "^2.0.5",
             "lodash.ismatch": "^4.1.1",
             "lodash.throttle": "^4.1.1",
@@ -34276,262 +40566,69 @@
             "shortid": "^2.2.16"
           }
         },
-        "@deephaven/dashboard-core-plugins": {
-          "version": "0.62.0",
-          "resolved": "https://registry.npmjs.org/@deephaven/dashboard-core-plugins/-/dashboard-core-plugins-0.62.0.tgz",
-          "integrity": "sha512-c5pULTIPABzEJJSZRPBnCmt6OKxt9Vcy4riI0WX7wj+ZDvfo+Sg59ErBpSoY3bHgDsUzV28bmh2Vn+RBQNN8vQ==",
-          "requires": {
-            "@deephaven/chart": "^0.62.0",
-            "@deephaven/components": "^0.62.0",
-            "@deephaven/console": "^0.62.0",
-            "@deephaven/dashboard": "^0.62.0",
-            "@deephaven/file-explorer": "^0.62.0",
-            "@deephaven/filters": "^0.62.0",
-            "@deephaven/golden-layout": "^0.62.0",
-            "@deephaven/grid": "^0.62.0",
-            "@deephaven/icons": "^0.62.0",
-            "@deephaven/iris-grid": "^0.62.0",
-            "@deephaven/jsapi-bootstrap": "^0.62.0",
-            "@deephaven/jsapi-components": "^0.62.0",
-            "@deephaven/jsapi-types": "^0.62.0",
-            "@deephaven/jsapi-utils": "^0.62.0",
-            "@deephaven/log": "^0.62.0",
-            "@deephaven/plugin": "^0.62.0",
-            "@deephaven/react-hooks": "^0.62.0",
-            "@deephaven/redux": "^0.62.0",
-            "@deephaven/storage": "^0.62.0",
-            "@deephaven/utils": "^0.62.0",
-            "@fortawesome/react-fontawesome": "^0.2.0",
-            "classnames": "^2.3.1",
-            "deep-equal": "^2.0.5",
-            "lodash.clamp": "^4.0.3",
-            "lodash.debounce": "^4.0.8",
-            "lodash.throttle": "^4.1.1",
-            "memoize-one": "^5.1.1",
-            "memoizee": "^0.4.15",
-            "prop-types": "^15.7.2",
-            "react-markdown": "^6.0.2",
-            "react-transition-group": "^4.4.2",
-            "redux": "^4.2.0",
-            "redux-thunk": "^2.4.1",
-            "remark-gfm": "1.0.0",
-            "shortid": "^2.2.16"
-          }
-        },
-        "@deephaven/file-explorer": {
-          "version": "0.62.0",
-          "resolved": "https://registry.npmjs.org/@deephaven/file-explorer/-/file-explorer-0.62.0.tgz",
-          "integrity": "sha512-pc6cH34DNkRxeWgy2ofGv/HUIGpI57LWLxVlnPqX7El/Q+Ma3cSBqj1sQH0uz5uNwP5WHv8q0L32JrJXJef0/Q==",
-          "requires": {
-            "@deephaven/components": "^0.62.0",
-            "@deephaven/icons": "^0.62.0",
-            "@deephaven/log": "^0.62.0",
-            "@deephaven/storage": "^0.62.0",
-            "@deephaven/utils": "^0.62.0",
-            "@fortawesome/fontawesome-svg-core": "^6.2.1",
-            "@fortawesome/react-fontawesome": "^0.2.0",
-            "classnames": "^2.3.1",
-            "lodash.throttle": "^4.1.1",
-            "prop-types": "^15.7.2"
-          }
-        },
-        "@deephaven/filters": {
-          "version": "0.62.0",
-          "resolved": "https://registry.npmjs.org/@deephaven/filters/-/filters-0.62.0.tgz",
-          "integrity": "sha512-WTa3z250SRoh8xYmL3gdfddPOwqZBj95sVKaj3LBGGepcTO0Me3vCp9nODl8MyUBaOGBsCXIsrnWX6DFjkiGLQ=="
-        },
         "@deephaven/golden-layout": {
-          "version": "0.62.0",
-          "resolved": "https://registry.npmjs.org/@deephaven/golden-layout/-/golden-layout-0.62.0.tgz",
-          "integrity": "sha512-eeXz4GHm3JO8S8GNr5SGrdoeyuktwsH8cFwDy5V3WOVut1QwGVkPiTNb63Lt7F55rdLeuOHVdsXDYNDnDUcZtQ==",
+          "version": "0.64.0",
+          "resolved": "https://registry.npmjs.org/@deephaven/golden-layout/-/golden-layout-0.64.0.tgz",
+          "integrity": "sha512-MP5H8EvhdVEJzJKDPEp5xO1kBjqbv8hg/PMkR7EcFJJjxvTcJXcx24prfqBDeHVHbcWzDce5HeI56j6I93iFwQ==",
           "requires": {
-            "@deephaven/components": "^0.62.0",
+            "@deephaven/components": "^0.64.0",
             "jquery": "^3.6.0"
           }
         },
-        "@deephaven/grid": {
-          "version": "0.62.0",
-          "resolved": "https://registry.npmjs.org/@deephaven/grid/-/grid-0.62.0.tgz",
-          "integrity": "sha512-rqCfJUtu83ApSSBJPOFx6bUyZG+5PMb+CGx74xg8QQ1OO61whfNOW5+A1DWRPnpK3GdOqmu+KMH39KPCXKVLTg==",
-          "requires": {
-            "@deephaven/utils": "^0.62.0",
-            "classnames": "^2.3.1",
-            "color-convert": "^2.0.1",
-            "event-target-shim": "^6.0.2",
-            "linkifyjs": "^4.1.0",
-            "lodash.clamp": "^4.0.3",
-            "memoize-one": "^5.1.1",
-            "memoizee": "^0.4.15",
-            "prop-types": "^15.7.2"
-          }
-        },
-        "@deephaven/icons": {
-          "version": "0.62.0",
-          "resolved": "https://registry.npmjs.org/@deephaven/icons/-/icons-0.62.0.tgz",
-          "integrity": "sha512-KQUftXbKj5Oww+Fxjto+wDcr8sFUP1ghhl6ZlynfbIx7KJg6QM6LDwyHIfMv+RX1MQID+i9gcGLnPfBYak7d6A==",
-          "requires": {
-            "@fortawesome/fontawesome-common-types": "^6.1.1"
-          }
-        },
-        "@deephaven/iris-grid": {
-          "version": "0.62.0",
-          "resolved": "https://registry.npmjs.org/@deephaven/iris-grid/-/iris-grid-0.62.0.tgz",
-          "integrity": "sha512-LkEbiCEE7MlBC0coaA6gw0tTG77+sV2FDmmK4MuTf0R6PE+EwXCtRdRPrknbBq4DsZynAsWRKB5PIBszQdt3Cw==",
-          "requires": {
-            "@deephaven/components": "^0.62.0",
-            "@deephaven/console": "^0.62.0",
-            "@deephaven/filters": "^0.62.0",
-            "@deephaven/grid": "^0.62.0",
-            "@deephaven/icons": "^0.62.0",
-            "@deephaven/jsapi-components": "^0.62.0",
-            "@deephaven/jsapi-types": "^0.62.0",
-            "@deephaven/jsapi-utils": "^0.62.0",
-            "@deephaven/log": "^0.62.0",
-            "@deephaven/react-hooks": "^0.62.0",
-            "@deephaven/storage": "^0.62.0",
-            "@deephaven/utils": "^0.62.0",
-            "@dnd-kit/core": "^6.0.5",
-            "@dnd-kit/sortable": "^7.0.0",
-            "@dnd-kit/utilities": "^3.2.0",
-            "@fortawesome/react-fontawesome": "^0.2.0",
-            "classnames": "^2.3.1",
-            "deep-equal": "^2.0.5",
-            "lodash.clamp": "^4.0.3",
-            "lodash.debounce": "^4.0.8",
-            "lodash.throttle": "^4.1.1",
-            "memoize-one": "^5.1.1",
-            "memoizee": "^0.4.15",
-            "monaco-editor": "^0.41.0",
-            "prop-types": "^15.7.2",
-            "react-beautiful-dnd": "^13.1.0",
-            "react-transition-group": "^4.4.2",
-            "shortid": "^2.2.16"
-          }
-        },
         "@deephaven/jsapi-bootstrap": {
-          "version": "0.62.0",
-          "resolved": "https://registry.npmjs.org/@deephaven/jsapi-bootstrap/-/jsapi-bootstrap-0.62.0.tgz",
-          "integrity": "sha512-LjXAn2nIyjiIyV7zsjAp921IPrknori6Yzh3RhgqTh8fWLF2x8RNWFpk7AGF/WKfzDJbMrpQ36u3B79PecmTaw==",
+          "version": "0.64.0",
+          "resolved": "https://registry.npmjs.org/@deephaven/jsapi-bootstrap/-/jsapi-bootstrap-0.64.0.tgz",
+          "integrity": "sha512-EGTYR1koWlG0nebD/7/1vCnA/McJqFCjIf+uL8y/2D945WMED3CalM3EwCLmXkYlQep0wtm9KgFyIhwenlwaCQ==",
           "requires": {
-            "@deephaven/components": "^0.62.0",
-            "@deephaven/jsapi-types": "^0.62.0",
-            "@deephaven/log": "^0.62.0",
-            "@deephaven/react-hooks": "^0.62.0"
-          }
-        },
-        "@deephaven/jsapi-components": {
-          "version": "0.62.0",
-          "resolved": "https://registry.npmjs.org/@deephaven/jsapi-components/-/jsapi-components-0.62.0.tgz",
-          "integrity": "sha512-S1zouiD9Imd6g+UsSmrRRykA3IbHw7LLWxoG26sA6ITuNCXw76vpM++mPWsHkAau3WQNxI9QVEUuhHEWkrnK+g==",
-          "requires": {
-            "@deephaven/components": "^0.62.0",
-            "@deephaven/jsapi-bootstrap": "^0.62.0",
-            "@deephaven/jsapi-types": "^0.62.0",
-            "@deephaven/jsapi-utils": "^0.62.0",
-            "@deephaven/log": "^0.62.0",
-            "@deephaven/react-hooks": "^0.62.0",
-            "@deephaven/utils": "^0.62.0",
-            "@types/js-cookie": "^3.0.3",
-            "classnames": "^2.3.2",
-            "js-cookie": "^3.0.5",
-            "lodash.debounce": "^4.0.8",
-            "prop-types": "^15.8.1"
+            "@deephaven/components": "^0.64.0",
+            "@deephaven/jsapi-types": "^0.64.0",
+            "@deephaven/log": "^0.64.0",
+            "@deephaven/react-hooks": "^0.64.0"
           }
         },
         "@deephaven/jsapi-types": {
-          "version": "0.62.0",
-          "resolved": "https://registry.npmjs.org/@deephaven/jsapi-types/-/jsapi-types-0.62.0.tgz",
-          "integrity": "sha512-5R/SdTsID37S+tn+l62xOeecSccmnhJtn0/+VOP1taPAZGRcOak36gVJnEos/4hJruiJK1Dri3v9M8P/GfLn8g=="
+          "version": "0.64.0",
+          "resolved": "https://registry.npmjs.org/@deephaven/jsapi-types/-/jsapi-types-0.64.0.tgz",
+          "integrity": "sha512-8e1YzqRPtRg0bhqUC4R3nZ9ICE/3ITRaLgFOmw8yjtGnp+VWG+RvYp/5EELIizrklfUkuWv/+Z5uxMbQYQNQRQ=="
         },
         "@deephaven/jsapi-utils": {
-          "version": "0.62.0",
-          "resolved": "https://registry.npmjs.org/@deephaven/jsapi-utils/-/jsapi-utils-0.62.0.tgz",
-          "integrity": "sha512-yWAk+zo2DOViROdpWRmA56xDwZotskIgyJCSO+9wFNxIo2YMUJNydtkB0vLWxXj/+lWWo0qTnbbDD+wNFoFTtg==",
+          "version": "0.64.0",
+          "resolved": "https://registry.npmjs.org/@deephaven/jsapi-utils/-/jsapi-utils-0.64.0.tgz",
+          "integrity": "sha512-U+cCICH8hcehbwqMlgG5+sGS3bcvm4GiY0SB+N15M3spLU3iAbWB5pMYo1lv8hf20TTnIYsJjF52MNp3R+F2FQ==",
           "requires": {
-            "@deephaven/filters": "^0.62.0",
-            "@deephaven/jsapi-types": "^0.62.0",
-            "@deephaven/log": "^0.62.0",
-            "@deephaven/utils": "^0.62.0",
+            "@deephaven/filters": "^0.64.0",
+            "@deephaven/jsapi-types": "^0.64.0",
+            "@deephaven/log": "^0.64.0",
+            "@deephaven/utils": "^0.64.0",
             "lodash.clamp": "^4.0.3",
             "shortid": "^2.2.16"
           }
         },
         "@deephaven/log": {
-          "version": "0.62.0",
-          "resolved": "https://registry.npmjs.org/@deephaven/log/-/log-0.62.0.tgz",
-          "integrity": "sha512-k3CDUJ21u1MzEb/C15qQCGKkXuVzO4Pc3KUTHSYMCyRDyskKbpcyQM88rYiQKFtp2Igyb6mvAdKIj7uubPc8Aw==",
+          "version": "0.64.0",
+          "resolved": "https://registry.npmjs.org/@deephaven/log/-/log-0.64.0.tgz",
+          "integrity": "sha512-E2/gUb/lfFIGxM/bm0Wimpu+EUVY1xNubItiedMKDEp/dfmVKMVng6XdF2pPw73kaeGAs7NoCbdnWnXdns5QdA==",
           "requires": {
             "event-target-shim": "^6.0.2"
           }
         },
-        "@deephaven/plugin": {
-          "version": "0.62.0",
-          "resolved": "https://registry.npmjs.org/@deephaven/plugin/-/plugin-0.62.0.tgz",
-          "integrity": "sha512-IokazAXbWLoITsAlnK+VM3HXtL5zpjH1DWY0mETpJwlMP6kAolhbc/UfDC2bRFYlQzTTHEPjVPVtRskse4JRAA==",
-          "requires": {
-            "@deephaven/components": "^0.62.0",
-            "@deephaven/golden-layout": "^0.62.0",
-            "@deephaven/icons": "^0.62.0",
-            "@deephaven/iris-grid": "^0.62.0",
-            "@deephaven/jsapi-types": "^0.62.0",
-            "@deephaven/log": "^0.62.0",
-            "@deephaven/react-hooks": "^0.62.0",
-            "@fortawesome/fontawesome-common-types": "^6.1.1",
-            "@fortawesome/react-fontawesome": "^0.2.0"
-          }
-        },
-        "@deephaven/react-hooks": {
-          "version": "0.62.0",
-          "resolved": "https://registry.npmjs.org/@deephaven/react-hooks/-/react-hooks-0.62.0.tgz",
-          "integrity": "sha512-jlCqhSWa9V/jyfynZjPc+WlbQQAnhIilpQvI7bdU9q4fTRDfQvd0nSqr0sA0xODgGq8kBgz+6yzZ9yVWsg7IIA==",
-          "requires": {
-            "@adobe/react-spectrum": "^3.29.0",
-            "@deephaven/log": "^0.62.0",
-            "@deephaven/utils": "^0.62.0",
-            "lodash.debounce": "^4.0.8",
-            "shortid": "^2.2.16"
-          }
-        },
         "@deephaven/redux": {
-          "version": "0.62.0",
-          "resolved": "https://registry.npmjs.org/@deephaven/redux/-/redux-0.62.0.tgz",
-          "integrity": "sha512-vmbSAKymKrPlgo3NJ8S/fl/ifjBv3R9pC0Ms/1HqsfNOftXKVlUKSRv/crZPcNWoLsD7fSufPs2lLVQijgXvjg==",
+          "version": "0.64.0",
+          "resolved": "https://registry.npmjs.org/@deephaven/redux/-/redux-0.64.0.tgz",
+          "integrity": "sha512-mnBMzJCUhBKDnA7yJGY49lJickgqDGb4ck2FpQEUtpzSsquOmjtz4glxBOgaNN3vLbm1bfXJyKUqkT08Hjknfw==",
           "requires": {
-            "@deephaven/jsapi-types": "^0.62.0",
-            "@deephaven/jsapi-utils": "^0.62.0",
-            "@deephaven/log": "^0.62.0",
-            "@deephaven/plugin": "^0.62.0",
+            "@deephaven/jsapi-types": "^0.64.0",
+            "@deephaven/jsapi-utils": "^0.64.0",
+            "@deephaven/log": "^0.64.0",
+            "@deephaven/plugin": "^0.64.0",
             "deep-equal": "^2.0.5",
             "redux-thunk": "2.4.1"
           }
         },
-        "@deephaven/storage": {
-          "version": "0.62.0",
-          "resolved": "https://registry.npmjs.org/@deephaven/storage/-/storage-0.62.0.tgz",
-          "integrity": "sha512-4ALHUPLTkNxmI3rxtjQ46631SIMQZlCI4lwamjQufg06f/KNPOkS2VIp2ZRoyiHhha0pnGADaOWqB6bAdKMMFA==",
-          "requires": {
-            "@deephaven/filters": "^0.62.0",
-            "@deephaven/log": "^0.62.0",
-            "lodash.throttle": "^4.1.1"
-          }
-        },
         "@deephaven/utils": {
-          "version": "0.62.0",
-          "resolved": "https://registry.npmjs.org/@deephaven/utils/-/utils-0.62.0.tgz",
-          "integrity": "sha512-faAhWYpMBSXNVD9hw9VP88pIbNkcPqQkodTdSEitc5MguYg65pP2a63ylYkR0xCgWM5jViy797LY1w3c8ZGgIA=="
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+          "version": "0.64.0",
+          "resolved": "https://registry.npmjs.org/@deephaven/utils/-/utils-0.64.0.tgz",
+          "integrity": "sha512-lt9cXEw0j2KMmUvR/+jmrpmWihrkYxNmhClW778WLFf0oi6Y4V/hsJxiNz+QvFvNbg3HqU6ZBMPHOtCNjKe7bQ=="
         },
         "event-target-shim": {
           "version": "6.0.2",
@@ -35070,12 +41167,123 @@
         }
       }
     },
+    "@deephaven/plugin": {
+      "version": "0.64.0",
+      "resolved": "https://registry.npmjs.org/@deephaven/plugin/-/plugin-0.64.0.tgz",
+      "integrity": "sha512-bMHriX77WQ/iCyU1xas9CjRIkxfcOeUTVv02LUqIMzPvftVlqNKrEoRHz2txu0UFDWCDvB3HrgvwVOi2aTGb3A==",
+      "requires": {
+        "@deephaven/components": "^0.64.0",
+        "@deephaven/golden-layout": "^0.64.0",
+        "@deephaven/icons": "^0.64.0",
+        "@deephaven/iris-grid": "^0.64.0",
+        "@deephaven/jsapi-types": "^0.64.0",
+        "@deephaven/log": "^0.64.0",
+        "@deephaven/react-hooks": "^0.64.0",
+        "@fortawesome/fontawesome-common-types": "^6.1.1",
+        "@fortawesome/react-fontawesome": "^0.2.0"
+      },
+      "dependencies": {
+        "@deephaven/components": {
+          "version": "0.64.0",
+          "resolved": "https://registry.npmjs.org/@deephaven/components/-/components-0.64.0.tgz",
+          "integrity": "sha512-L/G3r94eoHx7OzZM5DpbshGFgvmXyBi0SdmPKp872zfrWu/rcSTrsB2Mz3/QmJIBaO2wn8U5tw5pTKGoML8IfQ==",
+          "requires": {
+            "@adobe/react-spectrum": "^3.29.0",
+            "@deephaven/icons": "^0.64.0",
+            "@deephaven/log": "^0.64.0",
+            "@deephaven/react-hooks": "^0.64.0",
+            "@deephaven/utils": "^0.64.0",
+            "@fortawesome/fontawesome-svg-core": "^6.2.1",
+            "@fortawesome/react-fontawesome": "^0.2.0",
+            "@react-spectrum/theme-default": "^3.5.1",
+            "bootstrap": "4.6.2",
+            "classnames": "^2.3.1",
+            "event-target-shim": "^6.0.2",
+            "lodash.clamp": "^4.0.3",
+            "lodash.debounce": "^4.0.8",
+            "lodash.flatten": "^4.4.0",
+            "memoizee": "^0.4.15",
+            "popper.js": "^1.16.1",
+            "prop-types": "^15.7.2",
+            "react-beautiful-dnd": "^13.1.0",
+            "react-transition-group": "^4.4.2",
+            "react-virtualized-auto-sizer": "1.0.6",
+            "react-window": "^1.8.6",
+            "shortid": "^2.2.16"
+          }
+        },
+        "@deephaven/golden-layout": {
+          "version": "0.64.0",
+          "resolved": "https://registry.npmjs.org/@deephaven/golden-layout/-/golden-layout-0.64.0.tgz",
+          "integrity": "sha512-MP5H8EvhdVEJzJKDPEp5xO1kBjqbv8hg/PMkR7EcFJJjxvTcJXcx24prfqBDeHVHbcWzDce5HeI56j6I93iFwQ==",
+          "requires": {
+            "@deephaven/components": "^0.64.0",
+            "jquery": "^3.6.0"
+          }
+        },
+        "@deephaven/jsapi-types": {
+          "version": "0.64.0",
+          "resolved": "https://registry.npmjs.org/@deephaven/jsapi-types/-/jsapi-types-0.64.0.tgz",
+          "integrity": "sha512-8e1YzqRPtRg0bhqUC4R3nZ9ICE/3ITRaLgFOmw8yjtGnp+VWG+RvYp/5EELIizrklfUkuWv/+Z5uxMbQYQNQRQ=="
+        },
+        "@deephaven/log": {
+          "version": "0.64.0",
+          "resolved": "https://registry.npmjs.org/@deephaven/log/-/log-0.64.0.tgz",
+          "integrity": "sha512-E2/gUb/lfFIGxM/bm0Wimpu+EUVY1xNubItiedMKDEp/dfmVKMVng6XdF2pPw73kaeGAs7NoCbdnWnXdns5QdA==",
+          "requires": {
+            "event-target-shim": "^6.0.2"
+          }
+        },
+        "@deephaven/utils": {
+          "version": "0.64.0",
+          "resolved": "https://registry.npmjs.org/@deephaven/utils/-/utils-0.64.0.tgz",
+          "integrity": "sha512-lt9cXEw0j2KMmUvR/+jmrpmWihrkYxNmhClW778WLFf0oi6Y4V/hsJxiNz+QvFvNbg3HqU6ZBMPHOtCNjKe7bQ=="
+        },
+        "event-target-shim": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-6.0.2.tgz",
+          "integrity": "sha512-8q3LsZjRezbFZ2PN+uP+Q7pnHUMmAOziU2vA2OwoFaKIXxlxl38IylhSSgUorWu/rf4er67w0ikBqjBFk/pomA=="
+        }
+      }
+    },
     "@deephaven/prettier-config": {
       "version": "0.40.0",
       "resolved": "https://registry.npmjs.org/@deephaven/prettier-config/-/prettier-config-0.40.0.tgz",
       "integrity": "sha512-jnzyj7AFRtTVGflPJzbNvdVL2lSb0ah5NPwHZ9sNyfwHoB0mUK8Jy0JNv2DqHD96LpFQLdQS+2QK3ouTFEZHXg==",
       "dev": true,
       "requires": {}
+    },
+    "@deephaven/react-hooks": {
+      "version": "0.64.0",
+      "resolved": "https://registry.npmjs.org/@deephaven/react-hooks/-/react-hooks-0.64.0.tgz",
+      "integrity": "sha512-Y1VpFh8F5NVoXmcwQMBGbi/eAoN/JBds2+Nm33FQ4pkL1C20+RAdwthD0z6hW0Sn1hqNZzZMNV+/w0L9eEgkIA==",
+      "requires": {
+        "@adobe/react-spectrum": "^3.29.0",
+        "@deephaven/log": "^0.64.0",
+        "@deephaven/utils": "^0.64.0",
+        "lodash.debounce": "^4.0.8",
+        "shortid": "^2.2.16"
+      },
+      "dependencies": {
+        "@deephaven/log": {
+          "version": "0.64.0",
+          "resolved": "https://registry.npmjs.org/@deephaven/log/-/log-0.64.0.tgz",
+          "integrity": "sha512-E2/gUb/lfFIGxM/bm0Wimpu+EUVY1xNubItiedMKDEp/dfmVKMVng6XdF2pPw73kaeGAs7NoCbdnWnXdns5QdA==",
+          "requires": {
+            "event-target-shim": "^6.0.2"
+          }
+        },
+        "@deephaven/utils": {
+          "version": "0.64.0",
+          "resolved": "https://registry.npmjs.org/@deephaven/utils/-/utils-0.64.0.tgz",
+          "integrity": "sha512-lt9cXEw0j2KMmUvR/+jmrpmWihrkYxNmhClW778WLFf0oi6Y4V/hsJxiNz+QvFvNbg3HqU6ZBMPHOtCNjKe7bQ=="
+        },
+        "event-target-shim": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-6.0.2.tgz",
+          "integrity": "sha512-8q3LsZjRezbFZ2PN+uP+Q7pnHUMmAOziU2vA2OwoFaKIXxlxl38IylhSSgUorWu/rf4er67w0ikBqjBFk/pomA=="
+        }
+      }
     },
     "@deephaven/redux": {
       "version": "0.40.4",
@@ -35094,6 +41302,31 @@
           "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.4.1.tgz",
           "integrity": "sha512-OOYGNY5Jy2TWvTL1KgAlVy6dcx3siPJ1wTq741EPyUKfn6W6nChdICjZwCd0p8AZBs5kWpZlbkXW2nE/zjUa+Q==",
           "requires": {}
+        }
+      }
+    },
+    "@deephaven/storage": {
+      "version": "0.64.0",
+      "resolved": "https://registry.npmjs.org/@deephaven/storage/-/storage-0.64.0.tgz",
+      "integrity": "sha512-QFZ+ul70U6I2YrCEjLhMh7pnRowhSsgqRS4Tg5Y4Ydob6fBl1cp4w41FxuHnO/+1gZznWdpfGL6kYVrcL2qAeA==",
+      "requires": {
+        "@deephaven/filters": "^0.64.0",
+        "@deephaven/log": "^0.64.0",
+        "lodash.throttle": "^4.1.1"
+      },
+      "dependencies": {
+        "@deephaven/log": {
+          "version": "0.64.0",
+          "resolved": "https://registry.npmjs.org/@deephaven/log/-/log-0.64.0.tgz",
+          "integrity": "sha512-E2/gUb/lfFIGxM/bm0Wimpu+EUVY1xNubItiedMKDEp/dfmVKMVng6XdF2pPw73kaeGAs7NoCbdnWnXdns5QdA==",
+          "requires": {
+            "event-target-shim": "^6.0.2"
+          }
+        },
+        "event-target-shim": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-6.0.2.tgz",
+          "integrity": "sha512-8q3LsZjRezbFZ2PN+uP+Q7pnHUMmAOziU2vA2OwoFaKIXxlxl38IylhSSgUorWu/rf4er67w0ikBqjBFk/pomA=="
         }
       }
     },
@@ -40506,8 +46739,7 @@
     "@tootallnate/once": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
-      "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
-      "dev": true
+      "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A=="
     },
     "@tufjs/canonical-json": {
       "version": "1.0.0",
@@ -40630,6 +46862,14 @@
       "dev": true,
       "requires": {
         "@babel/types": "^7.20.7"
+      }
+    },
+    "@types/debug": {
+      "version": "4.1.12",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
+      "integrity": "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==",
+      "requires": {
+        "@types/ms": "*"
       }
     },
     "@types/deep-equal": {
@@ -40757,6 +46997,16 @@
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true
     },
+    "@types/katex": {
+      "version": "0.16.7",
+      "resolved": "https://registry.npmjs.org/@types/katex/-/katex-0.16.7.tgz",
+      "integrity": "sha512-HMwFiRujE5PjrgwHQ25+bsLJgowjGjm5Z8FVSf0N6PwgJrwxH0QxzHYDcKsTfV3wva0vzrpqMTJS2jXPr5BMEQ=="
+    },
+    "@types/mathjax": {
+      "version": "0.0.37",
+      "resolved": "https://registry.npmjs.org/@types/mathjax/-/mathjax-0.0.37.tgz",
+      "integrity": "sha512-y0WSZBtBNQwcYipTU/BhgeFu1EZNlFvUNCmkMXV9kBQZq7/o5z82dNVyH3yy2Xv5zzeNeQoHSL4Xm06+EQiH+g=="
+    },
     "@types/mdast": {
       "version": "3.0.15",
       "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-3.0.15.tgz",
@@ -40776,6 +47026,11 @@
       "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.5.tgz",
       "integrity": "sha512-hov8bUuiLiyFPGyFPE1lwWhmzYbirOXQNNo40+y3zow8aFVTeyn3VWL0VFFfdNddA8S4Vf0Tc062rzyNr7Paag==",
       "dev": true
+    },
+    "@types/ms": {
+      "version": "0.7.34",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.34.tgz",
+      "integrity": "sha512-nG96G3Wp6acyAgJqGasjODb+acrI7KltPiRxzHPXnP3NgI28bpQDRv53olbqGXbfcgF5aiiHmO3xpwEpS5Ld9g=="
     },
     "@types/node": {
       "version": "20.10.1",
@@ -41166,8 +47421,7 @@
     "abab": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.6.tgz",
-      "integrity": "sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==",
-      "dev": true
+      "integrity": "sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA=="
     },
     "abbrev": {
       "version": "2.0.0",
@@ -41192,14 +47446,12 @@
     "acorn": {
       "version": "8.11.2",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.2.tgz",
-      "integrity": "sha512-nc0Axzp/0FILLEVsm4fNwLCwMttvhEI263QtVPQcbpfZZ3ts0hLsZGOpE6czNlid7CJ9MlyH8reXkpsf3YUY4w==",
-      "dev": true
+      "integrity": "sha512-nc0Axzp/0FILLEVsm4fNwLCwMttvhEI263QtVPQcbpfZZ3ts0hLsZGOpE6czNlid7CJ9MlyH8reXkpsf3YUY4w=="
     },
     "acorn-globals": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-7.0.1.tgz",
       "integrity": "sha512-umOSDSDrfHbTNPuNpC2NSnnA3LUrqpevPb4T9jRx4MagXNS0rs+gwiTcAvqCRmsD6utzsrzNt+ebm00SNWiC3Q==",
-      "dev": true,
       "requires": {
         "acorn": "^8.1.0",
         "acorn-walk": "^8.0.2"
@@ -41215,8 +47467,7 @@
     "acorn-walk": {
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.0.tgz",
-      "integrity": "sha512-FS7hV565M5l1R08MXqo8odwMTB02C2UqzB17RVgu9EyuYFBqJZ3/ZY97sQD5FewVu1UyDFc1yztUDrAwT0EypA==",
-      "dev": true
+      "integrity": "sha512-FS7hV565M5l1R08MXqo8odwMTB02C2UqzB17RVgu9EyuYFBqJZ3/ZY97sQD5FewVu1UyDFc1yztUDrAwT0EypA=="
     },
     "add-stream": {
       "version": "1.0.0",
@@ -41228,7 +47479,6 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
       "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "dev": true,
       "requires": {
         "debug": "4"
       }
@@ -41515,8 +47765,7 @@
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "at-least-node": {
       "version": "1.0.0",
@@ -42427,7 +48676,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -42968,14 +49216,12 @@
     "cssom": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.5.0.tgz",
-      "integrity": "sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw==",
-      "dev": true
+      "integrity": "sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw=="
     },
     "cssstyle": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-2.3.0.tgz",
       "integrity": "sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==",
-      "dev": true,
       "requires": {
         "cssom": "~0.3.6"
       },
@@ -42983,8 +49229,7 @@
         "cssom": {
           "version": "0.3.8",
           "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
-          "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
-          "dev": true
+          "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg=="
         }
       }
     },
@@ -43122,7 +49367,6 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-3.0.2.tgz",
       "integrity": "sha512-Jy/tj3ldjZJo63sVAvg6LHt2mHvl4V6AgRAmNDtLdm7faqtsx+aJG42rsyCo9JCoRVKwPFzKlIPx3DIibwSIaQ==",
-      "dev": true,
       "requires": {
         "abab": "^2.0.6",
         "whatwg-mimetype": "^3.0.0",
@@ -43170,8 +49414,22 @@
     "decimal.js": {
       "version": "10.4.3",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.4.3.tgz",
-      "integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA==",
-      "dev": true
+      "integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA=="
+    },
+    "decode-named-character-reference": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.0.2.tgz",
+      "integrity": "sha512-O8x12RzrUF8xyVcY0KJowWsmaJxQbmy0/EtnNtHRpsOcT7dFk5W598coHqBVpmWo1oQQfsCqfCmkZN5DJrZVdg==",
+      "requires": {
+        "character-entities": "^2.0.0"
+      },
+      "dependencies": {
+        "character-entities": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+          "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ=="
+        }
+      }
     },
     "dedent": {
       "version": "1.5.1",
@@ -43275,8 +49533,7 @@
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "dev": true
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
     },
     "delegates": {
       "version": "1.0.0",
@@ -43293,8 +49550,7 @@
     "dequal": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
-      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-      "dev": true
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="
     },
     "detect-indent": {
       "version": "5.0.0",
@@ -43312,6 +49568,19 @@
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
       "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
       "dev": true
+    },
+    "devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "requires": {
+        "dequal": "^2.0.0"
+      }
+    },
+    "diff": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.0.tgz",
+      "integrity": "sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A=="
     },
     "diff-sequences": {
       "version": "29.6.3",
@@ -43356,7 +49625,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/domexception/-/domexception-4.0.0.tgz",
       "integrity": "sha512-A2is4PLG+eeSfoTMA95/s4pvAoSo2mKtiM5jlHkAVewmiO8ISFTFKZjH7UAM1Atli/OT/7JHOrJRJiMKUZKYBw==",
-      "dev": true,
       "requires": {
         "webidl-conversions": "^7.0.0"
       }
@@ -43548,8 +49816,7 @@
     "entities": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
-      "dev": true
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="
     },
     "env-paths": {
       "version": "2.2.1",
@@ -43780,7 +50047,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
       "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
-      "dev": true,
       "requires": {
         "esprima": "^4.0.1",
         "estraverse": "^5.2.0",
@@ -44259,6 +50525,11 @@
       "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
       "dev": true
     },
+    "esm": {
+      "version": "3.2.25",
+      "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
+      "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA=="
+    },
     "espree": {
       "version": "9.6.1",
       "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
@@ -44296,8 +50567,7 @@
     "estraverse": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-      "dev": true
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="
     },
     "esutils": {
       "version": "2.0.3",
@@ -45200,7 +51470,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
       "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-      "dev": true,
       "requires": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -46065,6 +52334,77 @@
         "function-bind": "^1.1.2"
       }
     },
+    "hast-util-from-dom": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/hast-util-from-dom/-/hast-util-from-dom-4.2.0.tgz",
+      "integrity": "sha512-t1RJW/OpJbCAJQeKi3Qrj1cAOLA0+av/iPFori112+0X7R3wng+jxLA+kXec8K4szqPRGI8vPxbbpEYvvpwaeQ==",
+      "requires": {
+        "hastscript": "^7.0.0",
+        "web-namespaces": "^2.0.0"
+      }
+    },
+    "hast-util-is-element": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-2.1.3.tgz",
+      "integrity": "sha512-O1bKah6mhgEq2WtVMk+Ta5K7pPMqsBBlmzysLdcwKVrqzZQ0CHqUPiIVspNhAG1rvxpvJjtGee17XfauZYKqVA==",
+      "requires": {
+        "@types/hast": "^2.0.0",
+        "@types/unist": "^2.0.0"
+      }
+    },
+    "hast-util-parse-selector": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-3.1.1.tgz",
+      "integrity": "sha512-jdlwBjEexy1oGz0aJ2f4GKMaVKkA9jwjr4MjAAI22E5fM/TXVZHuS5OpONtdeIkRKqAaryQ2E9xNQxijoThSZA==",
+      "requires": {
+        "@types/hast": "^2.0.0"
+      }
+    },
+    "hast-util-to-text": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/hast-util-to-text/-/hast-util-to-text-3.1.2.tgz",
+      "integrity": "sha512-tcllLfp23dJJ+ju5wCCZHVpzsQQ43+moJbqVX3jNWPB7z/KFC4FyZD6R7y94cHL6MQ33YtMZL8Z0aIXXI4XFTw==",
+      "requires": {
+        "@types/hast": "^2.0.0",
+        "@types/unist": "^2.0.0",
+        "hast-util-is-element": "^2.0.0",
+        "unist-util-find-after": "^4.0.0"
+      }
+    },
+    "hast-util-whitespace": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-2.0.1.tgz",
+      "integrity": "sha512-nAxA0v8+vXSBDt3AnRUNjyRIQ0rD+ntpbAp4LnPkumc5M9yUbSMa4XDU9Q6etY4f1Wp4bNgvc1yjiZtsTTrSng=="
+    },
+    "hastscript": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-7.2.0.tgz",
+      "integrity": "sha512-TtYPq24IldU8iKoJQqvZOuhi5CyCQRAbvDOX0x1eW6rsHSxa/1i2CCiptNTotGHJ3VoHRGmqiv6/D3q113ikkw==",
+      "requires": {
+        "@types/hast": "^2.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-parse-selector": "^3.0.0",
+        "property-information": "^6.0.0",
+        "space-separated-tokens": "^2.0.0"
+      },
+      "dependencies": {
+        "comma-separated-tokens": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+          "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg=="
+        },
+        "property-information": {
+          "version": "6.4.1",
+          "resolved": "https://registry.npmjs.org/property-information/-/property-information-6.4.1.tgz",
+          "integrity": "sha512-OHYtXfu5aI2sS2LWFSN5rgJjrQ4pCy8i1jubJLe2QvMF8JJ++HXTUIVWFLfXJoaOfvYYjk2SN8J2wFUWIGXT4w=="
+        },
+        "space-separated-tokens": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+          "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q=="
+        }
+      }
+    },
     "hoist-non-react-statics": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
@@ -46106,7 +52446,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-3.0.0.tgz",
       "integrity": "sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==",
-      "dev": true,
       "requires": {
         "whatwg-encoding": "^2.0.0"
       }
@@ -46134,7 +52473,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
       "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
-      "dev": true,
       "requires": {
         "@tootallnate/once": "2",
         "agent-base": "6",
@@ -46145,7 +52483,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
       "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-      "dev": true,
       "requires": {
         "agent-base": "6",
         "debug": "4"
@@ -46749,8 +53086,7 @@
     "is-potential-custom-element-name": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
-      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
-      "dev": true
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ=="
     },
     "is-promise": {
       "version": "2.2.2",
@@ -48826,7 +55162,6 @@
       "version": "20.0.3",
       "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-20.0.3.tgz",
       "integrity": "sha512-SYhBvTh89tTfCD/CRdSOm13mOBa42iTaTyfyEWBdKcGdPxPtLFBXuHR8XHb33YNYaP+lLbmSvBTsnoesCNJEsQ==",
-      "dev": true,
       "requires": {
         "abab": "^2.0.6",
         "acorn": "^8.8.1",
@@ -48970,6 +55305,21 @@
       "resolved": "https://registry.npmjs.org/just-diff-apply/-/just-diff-apply-5.5.0.tgz",
       "integrity": "sha512-OYTthRfSh55WOItVqwpefPtNt2VdKsq5AnAK6apdtR6yCH8pr0CmSr710J0Mf+WdQy7K/OzMy7K2MgAfdQURDw==",
       "dev": true
+    },
+    "katex": {
+      "version": "0.16.9",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.9.tgz",
+      "integrity": "sha512-fsSYjWS0EEOwvy81j3vRA8TEAhQhKiqO+FQaKWp0m39qwOzHVBgAUBIXWj1pB+O2W3fIpNa6Y9KSKCVbfPhyAQ==",
+      "requires": {
+        "commander": "^8.3.0"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "8.3.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+          "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww=="
+        }
+      }
     },
     "kdbush": {
       "version": "3.0.0",
@@ -50029,6 +56379,17 @@
       "resolved": "https://registry.npmjs.org/math-log2/-/math-log2-1.0.1.tgz",
       "integrity": "sha512-9W0yGtkaMAkf74XGYVy4Dqw3YUMnTNB2eeiw9aQbUl4A3KmuCEHTt2DgAB07ENzOYAjsYSAYufkAq0Zd+jU7zA=="
     },
+    "mathjax-full": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/mathjax-full/-/mathjax-full-3.2.2.tgz",
+      "integrity": "sha512-+LfG9Fik+OuI8SLwsiR02IVdjcnRCy5MufYLi0C3TdMT56L/pjB0alMVGgoWJF8pN9Rc7FESycZB9BMNWIid5w==",
+      "requires": {
+        "esm": "^3.2.25",
+        "mhchemparser": "^4.1.0",
+        "mj-context-menu": "^0.6.1",
+        "speech-rule-engine": "^4.0.6"
+      }
+    },
     "mathml-tag-names": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/mathml-tag-names/-/mathml-tag-names-2.1.3.tgz",
@@ -50095,6 +56456,172 @@
         "micromark": "^2.11.3"
       }
     },
+    "mdast-util-gfm-footnote": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.0.0.tgz",
+      "integrity": "sha512-5jOT2boTSVkMnQ7LTrd6n/18kqwjmuYqo7JUPe+tRCY6O7dAuTFMtTPauYYrMPpox9hlN0uOx/FL8XvEfG9/mQ==",
+      "requires": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0"
+      },
+      "dependencies": {
+        "@types/mdast": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.3.tgz",
+          "integrity": "sha512-LsjtqsyF+d2/yFOYaN22dHZI1Cpwkrj+g06G8+qtUKlhovPW89YhqSnfKtMbkgmEtYpH2gydRNULd6y8mciAFg==",
+          "requires": {
+            "@types/unist": "*"
+          }
+        },
+        "@types/unist": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.2.tgz",
+          "integrity": "sha512-dqId9J8K/vGi5Zr7oo212BGii5m3q5Hxlkwy3WpYuKPklmBEvsbMYYyLxAQpSffdLl/gdW0XUpKWFvYmyoWCoQ=="
+        },
+        "longest-streak": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+          "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g=="
+        },
+        "mdast-util-from-markdown": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.0.tgz",
+          "integrity": "sha512-n7MTOr/z+8NAX/wmhhDji8O3bRvPTV/U0oTCaZJkjhPSKTPhS3xufVhKGF8s1pJ7Ox4QgoIU7KHseh09S+9rTA==",
+          "requires": {
+            "@types/mdast": "^4.0.0",
+            "@types/unist": "^3.0.0",
+            "decode-named-character-reference": "^1.0.0",
+            "devlop": "^1.0.0",
+            "mdast-util-to-string": "^4.0.0",
+            "micromark": "^4.0.0",
+            "micromark-util-decode-numeric-character-reference": "^2.0.0",
+            "micromark-util-decode-string": "^2.0.0",
+            "micromark-util-normalize-identifier": "^2.0.0",
+            "micromark-util-symbol": "^2.0.0",
+            "micromark-util-types": "^2.0.0",
+            "unist-util-stringify-position": "^4.0.0"
+          }
+        },
+        "mdast-util-to-markdown": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.0.tgz",
+          "integrity": "sha512-SR2VnIEdVNCJbP6y7kVTJgPLifdr8WEU440fQec7qHoHOUz/oJ2jmNRqdDQ3rbiStOXb2mCDGTuwsK5OPUgYlQ==",
+          "requires": {
+            "@types/mdast": "^4.0.0",
+            "@types/unist": "^3.0.0",
+            "longest-streak": "^3.0.0",
+            "mdast-util-phrasing": "^4.0.0",
+            "mdast-util-to-string": "^4.0.0",
+            "micromark-util-decode-string": "^2.0.0",
+            "unist-util-visit": "^5.0.0",
+            "zwitch": "^2.0.0"
+          }
+        },
+        "mdast-util-to-string": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+          "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+          "requires": {
+            "@types/mdast": "^4.0.0"
+          }
+        },
+        "micromark": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.0.tgz",
+          "integrity": "sha512-o/sd0nMof8kYff+TqcDx3VSrgBTcZpSvYcAHIfHhv5VAuNmisCxjhx6YmxS8PFEpb9z5WKWKPdzf0jM23ro3RQ==",
+          "requires": {
+            "@types/debug": "^4.0.0",
+            "debug": "^4.0.0",
+            "decode-named-character-reference": "^1.0.0",
+            "devlop": "^1.0.0",
+            "micromark-core-commonmark": "^2.0.0",
+            "micromark-factory-space": "^2.0.0",
+            "micromark-util-character": "^2.0.0",
+            "micromark-util-chunked": "^2.0.0",
+            "micromark-util-combine-extensions": "^2.0.0",
+            "micromark-util-decode-numeric-character-reference": "^2.0.0",
+            "micromark-util-encode": "^2.0.0",
+            "micromark-util-normalize-identifier": "^2.0.0",
+            "micromark-util-resolve-all": "^2.0.0",
+            "micromark-util-sanitize-uri": "^2.0.0",
+            "micromark-util-subtokenize": "^2.0.0",
+            "micromark-util-symbol": "^2.0.0",
+            "micromark-util-types": "^2.0.0"
+          }
+        },
+        "micromark-factory-space": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.0.tgz",
+          "integrity": "sha512-TKr+LIDX2pkBJXFLzpyPyljzYK3MtmllMUMODTQJIUfDGncESaqB90db9IAUcz4AZAJFdd8U9zOp9ty1458rxg==",
+          "requires": {
+            "micromark-util-character": "^2.0.0",
+            "micromark-util-types": "^2.0.0"
+          }
+        },
+        "micromark-util-character": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.0.tgz",
+          "integrity": "sha512-KvOVV+X1yLBfs9dCBSopq/+G1PcgT3lAK07mC4BzXi5E7ahzMAF8oIupDDJ6mievI6F+lAATkbQQlQixJfT3aQ==",
+          "requires": {
+            "micromark-util-symbol": "^2.0.0",
+            "micromark-util-types": "^2.0.0"
+          }
+        },
+        "micromark-util-symbol": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.0.tgz",
+          "integrity": "sha512-8JZt9ElZ5kyTnO94muPxIGS8oyElRJaiJO8EzV6ZSyGQ1Is8xwl4Q45qU5UOg+bGH4AikWziz0iN4sFLWs8PGw=="
+        },
+        "micromark-util-types": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.0.tgz",
+          "integrity": "sha512-oNh6S2WMHWRZrmutsRmDDfkzKtxF+bc2VxLC9dvtrDIRFln627VsFP6fLMgTryGDljgLPjkrzQSDcPrjPyDJ5w=="
+        },
+        "unist-util-is": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.0.tgz",
+          "integrity": "sha512-2qCTHimwdxLfz+YzdGfkqNlH0tLi9xjTnHddPmJwtIG9MGsdbutfTc4P+haPD7l7Cjxf/WZj+we5qfVPvvxfYw==",
+          "requires": {
+            "@types/unist": "^3.0.0"
+          }
+        },
+        "unist-util-stringify-position": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+          "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+          "requires": {
+            "@types/unist": "^3.0.0"
+          }
+        },
+        "unist-util-visit": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.0.0.tgz",
+          "integrity": "sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==",
+          "requires": {
+            "@types/unist": "^3.0.0",
+            "unist-util-is": "^6.0.0",
+            "unist-util-visit-parents": "^6.0.0"
+          }
+        },
+        "unist-util-visit-parents": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.1.tgz",
+          "integrity": "sha512-L/PqWzfTP9lzzEa6CKs0k2nARxTdZduw3zyh8d2NVBnsyvHjSX4TWse388YrrQKbvI8w20fGjGlhgT96WwKykw==",
+          "requires": {
+            "@types/unist": "^3.0.0",
+            "unist-util-is": "^6.0.0"
+          }
+        },
+        "zwitch": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+          "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="
+        }
+      }
+    },
     "mdast-util-gfm-strikethrough": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-0.2.3.tgz",
@@ -50118,6 +56645,138 @@
       "integrity": "sha512-/d51FFIfPsSmCIRNp7E6pozM9z1GYPIkSy1urQ8s/o4TC22BZ7DqfHFWiqBD23bc7J3vV1Fc9O4QIHBlfuit8A==",
       "requires": {
         "mdast-util-to-markdown": "~0.6.0"
+      }
+    },
+    "mdast-util-math": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-math/-/mdast-util-math-2.0.2.tgz",
+      "integrity": "sha512-8gmkKVp9v6+Tgjtq6SYx9kGPpTf6FVYRa53/DLh479aldR9AyP48qeVOgNZ5X7QUK7nOy4yw7vg6mbiGcs9jWQ==",
+      "requires": {
+        "@types/mdast": "^3.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-to-markdown": "^1.3.0"
+      },
+      "dependencies": {
+        "longest-streak": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+          "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g=="
+        },
+        "mdast-util-phrasing": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-3.0.1.tgz",
+          "integrity": "sha512-WmI1gTXUBJo4/ZmSk79Wcb2HcjPJBzM1nlI/OUWA8yk2X9ik3ffNbBGsU+09BFmXaL1IBb9fiuvq6/KMiNycSg==",
+          "requires": {
+            "@types/mdast": "^3.0.0",
+            "unist-util-is": "^5.0.0"
+          }
+        },
+        "mdast-util-to-markdown": {
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-1.5.0.tgz",
+          "integrity": "sha512-bbv7TPv/WC49thZPg3jXuqzuvI45IL2EVAr/KxF0BSdHsU0ceFHOmwQn6evxAh1GaoK/6GQ1wp4R4oW2+LFL/A==",
+          "requires": {
+            "@types/mdast": "^3.0.0",
+            "@types/unist": "^2.0.0",
+            "longest-streak": "^3.0.0",
+            "mdast-util-phrasing": "^3.0.0",
+            "mdast-util-to-string": "^3.0.0",
+            "micromark-util-decode-string": "^1.0.0",
+            "unist-util-visit": "^4.0.0",
+            "zwitch": "^2.0.0"
+          }
+        },
+        "mdast-util-to-string": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-3.2.0.tgz",
+          "integrity": "sha512-V4Zn/ncyN1QNSqSBxTrMOLpjr+IKdHl2v3KVLoWmDPscP4r9GcCi71gjgvUV1SFSKh92AjAG4peFuBl2/YgCJg==",
+          "requires": {
+            "@types/mdast": "^3.0.0"
+          }
+        },
+        "micromark-util-decode-numeric-character-reference": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-1.1.0.tgz",
+          "integrity": "sha512-m9V0ExGv0jB1OT21mrWcuf4QhP46pH1KkfWy9ZEezqHKAxkj4mPCy3nIH1rkbdMlChLHX531eOrymlwyZIf2iw==",
+          "requires": {
+            "micromark-util-symbol": "^1.0.0"
+          }
+        },
+        "micromark-util-decode-string": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-1.1.0.tgz",
+          "integrity": "sha512-YphLGCK8gM1tG1bd54azwyrQRjCFcmgj2S2GoJDNnh4vYtnL38JS8M4gpxzOPNyHdNEpheyWXCTnnTDY3N+NVQ==",
+          "requires": {
+            "decode-named-character-reference": "^1.0.0",
+            "micromark-util-character": "^1.0.0",
+            "micromark-util-decode-numeric-character-reference": "^1.0.0",
+            "micromark-util-symbol": "^1.0.0"
+          }
+        },
+        "unist-util-is": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-5.2.1.tgz",
+          "integrity": "sha512-u9njyyfEh43npf1M+yGKDGVPbY/JWEemg5nH05ncKPfi+kBbKBJoTdsogMu33uhytuLlv9y0O7GH7fEdwLdLQw==",
+          "requires": {
+            "@types/unist": "^2.0.0"
+          }
+        },
+        "unist-util-visit": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-4.1.2.tgz",
+          "integrity": "sha512-MSd8OUGISqHdVvfY9TPhyK2VdUrPgxkUtWSuMHF6XAAFuL4LokseigBnZtPnJMu+FbynTkFNnFlyjxpVKujMRg==",
+          "requires": {
+            "@types/unist": "^2.0.0",
+            "unist-util-is": "^5.0.0",
+            "unist-util-visit-parents": "^5.1.1"
+          }
+        },
+        "unist-util-visit-parents": {
+          "version": "5.1.3",
+          "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-5.1.3.tgz",
+          "integrity": "sha512-x6+y8g7wWMyQhL1iZfhIPhDAs7Xwbn9nRosDXl7qoPTSCy0yNxnKc+hWokFifWQIDGi154rdUqKvbCa4+1kLhg==",
+          "requires": {
+            "@types/unist": "^2.0.0",
+            "unist-util-is": "^5.0.0"
+          }
+        },
+        "zwitch": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+          "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="
+        }
+      }
+    },
+    "mdast-util-phrasing": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
+      "integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
+      "requires": {
+        "@types/mdast": "^4.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "dependencies": {
+        "@types/mdast": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.3.tgz",
+          "integrity": "sha512-LsjtqsyF+d2/yFOYaN22dHZI1Cpwkrj+g06G8+qtUKlhovPW89YhqSnfKtMbkgmEtYpH2gydRNULd6y8mciAFg==",
+          "requires": {
+            "@types/unist": "*"
+          }
+        },
+        "@types/unist": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.2.tgz",
+          "integrity": "sha512-dqId9J8K/vGi5Zr7oo212BGii5m3q5Hxlkwy3WpYuKPklmBEvsbMYYyLxAQpSffdLl/gdW0XUpKWFvYmyoWCoQ=="
+        },
+        "unist-util-is": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.0.tgz",
+          "integrity": "sha512-2qCTHimwdxLfz+YzdGfkqNlH0tLi9xjTnHddPmJwtIG9MGsdbutfTc4P+haPD7l7Cjxf/WZj+we5qfVPvvxfYw==",
+          "requires": {
+            "@types/unist": "^3.0.0"
+          }
+        }
       }
     },
     "mdast-util-to-hast": {
@@ -50375,6 +57034,11 @@
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
       "dev": true
     },
+    "mhchemparser": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/mhchemparser/-/mhchemparser-4.2.1.tgz",
+      "integrity": "sha512-kYmyrCirqJf3zZ9t/0wGgRZ4/ZJw//VwaRVGA75C4nhE60vtnIzhl9J9ndkX/h6hxSN7pjg/cE0VxbnNM+bnDQ=="
+    },
     "micromark": {
       "version": "2.11.4",
       "resolved": "https://registry.npmjs.org/micromark/-/micromark-2.11.4.tgz",
@@ -50382,6 +57046,59 @@
       "requires": {
         "debug": "^4.0.0",
         "parse-entities": "^2.0.0"
+      }
+    },
+    "micromark-core-commonmark": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.0.tgz",
+      "integrity": "sha512-jThOz/pVmAYUtkroV3D5c1osFXAMv9e0ypGDOIZuCeAe91/sD6BoE2Sjzt30yuXtwOYUmySOhMas/PVyh02itA==",
+      "requires": {
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-destination": "^2.0.0",
+        "micromark-factory-label": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-title": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-html-tag-name": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "dependencies": {
+        "micromark-factory-space": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.0.tgz",
+          "integrity": "sha512-TKr+LIDX2pkBJXFLzpyPyljzYK3MtmllMUMODTQJIUfDGncESaqB90db9IAUcz4AZAJFdd8U9zOp9ty1458rxg==",
+          "requires": {
+            "micromark-util-character": "^2.0.0",
+            "micromark-util-types": "^2.0.0"
+          }
+        },
+        "micromark-util-character": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.0.tgz",
+          "integrity": "sha512-KvOVV+X1yLBfs9dCBSopq/+G1PcgT3lAK07mC4BzXi5E7ahzMAF8oIupDDJ6mievI6F+lAATkbQQlQixJfT3aQ==",
+          "requires": {
+            "micromark-util-symbol": "^2.0.0",
+            "micromark-util-types": "^2.0.0"
+          }
+        },
+        "micromark-util-symbol": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.0.tgz",
+          "integrity": "sha512-8JZt9ElZ5kyTnO94muPxIGS8oyElRJaiJO8EzV6ZSyGQ1Is8xwl4Q45qU5UOg+bGH4AikWziz0iN4sFLWs8PGw=="
+        },
+        "micromark-util-types": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.0.tgz",
+          "integrity": "sha512-oNh6S2WMHWRZrmutsRmDDfkzKtxF+bc2VxLC9dvtrDIRFln627VsFP6fLMgTryGDljgLPjkrzQSDcPrjPyDJ5w=="
+        }
       }
     },
     "micromark-extension-gfm": {
@@ -50403,6 +57120,51 @@
       "integrity": "sha512-ePiDGH0/lhcngCe8FtH4ARFoxKTUelMp4L7Gg2pujYD5CSMb9PbblnyL+AAMud/SNMyusbS2XDSiPIRcQoNFAw==",
       "requires": {
         "micromark": "~2.11.3"
+      }
+    },
+    "micromark-extension-gfm-footnote": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.0.0.tgz",
+      "integrity": "sha512-6Rzu0CYRKDv3BfLAUnZsSlzx3ak6HAoI85KTiijuKIz5UxZxbUI+pD6oHgw+6UtQuiRwnGRhzMmPRv4smcz0fg==",
+      "requires": {
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "dependencies": {
+        "micromark-factory-space": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.0.tgz",
+          "integrity": "sha512-TKr+LIDX2pkBJXFLzpyPyljzYK3MtmllMUMODTQJIUfDGncESaqB90db9IAUcz4AZAJFdd8U9zOp9ty1458rxg==",
+          "requires": {
+            "micromark-util-character": "^2.0.0",
+            "micromark-util-types": "^2.0.0"
+          }
+        },
+        "micromark-util-character": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.0.tgz",
+          "integrity": "sha512-KvOVV+X1yLBfs9dCBSopq/+G1PcgT3lAK07mC4BzXi5E7ahzMAF8oIupDDJ6mievI6F+lAATkbQQlQixJfT3aQ==",
+          "requires": {
+            "micromark-util-symbol": "^2.0.0",
+            "micromark-util-types": "^2.0.0"
+          }
+        },
+        "micromark-util-symbol": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.0.tgz",
+          "integrity": "sha512-8JZt9ElZ5kyTnO94muPxIGS8oyElRJaiJO8EzV6ZSyGQ1Is8xwl4Q45qU5UOg+bGH4AikWziz0iN4sFLWs8PGw=="
+        },
+        "micromark-util-types": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.0.tgz",
+          "integrity": "sha512-oNh6S2WMHWRZrmutsRmDDfkzKtxF+bc2VxLC9dvtrDIRFln627VsFP6fLMgTryGDljgLPjkrzQSDcPrjPyDJ5w=="
+        }
       }
     },
     "micromark-extension-gfm-strikethrough": {
@@ -50434,6 +57196,396 @@
         "micromark": "~2.11.0"
       }
     },
+    "micromark-extension-math": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/micromark-extension-math/-/micromark-extension-math-2.1.2.tgz",
+      "integrity": "sha512-es0CcOV89VNS9wFmyn+wyFTKweXGW4CEvdaAca6SWRWPyYCbBisnjaHLjWO4Nszuiud84jCpkHsqAJoa768Pvg==",
+      "requires": {
+        "@types/katex": "^0.16.0",
+        "katex": "^0.16.0",
+        "micromark-factory-space": "^1.0.0",
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0",
+        "uvu": "^0.5.0"
+      }
+    },
+    "micromark-factory-destination": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.0.tgz",
+      "integrity": "sha512-j9DGrQLm/Uhl2tCzcbLhy5kXsgkHUrjJHg4fFAeoMRwJmJerT9aw4FEhIbZStWN8A3qMwOp1uzHr4UL8AInxtA==",
+      "requires": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "dependencies": {
+        "micromark-util-character": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.0.tgz",
+          "integrity": "sha512-KvOVV+X1yLBfs9dCBSopq/+G1PcgT3lAK07mC4BzXi5E7ahzMAF8oIupDDJ6mievI6F+lAATkbQQlQixJfT3aQ==",
+          "requires": {
+            "micromark-util-symbol": "^2.0.0",
+            "micromark-util-types": "^2.0.0"
+          }
+        },
+        "micromark-util-symbol": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.0.tgz",
+          "integrity": "sha512-8JZt9ElZ5kyTnO94muPxIGS8oyElRJaiJO8EzV6ZSyGQ1Is8xwl4Q45qU5UOg+bGH4AikWziz0iN4sFLWs8PGw=="
+        },
+        "micromark-util-types": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.0.tgz",
+          "integrity": "sha512-oNh6S2WMHWRZrmutsRmDDfkzKtxF+bc2VxLC9dvtrDIRFln627VsFP6fLMgTryGDljgLPjkrzQSDcPrjPyDJ5w=="
+        }
+      }
+    },
+    "micromark-factory-label": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.0.tgz",
+      "integrity": "sha512-RR3i96ohZGde//4WSe/dJsxOX6vxIg9TimLAS3i4EhBAFx8Sm5SmqVfR8E87DPSR31nEAjZfbt91OMZWcNgdZw==",
+      "requires": {
+        "devlop": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "dependencies": {
+        "micromark-util-character": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.0.tgz",
+          "integrity": "sha512-KvOVV+X1yLBfs9dCBSopq/+G1PcgT3lAK07mC4BzXi5E7ahzMAF8oIupDDJ6mievI6F+lAATkbQQlQixJfT3aQ==",
+          "requires": {
+            "micromark-util-symbol": "^2.0.0",
+            "micromark-util-types": "^2.0.0"
+          }
+        },
+        "micromark-util-symbol": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.0.tgz",
+          "integrity": "sha512-8JZt9ElZ5kyTnO94muPxIGS8oyElRJaiJO8EzV6ZSyGQ1Is8xwl4Q45qU5UOg+bGH4AikWziz0iN4sFLWs8PGw=="
+        },
+        "micromark-util-types": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.0.tgz",
+          "integrity": "sha512-oNh6S2WMHWRZrmutsRmDDfkzKtxF+bc2VxLC9dvtrDIRFln627VsFP6fLMgTryGDljgLPjkrzQSDcPrjPyDJ5w=="
+        }
+      }
+    },
+    "micromark-factory-space": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-1.1.0.tgz",
+      "integrity": "sha512-cRzEj7c0OL4Mw2v6nwzttyOZe8XY/Z8G0rzmWQZTBi/jjwyw/U4uqKtUORXQrR5bAZZnbTI/feRV/R7hc4jQYQ==",
+      "requires": {
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-types": "^1.0.0"
+      }
+    },
+    "micromark-factory-title": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.0.tgz",
+      "integrity": "sha512-jY8CSxmpWLOxS+t8W+FG3Xigc0RDQA9bKMY/EwILvsesiRniiVMejYTE4wumNc2f4UbAa4WsHqe3J1QS1sli+A==",
+      "requires": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "dependencies": {
+        "micromark-factory-space": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.0.tgz",
+          "integrity": "sha512-TKr+LIDX2pkBJXFLzpyPyljzYK3MtmllMUMODTQJIUfDGncESaqB90db9IAUcz4AZAJFdd8U9zOp9ty1458rxg==",
+          "requires": {
+            "micromark-util-character": "^2.0.0",
+            "micromark-util-types": "^2.0.0"
+          }
+        },
+        "micromark-util-character": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.0.tgz",
+          "integrity": "sha512-KvOVV+X1yLBfs9dCBSopq/+G1PcgT3lAK07mC4BzXi5E7ahzMAF8oIupDDJ6mievI6F+lAATkbQQlQixJfT3aQ==",
+          "requires": {
+            "micromark-util-symbol": "^2.0.0",
+            "micromark-util-types": "^2.0.0"
+          }
+        },
+        "micromark-util-symbol": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.0.tgz",
+          "integrity": "sha512-8JZt9ElZ5kyTnO94muPxIGS8oyElRJaiJO8EzV6ZSyGQ1Is8xwl4Q45qU5UOg+bGH4AikWziz0iN4sFLWs8PGw=="
+        },
+        "micromark-util-types": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.0.tgz",
+          "integrity": "sha512-oNh6S2WMHWRZrmutsRmDDfkzKtxF+bc2VxLC9dvtrDIRFln627VsFP6fLMgTryGDljgLPjkrzQSDcPrjPyDJ5w=="
+        }
+      }
+    },
+    "micromark-factory-whitespace": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.0.tgz",
+      "integrity": "sha512-28kbwaBjc5yAI1XadbdPYHX/eDnqaUFVikLwrO7FDnKG7lpgxnvk/XGRhX/PN0mOZ+dBSZ+LgunHS+6tYQAzhA==",
+      "requires": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "dependencies": {
+        "micromark-factory-space": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.0.tgz",
+          "integrity": "sha512-TKr+LIDX2pkBJXFLzpyPyljzYK3MtmllMUMODTQJIUfDGncESaqB90db9IAUcz4AZAJFdd8U9zOp9ty1458rxg==",
+          "requires": {
+            "micromark-util-character": "^2.0.0",
+            "micromark-util-types": "^2.0.0"
+          }
+        },
+        "micromark-util-character": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.0.tgz",
+          "integrity": "sha512-KvOVV+X1yLBfs9dCBSopq/+G1PcgT3lAK07mC4BzXi5E7ahzMAF8oIupDDJ6mievI6F+lAATkbQQlQixJfT3aQ==",
+          "requires": {
+            "micromark-util-symbol": "^2.0.0",
+            "micromark-util-types": "^2.0.0"
+          }
+        },
+        "micromark-util-symbol": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.0.tgz",
+          "integrity": "sha512-8JZt9ElZ5kyTnO94muPxIGS8oyElRJaiJO8EzV6ZSyGQ1Is8xwl4Q45qU5UOg+bGH4AikWziz0iN4sFLWs8PGw=="
+        },
+        "micromark-util-types": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.0.tgz",
+          "integrity": "sha512-oNh6S2WMHWRZrmutsRmDDfkzKtxF+bc2VxLC9dvtrDIRFln627VsFP6fLMgTryGDljgLPjkrzQSDcPrjPyDJ5w=="
+        }
+      }
+    },
+    "micromark-util-character": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-1.2.0.tgz",
+      "integrity": "sha512-lXraTwcX3yH/vMDaFWCQJP1uIszLVebzUa3ZHdrgxr7KEU/9mL4mVgCpGbyhvNLNlauROiNUq7WN5u7ndbY6xg==",
+      "requires": {
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0"
+      }
+    },
+    "micromark-util-chunked": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.0.tgz",
+      "integrity": "sha512-anK8SWmNphkXdaKgz5hJvGa7l00qmcaUQoMYsBwDlSKFKjc6gjGXPDw3FNL3Nbwq5L8gE+RCbGqTw49FK5Qyvg==",
+      "requires": {
+        "micromark-util-symbol": "^2.0.0"
+      },
+      "dependencies": {
+        "micromark-util-symbol": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.0.tgz",
+          "integrity": "sha512-8JZt9ElZ5kyTnO94muPxIGS8oyElRJaiJO8EzV6ZSyGQ1Is8xwl4Q45qU5UOg+bGH4AikWziz0iN4sFLWs8PGw=="
+        }
+      }
+    },
+    "micromark-util-classify-character": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.0.tgz",
+      "integrity": "sha512-S0ze2R9GH+fu41FA7pbSqNWObo/kzwf8rN/+IGlW/4tC6oACOs8B++bh+i9bVyNnwCcuksbFwsBme5OCKXCwIw==",
+      "requires": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "dependencies": {
+        "micromark-util-character": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.0.tgz",
+          "integrity": "sha512-KvOVV+X1yLBfs9dCBSopq/+G1PcgT3lAK07mC4BzXi5E7ahzMAF8oIupDDJ6mievI6F+lAATkbQQlQixJfT3aQ==",
+          "requires": {
+            "micromark-util-symbol": "^2.0.0",
+            "micromark-util-types": "^2.0.0"
+          }
+        },
+        "micromark-util-symbol": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.0.tgz",
+          "integrity": "sha512-8JZt9ElZ5kyTnO94muPxIGS8oyElRJaiJO8EzV6ZSyGQ1Is8xwl4Q45qU5UOg+bGH4AikWziz0iN4sFLWs8PGw=="
+        },
+        "micromark-util-types": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.0.tgz",
+          "integrity": "sha512-oNh6S2WMHWRZrmutsRmDDfkzKtxF+bc2VxLC9dvtrDIRFln627VsFP6fLMgTryGDljgLPjkrzQSDcPrjPyDJ5w=="
+        }
+      }
+    },
+    "micromark-util-combine-extensions": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.0.tgz",
+      "integrity": "sha512-vZZio48k7ON0fVS3CUgFatWHoKbbLTK/rT7pzpJ4Bjp5JjkZeasRfrS9wsBdDJK2cJLHMckXZdzPSSr1B8a4oQ==",
+      "requires": {
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "dependencies": {
+        "micromark-util-types": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.0.tgz",
+          "integrity": "sha512-oNh6S2WMHWRZrmutsRmDDfkzKtxF+bc2VxLC9dvtrDIRFln627VsFP6fLMgTryGDljgLPjkrzQSDcPrjPyDJ5w=="
+        }
+      }
+    },
+    "micromark-util-decode-numeric-character-reference": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.1.tgz",
+      "integrity": "sha512-bmkNc7z8Wn6kgjZmVHOX3SowGmVdhYS7yBpMnuMnPzDq/6xwVA604DuOXMZTO1lvq01g+Adfa0pE2UKGlxL1XQ==",
+      "requires": {
+        "micromark-util-symbol": "^2.0.0"
+      },
+      "dependencies": {
+        "micromark-util-symbol": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.0.tgz",
+          "integrity": "sha512-8JZt9ElZ5kyTnO94muPxIGS8oyElRJaiJO8EzV6ZSyGQ1Is8xwl4Q45qU5UOg+bGH4AikWziz0iN4sFLWs8PGw=="
+        }
+      }
+    },
+    "micromark-util-decode-string": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.0.tgz",
+      "integrity": "sha512-r4Sc6leeUTn3P6gk20aFMj2ntPwn6qpDZqWvYmAG6NgvFTIlj4WtrAudLi65qYoaGdXYViXYw2pkmn7QnIFasA==",
+      "requires": {
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      },
+      "dependencies": {
+        "micromark-util-character": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.0.tgz",
+          "integrity": "sha512-KvOVV+X1yLBfs9dCBSopq/+G1PcgT3lAK07mC4BzXi5E7ahzMAF8oIupDDJ6mievI6F+lAATkbQQlQixJfT3aQ==",
+          "requires": {
+            "micromark-util-symbol": "^2.0.0",
+            "micromark-util-types": "^2.0.0"
+          }
+        },
+        "micromark-util-symbol": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.0.tgz",
+          "integrity": "sha512-8JZt9ElZ5kyTnO94muPxIGS8oyElRJaiJO8EzV6ZSyGQ1Is8xwl4Q45qU5UOg+bGH4AikWziz0iN4sFLWs8PGw=="
+        },
+        "micromark-util-types": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.0.tgz",
+          "integrity": "sha512-oNh6S2WMHWRZrmutsRmDDfkzKtxF+bc2VxLC9dvtrDIRFln627VsFP6fLMgTryGDljgLPjkrzQSDcPrjPyDJ5w=="
+        }
+      }
+    },
+    "micromark-util-encode": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.0.tgz",
+      "integrity": "sha512-pS+ROfCXAGLWCOc8egcBvT0kf27GoWMqtdarNfDcjb6YLuV5cM3ioG45Ys2qOVqeqSbjaKg72vU+Wby3eddPsA=="
+    },
+    "micromark-util-html-tag-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.0.tgz",
+      "integrity": "sha512-xNn4Pqkj2puRhKdKTm8t1YHC/BAjx6CEwRFXntTaRf/x16aqka6ouVoutm+QdkISTlT7e2zU7U4ZdlDLJd2Mcw=="
+    },
+    "micromark-util-normalize-identifier": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.0.tgz",
+      "integrity": "sha512-2xhYT0sfo85FMrUPtHcPo2rrp1lwbDEEzpx7jiH2xXJLqBuy4H0GgXk5ToU8IEwoROtXuL8ND0ttVa4rNqYK3w==",
+      "requires": {
+        "micromark-util-symbol": "^2.0.0"
+      },
+      "dependencies": {
+        "micromark-util-symbol": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.0.tgz",
+          "integrity": "sha512-8JZt9ElZ5kyTnO94muPxIGS8oyElRJaiJO8EzV6ZSyGQ1Is8xwl4Q45qU5UOg+bGH4AikWziz0iN4sFLWs8PGw=="
+        }
+      }
+    },
+    "micromark-util-resolve-all": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.0.tgz",
+      "integrity": "sha512-6KU6qO7DZ7GJkaCgwBNtplXCvGkJToU86ybBAUdavvgsCiG8lSSvYxr9MhwmQ+udpzywHsl4RpGJsYWG1pDOcA==",
+      "requires": {
+        "micromark-util-types": "^2.0.0"
+      },
+      "dependencies": {
+        "micromark-util-types": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.0.tgz",
+          "integrity": "sha512-oNh6S2WMHWRZrmutsRmDDfkzKtxF+bc2VxLC9dvtrDIRFln627VsFP6fLMgTryGDljgLPjkrzQSDcPrjPyDJ5w=="
+        }
+      }
+    },
+    "micromark-util-sanitize-uri": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.0.tgz",
+      "integrity": "sha512-WhYv5UEcZrbAtlsnPuChHUAsu/iBPOVaEVsntLBIdpibO0ddy8OzavZz3iL2xVvBZOpolujSliP65Kq0/7KIYw==",
+      "requires": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      },
+      "dependencies": {
+        "micromark-util-character": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.0.tgz",
+          "integrity": "sha512-KvOVV+X1yLBfs9dCBSopq/+G1PcgT3lAK07mC4BzXi5E7ahzMAF8oIupDDJ6mievI6F+lAATkbQQlQixJfT3aQ==",
+          "requires": {
+            "micromark-util-symbol": "^2.0.0",
+            "micromark-util-types": "^2.0.0"
+          }
+        },
+        "micromark-util-symbol": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.0.tgz",
+          "integrity": "sha512-8JZt9ElZ5kyTnO94muPxIGS8oyElRJaiJO8EzV6ZSyGQ1Is8xwl4Q45qU5UOg+bGH4AikWziz0iN4sFLWs8PGw=="
+        },
+        "micromark-util-types": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.0.tgz",
+          "integrity": "sha512-oNh6S2WMHWRZrmutsRmDDfkzKtxF+bc2VxLC9dvtrDIRFln627VsFP6fLMgTryGDljgLPjkrzQSDcPrjPyDJ5w=="
+        }
+      }
+    },
+    "micromark-util-subtokenize": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.0.0.tgz",
+      "integrity": "sha512-vc93L1t+gpR3p8jxeVdaYlbV2jTYteDje19rNSS/H5dlhxUYll5Fy6vJ2cDwP8RnsXi818yGty1ayP55y3W6fg==",
+      "requires": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "dependencies": {
+        "micromark-util-symbol": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.0.tgz",
+          "integrity": "sha512-8JZt9ElZ5kyTnO94muPxIGS8oyElRJaiJO8EzV6ZSyGQ1Is8xwl4Q45qU5UOg+bGH4AikWziz0iN4sFLWs8PGw=="
+        },
+        "micromark-util-types": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.0.tgz",
+          "integrity": "sha512-oNh6S2WMHWRZrmutsRmDDfkzKtxF+bc2VxLC9dvtrDIRFln627VsFP6fLMgTryGDljgLPjkrzQSDcPrjPyDJ5w=="
+        }
+      }
+    },
+    "micromark-util-symbol": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-1.1.0.tgz",
+      "integrity": "sha512-uEjpEYY6KMs1g7QfJ2eX1SQEV+ZT4rUD3UcF6l57acZvLNK7PBZL+ty82Z1qhK1/yXIY4bdx04FKMgR0g4IAag=="
+    },
+    "micromark-util-types": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-1.1.0.tgz",
+      "integrity": "sha512-ukRBgie8TIAcacscVHSiddHjO4k/q3pnedmzMQ4iwDcK0FtFCohKOlFbaOL/mPgfnPsL3C1ZyxJa4sbWrBl3jg=="
+    },
     "micromatch": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
@@ -50447,14 +57599,12 @@
     "mime-db": {
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
     },
     "mime-types": {
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
       "requires": {
         "mime-db": "1.52.0"
       }
@@ -50689,6 +57839,11 @@
         }
       }
     },
+    "mj-context-menu": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/mj-context-menu/-/mj-context-menu-0.6.1.tgz",
+      "integrity": "sha512-7NO5s6n10TIV96d4g2uDpG7ZDpIhMh0QNfGdJw/W47JswFcosz457wqz/b5sAKvl12sxINGFCn80NZHKwxQEXA=="
+    },
     "mkdirp": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
@@ -50761,6 +57916,11 @@
         "signum": "^1.0.0",
         "to-px": "^1.0.1"
       }
+    },
+    "mri": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
+      "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA=="
     },
     "ms": {
       "version": "2.1.2",
@@ -51514,8 +58674,7 @@
     "nwsapi": {
       "version": "2.2.7",
       "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.7.tgz",
-      "integrity": "sha512-ub5E4+FBPKwAZx0UwIQOjYWGHTEq5sPqHQNRN8Z9e4A7u3Tj1weLJsL59yH9vmvqEtBHaOmT6cYQKIZOxp35FQ==",
-      "dev": true
+      "integrity": "sha512-ub5E4+FBPKwAZx0UwIQOjYWGHTEq5sPqHQNRN8Z9e4A7u3Tj1weLJsL59yH9vmvqEtBHaOmT6cYQKIZOxp35FQ=="
     },
     "nx": {
       "version": "15.9.2",
@@ -52310,7 +59469,6 @@
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
       "integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
-      "dev": true,
       "requires": {
         "entities": "^4.4.0"
       }
@@ -52757,14 +59915,12 @@
     "psl": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
-      "integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag==",
-      "dev": true
+      "integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag=="
     },
     "punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
-      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-      "dev": true
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="
     },
     "pure-color": {
       "version": "1.3.0",
@@ -52786,8 +59942,7 @@
     "querystringify": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
-      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
-      "dev": true
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="
     },
     "queue-microtask": {
       "version": "1.2.3",
@@ -53450,6 +60605,107 @@
         "regl-scatter2d": "^3.2.3"
       }
     },
+    "rehype-mathjax": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/rehype-mathjax/-/rehype-mathjax-4.0.3.tgz",
+      "integrity": "sha512-QIwWH9U+r54nMQklVkT1qluxhKyzdPWz9dFwgel3BrseQsWZafRTDTUj8VR8/14nFuRIV2ChuCMz4zpACPoYvg==",
+      "requires": {
+        "@types/hast": "^2.0.0",
+        "@types/mathjax": "^0.0.37",
+        "hast-util-from-dom": "^4.0.0",
+        "hast-util-to-text": "^3.1.0",
+        "jsdom": "^20.0.0",
+        "mathjax-full": "^3.0.0",
+        "unified": "^10.0.0",
+        "unist-util-visit": "^4.0.0"
+      },
+      "dependencies": {
+        "bail": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+          "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw=="
+        },
+        "is-plain-obj": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+          "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg=="
+        },
+        "trough": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+          "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw=="
+        },
+        "unified": {
+          "version": "10.1.2",
+          "resolved": "https://registry.npmjs.org/unified/-/unified-10.1.2.tgz",
+          "integrity": "sha512-pUSWAi/RAnVy1Pif2kAoeWNBa3JVrx0MId2LASj8G+7AiHWoKZNTomq6LG326T68U7/e263X6fTdcXIy7XnF7Q==",
+          "requires": {
+            "@types/unist": "^2.0.0",
+            "bail": "^2.0.0",
+            "extend": "^3.0.0",
+            "is-buffer": "^2.0.0",
+            "is-plain-obj": "^4.0.0",
+            "trough": "^2.0.0",
+            "vfile": "^5.0.0"
+          }
+        },
+        "unist-util-is": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-5.2.1.tgz",
+          "integrity": "sha512-u9njyyfEh43npf1M+yGKDGVPbY/JWEemg5nH05ncKPfi+kBbKBJoTdsogMu33uhytuLlv9y0O7GH7fEdwLdLQw==",
+          "requires": {
+            "@types/unist": "^2.0.0"
+          }
+        },
+        "unist-util-stringify-position": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-3.0.3.tgz",
+          "integrity": "sha512-k5GzIBZ/QatR8N5X2y+drfpWG8IDBzdnVj6OInRNWm1oXrzydiaAT2OQiA8DPRRZyAKb9b6I2a6PxYklZD0gKg==",
+          "requires": {
+            "@types/unist": "^2.0.0"
+          }
+        },
+        "unist-util-visit": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-4.1.2.tgz",
+          "integrity": "sha512-MSd8OUGISqHdVvfY9TPhyK2VdUrPgxkUtWSuMHF6XAAFuL4LokseigBnZtPnJMu+FbynTkFNnFlyjxpVKujMRg==",
+          "requires": {
+            "@types/unist": "^2.0.0",
+            "unist-util-is": "^5.0.0",
+            "unist-util-visit-parents": "^5.1.1"
+          }
+        },
+        "unist-util-visit-parents": {
+          "version": "5.1.3",
+          "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-5.1.3.tgz",
+          "integrity": "sha512-x6+y8g7wWMyQhL1iZfhIPhDAs7Xwbn9nRosDXl7qoPTSCy0yNxnKc+hWokFifWQIDGi154rdUqKvbCa4+1kLhg==",
+          "requires": {
+            "@types/unist": "^2.0.0",
+            "unist-util-is": "^5.0.0"
+          }
+        },
+        "vfile": {
+          "version": "5.3.7",
+          "resolved": "https://registry.npmjs.org/vfile/-/vfile-5.3.7.tgz",
+          "integrity": "sha512-r7qlzkgErKjobAmyNIkkSpizsFPYiUPuJb5pNW1RB4JcYVZhs4lIbVqk8XPk033CV/1z8ss5pkax8SuhGpcG8g==",
+          "requires": {
+            "@types/unist": "^2.0.0",
+            "is-buffer": "^2.0.0",
+            "unist-util-stringify-position": "^3.0.0",
+            "vfile-message": "^3.0.0"
+          }
+        },
+        "vfile-message": {
+          "version": "3.1.4",
+          "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-3.1.4.tgz",
+          "integrity": "sha512-fa0Z6P8HUrQN4BZaX05SIVXic+7kE3b05PWAtPuYP9QLHsLKYR7/AlLW3NtOrpXRLeawpDLMsVkmk5DG0NXgWw==",
+          "requires": {
+            "@types/unist": "^2.0.0",
+            "unist-util-stringify-position": "^3.0.0"
+          }
+        }
+      }
+    },
     "remark-gfm": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-1.0.0.tgz",
@@ -53457,6 +60713,76 @@
       "requires": {
         "mdast-util-gfm": "^0.1.0",
         "micromark-extension-gfm": "^0.3.0"
+      }
+    },
+    "remark-math": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/remark-math/-/remark-math-5.1.1.tgz",
+      "integrity": "sha512-cE5T2R/xLVtfFI4cCePtiRn+e6jKMtFDR3P8V3qpv8wpKjwvHoBA4eJzvX+nVrnlNy0911bdGmuspCSwetfYHw==",
+      "requires": {
+        "@types/mdast": "^3.0.0",
+        "mdast-util-math": "^2.0.0",
+        "micromark-extension-math": "^2.0.0",
+        "unified": "^10.0.0"
+      },
+      "dependencies": {
+        "bail": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+          "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw=="
+        },
+        "is-plain-obj": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+          "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg=="
+        },
+        "trough": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+          "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw=="
+        },
+        "unified": {
+          "version": "10.1.2",
+          "resolved": "https://registry.npmjs.org/unified/-/unified-10.1.2.tgz",
+          "integrity": "sha512-pUSWAi/RAnVy1Pif2kAoeWNBa3JVrx0MId2LASj8G+7AiHWoKZNTomq6LG326T68U7/e263X6fTdcXIy7XnF7Q==",
+          "requires": {
+            "@types/unist": "^2.0.0",
+            "bail": "^2.0.0",
+            "extend": "^3.0.0",
+            "is-buffer": "^2.0.0",
+            "is-plain-obj": "^4.0.0",
+            "trough": "^2.0.0",
+            "vfile": "^5.0.0"
+          }
+        },
+        "unist-util-stringify-position": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-3.0.3.tgz",
+          "integrity": "sha512-k5GzIBZ/QatR8N5X2y+drfpWG8IDBzdnVj6OInRNWm1oXrzydiaAT2OQiA8DPRRZyAKb9b6I2a6PxYklZD0gKg==",
+          "requires": {
+            "@types/unist": "^2.0.0"
+          }
+        },
+        "vfile": {
+          "version": "5.3.7",
+          "resolved": "https://registry.npmjs.org/vfile/-/vfile-5.3.7.tgz",
+          "integrity": "sha512-r7qlzkgErKjobAmyNIkkSpizsFPYiUPuJb5pNW1RB4JcYVZhs4lIbVqk8XPk033CV/1z8ss5pkax8SuhGpcG8g==",
+          "requires": {
+            "@types/unist": "^2.0.0",
+            "is-buffer": "^2.0.0",
+            "unist-util-stringify-position": "^3.0.0",
+            "vfile-message": "^3.0.0"
+          }
+        },
+        "vfile-message": {
+          "version": "3.1.4",
+          "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-3.1.4.tgz",
+          "integrity": "sha512-fa0Z6P8HUrQN4BZaX05SIVXic+7kE3b05PWAtPuYP9QLHsLKYR7/AlLW3NtOrpXRLeawpDLMsVkmk5DG0NXgWw==",
+          "requires": {
+            "@types/unist": "^2.0.0",
+            "unist-util-stringify-position": "^3.0.0"
+          }
+        }
       }
     },
     "remark-parse": {
@@ -53473,6 +60799,147 @@
       "integrity": "sha512-EbCu9kHgAxKmW1yEYjx3QafMyGY3q8noUbNUI5xyKbaFP89wbhDrKxyIQNukNYthzjNHZu6J7hwFg7hRm1svYA==",
       "requires": {
         "mdast-util-to-hast": "^10.2.0"
+      }
+    },
+    "remark-stringify": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
+      "integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
+      "requires": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "dependencies": {
+        "@types/mdast": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.3.tgz",
+          "integrity": "sha512-LsjtqsyF+d2/yFOYaN22dHZI1Cpwkrj+g06G8+qtUKlhovPW89YhqSnfKtMbkgmEtYpH2gydRNULd6y8mciAFg==",
+          "requires": {
+            "@types/unist": "*"
+          }
+        },
+        "@types/unist": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.2.tgz",
+          "integrity": "sha512-dqId9J8K/vGi5Zr7oo212BGii5m3q5Hxlkwy3WpYuKPklmBEvsbMYYyLxAQpSffdLl/gdW0XUpKWFvYmyoWCoQ=="
+        },
+        "bail": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+          "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw=="
+        },
+        "is-plain-obj": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+          "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg=="
+        },
+        "longest-streak": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+          "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g=="
+        },
+        "mdast-util-to-markdown": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.0.tgz",
+          "integrity": "sha512-SR2VnIEdVNCJbP6y7kVTJgPLifdr8WEU440fQec7qHoHOUz/oJ2jmNRqdDQ3rbiStOXb2mCDGTuwsK5OPUgYlQ==",
+          "requires": {
+            "@types/mdast": "^4.0.0",
+            "@types/unist": "^3.0.0",
+            "longest-streak": "^3.0.0",
+            "mdast-util-phrasing": "^4.0.0",
+            "mdast-util-to-string": "^4.0.0",
+            "micromark-util-decode-string": "^2.0.0",
+            "unist-util-visit": "^5.0.0",
+            "zwitch": "^2.0.0"
+          }
+        },
+        "mdast-util-to-string": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+          "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+          "requires": {
+            "@types/mdast": "^4.0.0"
+          }
+        },
+        "trough": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+          "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw=="
+        },
+        "unified": {
+          "version": "11.0.4",
+          "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.4.tgz",
+          "integrity": "sha512-apMPnyLjAX+ty4OrNap7yumyVAMlKx5IWU2wlzzUdYJO9A8f1p9m/gywF/GM2ZDFcjQPrx59Mc90KwmxsoklxQ==",
+          "requires": {
+            "@types/unist": "^3.0.0",
+            "bail": "^2.0.0",
+            "devlop": "^1.0.0",
+            "extend": "^3.0.0",
+            "is-plain-obj": "^4.0.0",
+            "trough": "^2.0.0",
+            "vfile": "^6.0.0"
+          }
+        },
+        "unist-util-is": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.0.tgz",
+          "integrity": "sha512-2qCTHimwdxLfz+YzdGfkqNlH0tLi9xjTnHddPmJwtIG9MGsdbutfTc4P+haPD7l7Cjxf/WZj+we5qfVPvvxfYw==",
+          "requires": {
+            "@types/unist": "^3.0.0"
+          }
+        },
+        "unist-util-stringify-position": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+          "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+          "requires": {
+            "@types/unist": "^3.0.0"
+          }
+        },
+        "unist-util-visit": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.0.0.tgz",
+          "integrity": "sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==",
+          "requires": {
+            "@types/unist": "^3.0.0",
+            "unist-util-is": "^6.0.0",
+            "unist-util-visit-parents": "^6.0.0"
+          }
+        },
+        "unist-util-visit-parents": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.1.tgz",
+          "integrity": "sha512-L/PqWzfTP9lzzEa6CKs0k2nARxTdZduw3zyh8d2NVBnsyvHjSX4TWse388YrrQKbvI8w20fGjGlhgT96WwKykw==",
+          "requires": {
+            "@types/unist": "^3.0.0",
+            "unist-util-is": "^6.0.0"
+          }
+        },
+        "vfile": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.1.tgz",
+          "integrity": "sha512-1bYqc7pt6NIADBJ98UiG0Bn/CHIVOoZ/IyEkqIruLg0mE1BKzkOXY2D6CSqQIcKqgadppE5lrxgWXJmXd7zZJw==",
+          "requires": {
+            "@types/unist": "^3.0.0",
+            "unist-util-stringify-position": "^4.0.0",
+            "vfile-message": "^4.0.0"
+          }
+        },
+        "vfile-message": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.2.tgz",
+          "integrity": "sha512-jRDZ1IMLttGj41KcZvlrYAaI3CfqpLpfpf+Mfig13viT6NKvRzWZ+lXz0Y5D60w6uJIBAOGq9mSHf0gktF0duw==",
+          "requires": {
+            "@types/unist": "^3.0.0",
+            "unist-util-stringify-position": "^4.0.0"
+          }
+        },
+        "zwitch": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+          "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="
+        }
       }
     },
     "repeat-string": {
@@ -53496,8 +60963,7 @@
     "requires-port": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
-      "dev": true
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="
     },
     "resolve": {
       "version": "1.22.8",
@@ -53627,6 +61093,14 @@
         "tslib": "^2.1.0"
       }
     },
+    "sade": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/sade/-/sade-1.8.1.tgz",
+      "integrity": "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==",
+      "requires": {
+        "mri": "^1.1.0"
+      }
+    },
     "safe-array-concat": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.0.1.tgz",
@@ -53681,7 +61155,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
       "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
-      "dev": true,
       "requires": {
         "xmlchars": "^2.2.0"
       }
@@ -54037,6 +61510,23 @@
       "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.16.tgz",
       "integrity": "sha512-eWN+LnM3GR6gPu35WxNgbGl8rmY1AEmoMDvL/QD6zYmPWgywxWqJWNdLGT+ke8dKNWrcYgYjPpG5gbTfghP8rw==",
       "dev": true
+    },
+    "speech-rule-engine": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/speech-rule-engine/-/speech-rule-engine-4.0.7.tgz",
+      "integrity": "sha512-sJrL3/wHzNwJRLBdf6CjJWIlxC04iYKkyXvYSVsWVOiC2DSkHmxsqOhEeMsBA9XK+CHuNcsdkbFDnoUfAsmp9g==",
+      "requires": {
+        "commander": "9.2.0",
+        "wicked-good-xpath": "1.3.0",
+        "xmldom-sre": "0.1.31"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "9.2.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-9.2.0.tgz",
+          "integrity": "sha512-e2i4wANQiSXgnrBlIatyHtP1odfUp0BbV5Y5nEGbxtIrStkEOAAzCUirvLBNXHLr7kwLvJl6V+4V3XV9x7Wd9w=="
+        }
+      }
     },
     "split": {
       "version": "1.0.1",
@@ -54806,8 +62296,7 @@
     "symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
-      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
-      "dev": true
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="
     },
     "table": {
       "version": "6.8.1",
@@ -55061,7 +62550,6 @@
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.3.tgz",
       "integrity": "sha512-aX/y5pVRkfRnfmuX+OdbSdXvPe6ieKX/G2s7e98f4poJHnqH3281gDPm/metm6E/WRamfx7WC4HUqkWHfQHprw==",
-      "dev": true,
       "requires": {
         "psl": "^1.1.33",
         "punycode": "^2.1.1",
@@ -55072,8 +62560,7 @@
         "universalify": {
           "version": "0.2.0",
           "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
-          "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
-          "dev": true
+          "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg=="
         }
       }
     },
@@ -55081,7 +62568,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
       "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
-      "dev": true,
       "requires": {
         "punycode": "^2.1.1"
       }
@@ -55091,6 +62577,11 @@
       "resolved": "https://registry.npmjs.org/treeverse/-/treeverse-3.0.0.tgz",
       "integrity": "sha512-gcANaAnd2QDZFmHFEOF4k7uc1J/6a6z3DJMd/QwEyxLoKGiptJRwid582r7QIsFlFMIZ3SnxfS52S4hm2DHkuQ==",
       "dev": true
+    },
+    "trim-lines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg=="
     },
     "trim-newlines": {
       "version": "3.0.1",
@@ -55442,6 +62933,25 @@
       "resolved": "https://registry.npmjs.org/unist-builder/-/unist-builder-2.0.3.tgz",
       "integrity": "sha512-f98yt5pnlMWlzP539tPc4grGMsFaQQlP/vM396b00jngsiINumNmsY8rkXjfoi1c6QaM8nQ3vaGDuoKWbe/1Uw=="
     },
+    "unist-util-find-after": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-find-after/-/unist-util-find-after-4.0.1.tgz",
+      "integrity": "sha512-QO/PuPMm2ERxC6vFXEPtmAutOopy5PknD+Oq64gGwxKtk4xwo9Z97t9Av1obPmGU0IyTa6EKYUfTrK2QJS3Ozw==",
+      "requires": {
+        "@types/unist": "^2.0.0",
+        "unist-util-is": "^5.0.0"
+      },
+      "dependencies": {
+        "unist-util-is": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-5.2.1.tgz",
+          "integrity": "sha512-u9njyyfEh43npf1M+yGKDGVPbY/JWEemg5nH05ncKPfi+kBbKBJoTdsogMu33uhytuLlv9y0O7GH7fEdwLdLQw==",
+          "requires": {
+            "@types/unist": "^2.0.0"
+          }
+        }
+      }
+    },
     "unist-util-generated": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/unist-util-generated/-/unist-util-generated-1.1.6.tgz",
@@ -55535,7 +63045,6 @@
       "version": "1.5.10",
       "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
       "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
-      "dev": true,
       "requires": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
@@ -55577,6 +63086,24 @@
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
       "dev": true
+    },
+    "uvu": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/uvu/-/uvu-0.5.6.tgz",
+      "integrity": "sha512-+g8ENReyr8YsOc6fv/NVJs2vFdHBnBNdfE49rshrTzDWOlUx4Gq7KOS2GD8eqhy2j+Ejq29+SbKH8yjkAqXqoA==",
+      "requires": {
+        "dequal": "^2.0.0",
+        "diff": "^5.0.0",
+        "kleur": "^4.0.3",
+        "sade": "^1.7.3"
+      },
+      "dependencies": {
+        "kleur": {
+          "version": "4.1.5",
+          "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+          "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ=="
+        }
+      }
     },
     "v8-compile-cache": {
       "version": "2.3.0",
@@ -55661,7 +63188,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-4.0.0.tgz",
       "integrity": "sha512-d+BFHzbiCx6zGfz0HyQ6Rg69w9k19nviJspaj4yNscGjrHu94sVP+aRm75yEbCh+r2/yR+7q6hux9LVtbuTGBw==",
-      "dev": true,
       "requires": {
         "xml-name-validator": "^4.0.0"
       }
@@ -55695,6 +63221,11 @@
       "resolved": "https://registry.npmjs.org/weak-map/-/weak-map-1.0.8.tgz",
       "integrity": "sha512-lNR9aAefbGPpHO7AEnY0hCFjz1eTkWCXYvkTRrTHs9qv8zJp+SkVYpzfLIFXQQiG3tVvbNFQgVg2bQS8YGgxyw=="
     },
+    "web-namespaces": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
+      "integrity": "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ=="
+    },
     "webgl-context": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/webgl-context/-/webgl-context-2.2.0.tgz",
@@ -55706,14 +63237,12 @@
     "webidl-conversions": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
-      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
-      "dev": true
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g=="
     },
     "whatwg-encoding": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-2.0.0.tgz",
       "integrity": "sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==",
-      "dev": true,
       "requires": {
         "iconv-lite": "0.6.3"
       },
@@ -55722,7 +63251,6 @@
           "version": "0.6.3",
           "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
           "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-          "dev": true,
           "requires": {
             "safer-buffer": ">= 2.1.2 < 3.0.0"
           }
@@ -55732,14 +63260,12 @@
     "whatwg-mimetype": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
-      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
-      "dev": true
+      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q=="
     },
     "whatwg-url": {
       "version": "11.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
       "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
-      "dev": true,
       "requires": {
         "tr46": "^3.0.0",
         "webidl-conversions": "^7.0.0"
@@ -55808,6 +63334,11 @@
         "gopd": "^1.0.1",
         "has-tostringtag": "^1.0.0"
       }
+    },
+    "wicked-good-xpath": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/wicked-good-xpath/-/wicked-good-xpath-1.3.0.tgz",
+      "integrity": "sha512-Gd9+TUn5nXdwj/hFsPVx5cuHHiF5Bwuc30jZ4+ronF1qHK5O7HD0sgmXWSEgwKquT3ClLoKPVbO6qGwVwLzvAw=="
     },
     "wide-align": {
       "version": "1.1.5",
@@ -55998,20 +63529,22 @@
       "version": "8.14.2",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.14.2.tgz",
       "integrity": "sha512-wEBG1ftX4jcglPxgFCMJmZ2PLtSbJ2Peg6TmpJFTbe9GZYOQCDPdMYu/Tm0/bGZkw8paZnJY45J4K2PZrLYq8g==",
-      "dev": true,
       "requires": {}
     },
     "xml-name-validator": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-4.0.0.tgz",
-      "integrity": "sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==",
-      "dev": true
+      "integrity": "sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw=="
     },
     "xmlchars": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
-      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
-      "dev": true
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="
+    },
+    "xmldom-sre": {
+      "version": "0.1.31",
+      "resolved": "https://registry.npmjs.org/xmldom-sre/-/xmldom-sre-0.1.31.tgz",
+      "integrity": "sha512-f9s+fUkX04BxQf+7mMWAp5zk61pciie+fFLC9hX9UVvCeJQfNHRHXpeo5MPcR0EUf57PYLdt+ZO4f3Ipk2oZUw=="
     },
     "xtend": {
       "version": "4.0.2",

--- a/plugins/plotly-express/src/js/package.json
+++ b/plugins/plotly-express/src/js/package.json
@@ -35,7 +35,7 @@
     "build": "tsc && vite build"
   },
   "devDependencies": {
-    "@deephaven/jsapi-types": "0.62.0",
+    "@deephaven/jsapi-types": "0.64.0",
     "@types/deep-equal": "^1.0.1",
     "@types/plotly.js": "^2.12.18",
     "@types/plotly.js-dist-min": "^2.3.1",
@@ -50,15 +50,15 @@
     "react": "^17.0.2"
   },
   "dependencies": {
-    "@deephaven/chart": "0.62.0",
-    "@deephaven/components": "0.62.0",
-    "@deephaven/dashboard": "0.62.0",
-    "@deephaven/dashboard-core-plugins": "0.62.0",
-    "@deephaven/icons": "0.62.0",
-    "@deephaven/jsapi-bootstrap": "0.62.0",
-    "@deephaven/log": "0.62.0",
-    "@deephaven/plugin": "0.62.0",
-    "@deephaven/utils": "0.62.0",
+    "@deephaven/chart": "0.64.0",
+    "@deephaven/components": "0.64.0",
+    "@deephaven/dashboard": "0.64.0",
+    "@deephaven/dashboard-core-plugins": "0.64.0",
+    "@deephaven/icons": "0.64.0",
+    "@deephaven/jsapi-bootstrap": "0.64.0",
+    "@deephaven/log": "0.64.0",
+    "@deephaven/plugin": "0.64.0",
+    "@deephaven/utils": "0.64.0",
     "deep-equal": "^2.2.1",
     "plotly.js": "^2.23.0",
     "plotly.js-dist-min": "^2.23.0",

--- a/plugins/plotly-express/src/js/src/PlotlyExpressChartModel.ts
+++ b/plugins/plotly-express/src/js/src/PlotlyExpressChartModel.ts
@@ -7,35 +7,24 @@ import type {
   TableSubscription,
   TableData,
 } from '@deephaven/jsapi-types';
-import {
-  ChartModel,
-  ChartUtils,
-  ChartTheme,
-  defaultChartTheme,
-} from '@deephaven/chart';
+import { ChartModel, ChartUtils } from '@deephaven/chart';
 import Log from '@deephaven/log';
 import {
   PlotlyChartWidgetData,
-  applyColorwayToData,
   getDataMappings,
   getWidgetData,
+  removeColorsFromData,
 } from './PlotlyExpressChartUtils.js';
 
 const log = Log.module('@deephaven/js-plugin-plotly-express.ChartModel');
 
 export class PlotlyExpressChartModel extends ChartModel {
-  constructor(
-    dh: DhType,
-    widget: Widget,
-    refetch: () => Promise<Widget>,
-    theme: ChartTheme = defaultChartTheme()
-  ) {
+  constructor(dh: DhType, widget: Widget, refetch: () => Promise<Widget>) {
     super(dh);
 
     this.widget = widget;
     this.refetch = refetch;
     this.chartUtils = new ChartUtils(dh);
-    this.theme = theme;
 
     this.handleFigureUpdated = this.handleFigureUpdated.bind(this);
     this.handleWidgetUpdated = this.handleWidgetUpdated.bind(this);
@@ -89,13 +78,9 @@ export class PlotlyExpressChartModel extends ChartModel {
    */
   tableDataMap: Map<number, { [key: string]: unknown[] }> = new Map();
 
-  theme: ChartTheme;
-
   plotlyData: Data[] = [];
 
   layout: Partial<Layout> = {};
-
-  plotlyLayout: Partial<Layout> = {};
 
   isPaused = false;
 
@@ -197,22 +182,11 @@ export class PlotlyExpressChartModel extends ChartModel {
 
   updateLayout(data: PlotlyChartWidgetData) {
     const { figure } = data;
-    const { plotly, deephaven } = figure;
+    const { plotly } = figure;
     const { layout: plotlyLayout = {} } = plotly;
-
-    const template = { layout: this.chartUtils.makeDefaultLayout(this.theme) };
-
-    // For now we will only use the plotly theme colorway since most plotly themes are light mode
-    if (deephaven.is_user_set_template) {
-      template.layout.colorway =
-        plotlyLayout.template?.layout?.colorway ?? template.layout.colorway;
-    }
-
-    this.plotlyLayout = plotlyLayout;
 
     this.layout = {
       ...plotlyLayout,
-      template,
     };
   }
 
@@ -225,17 +199,19 @@ export class PlotlyExpressChartModel extends ChartModel {
       new_references: newReferences,
       removed_references: removedReferences,
     } = data;
-    const { plotly } = figure;
+    const { plotly, deephaven } = figure;
+    const { layout: plotlyLayout = {} } = plotly;
     this.tableColumnReplacementMap = getDataMappings(data);
 
     this.plotlyData = plotly.data;
     this.updateLayout(data);
 
-    applyColorwayToData(
-      this.layout?.template?.layout?.colorway ?? [],
-      this.plotlyLayout?.template?.layout?.colorway ?? [],
-      this.plotlyData
-    );
+    if (!deephaven.is_user_set_template) {
+      removeColorsFromData(
+        plotlyLayout?.template?.layout?.colorway ?? [],
+        this.plotlyData
+      );
+    }
 
     newReferences.forEach(async (id, i) => {
       this.tableDataMap.set(id, {}); // Plot may render while tables are being fetched. Set this to avoid a render error

--- a/plugins/plotly-express/src/js/vite.config.ts
+++ b/plugins/plotly-express/src/js/vite.config.ts
@@ -19,6 +19,7 @@ export default defineConfig(({ mode }) => ({
         'redux',
         'react-redux',
         '@deephaven/jsapi-bootstrap',
+        '@deephaven/chart',
       ],
     },
   },


### PR DESCRIPTION
Fixes #216 

PlotlyExpressChartModel should just remove the colors on the traces instead of setting them to the UI theme. The UI theme then gets applied via the template colorway