### PR TITLE
build: Added config for STRICT_PORT

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 node_modules
 .vscode/
 tsconfig.tsbuildinfo
+.env*local
 
 # Ignore user IntelliJ settings
 .idea/

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 node_modules
 .vscode/
 tsconfig.tsbuildinfo
-.env*local
+.env.*local
 
 # Ignore user IntelliJ settings
 .idea/

--- a/vite.config.js
+++ b/vite.config.js
@@ -4,8 +4,12 @@ import { defineConfig, loadEnv } from 'vite';
 const DEFAULT_PORT = 4100;
 
 export default defineConfig(({ mode }) => {
-  const env = loadEnv(mode, process.cwd());
+  // Load env file based on `mode` in the current working directory.
+  // Set the third parameter to '' to load all env regardless of the `VITE_` prefix.
+  const env = loadEnv(mode, process.cwd(), '');
+
   const port = Number(env.PORT || process.env.PORT || DEFAULT_PORT);
+  const strictPort = (env.STRICT_PORT || process.env.STRICT_PORT) === 'true';
 
   // This config doesn't build anything, it just serves the files from the
   // plugins directory
@@ -13,6 +17,7 @@ export default defineConfig(({ mode }) => {
     publicDir: 'plugins',
     server: {
       port,
+      strictPort,
     },
   };
 });

--- a/vite.config.js
+++ b/vite.config.js
@@ -8,8 +8,7 @@ export default defineConfig(({ mode }) => {
   // Set the third parameter to '' to load all env regardless of the `VITE_` prefix.
   const env = loadEnv(mode, process.cwd(), '');
 
-  const port = Number(env.PORT || process.env.PORT || DEFAULT_PORT);
-  const strictPort = (env.STRICT_PORT || process.env.STRICT_PORT) === 'true';
+  const port = Number(env.PORT || DEFAULT_PORT);
 
   // This config doesn't build anything, it just serves the files from the
   // plugins directory
@@ -17,7 +16,7 @@ export default defineConfig(({ mode }) => {
     publicDir: 'plugins',
     server: {
       port,
-      strictPort,
+      strictPort: true,
     },
   };
 });


### PR DESCRIPTION
Added support for optional `STRICT_PORT` env.

**Testing**
- Create a `.env.development.local` file in the repo root and set `STRICT_PORT=true`
- In another checkout of the plugins repo, run `npm start` (or you could run something else on port 4100)`
- Run `npm start` in repo with the new env file. It should fail due to port already in use

resolves #262