### PR TITLE
fix: Stock rollup example was not working

### DIFF
--- a/plugins/ui/examples/README.md
+++ b/plugins/ui/examples/README.md
@@ -790,7 +790,12 @@ def stock_table(source):
         [source, highlight],
     )
     rolled_table = use_memo(
-        lambda: t if len(by) == 0 else t.rollup(aggs=aggs, by=by), [t, aggs, by]
+        lambda: (
+            formatted_table
+            if len(by) == 0
+            else formatted_table.rollup(aggs=aggs, by=by)
+        ),
+        [formatted_table, aggs, by],
     )
 
     return ui.flex(
@@ -799,20 +804,22 @@ def stock_table(source):
             ui.toggle_button(
                 ui.icon("vsBell"), "By Exchange", on_change=set_is_exchange
             ),
-            ui.fragment(
-                ui.text_field(
-                    label="Highlight Sym",
-                    label_position="side",
-                    value=highlight,
-                    on_change=set_highlight,
-                ),
-                ui.contextual_help(
-                    ui.heading("Highlight Sym"),
-                    ui.content("Enter a sym you would like highlighted."),
-                ),
-            )
-            if not is_sym and not is_exchange
-            else None,
+            (
+                ui.fragment(
+                    ui.text_field(
+                        label="Highlight Sym",
+                        label_position="side",
+                        value=highlight,
+                        on_change=set_highlight,
+                    ),
+                    ui.contextual_help(
+                        ui.heading("Highlight Sym"),
+                        ui.content("Enter a sym you would like highlighted."),
+                    ),
+                )
+                if not is_sym and not is_exchange
+                else None
+            ),
             align_items="center",
             gap="size-100",
             margin="size-100",

--- a/plugins/ui/src/deephaven/ui/renderer/NodeEncoder.py
+++ b/plugins/ui/src/deephaven/ui/renderer/NodeEncoder.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
 import json
+import logging
 from typing import Any, Callable, TypedDict
 from weakref import WeakKeyDictionary
 from .RenderedNode import RenderedNode
+
+logger = logging.getLogger(__name__)
 
 CALLABLE_KEY = "__dhCbid"
 OBJECT_KEY = "__dhObid"
@@ -20,7 +23,7 @@ ObjectId = int
 
 class NodeEncoderResult(TypedDict):
     """
-    Result of encoding a node. Contains the encoded node, list of new objects, and callables dictionary.
+    Result of encoding a node. Contains the encoded node, set of new objects, and callables dictionary.
     """
 
     encoded_node: str
@@ -72,9 +75,15 @@ class NodeEncoder(json.JSONEncoder):
     The next object id to use. Increment for each new object encountered.
     """
 
-    _object_id_dict: WeakKeyDictionary[Any, int]
+    _old_objects: set[Any]
     """
-    Dictionary from an object to the ID assigned to it
+    List of objects from the last render. Used to remove objects that are no longer in the document.
+    """
+
+    _object_id_dict: dict[Any, int]
+    """
+    Dictionary from an object to the ID assigned to it. Objects are removed after the next render if they are no longer in the document.
+    We can't use a WeakKeyDictionary as we need to pass the exported objects to the client and we can't guarantee they won't be freed up by the client or server.
     """
 
     def __init__(
@@ -95,9 +104,9 @@ class NodeEncoder(json.JSONEncoder):
         self._callable_id_prefix = callable_id_prefix
         self._next_callable_id = 0
         self._callable_dict = WeakKeyDictionary()
-        self._new_objects = []
+        self._new_objects = list()
         self._next_object_id = 0
-        self._object_id_dict = WeakKeyDictionary()
+        self._object_id_dict = {}
 
     def default(self, o: Any):
         if isinstance(o, RenderedNode):
@@ -122,9 +131,21 @@ class NodeEncoder(json.JSONEncoder):
         Args:
             o: The document to encode
         """
+
         # Reset the new objects list - they will get set when encoding
-        self._new_objects = []
+        self._new_objects = list()
+        self._old_objects = set(self._object_id_dict.keys())
+
+        logger.debug("Encoding node with object_id_dict: %s", self._object_id_dict)
+
         encoded_node = super().encode(node)
+
+        # Remove the old objects from last render from the object id dict
+        for obj in self._old_objects:
+            popped = self._object_id_dict.pop(obj, None)
+            if popped is not None:
+                logger.debug("Popped object %s with id %s", obj, popped)
+
         return {
             "encoded_node": encoded_node,
             "new_objects": self._new_objects,
@@ -155,6 +176,9 @@ class NodeEncoder(json.JSONEncoder):
             self._next_object_id += 1
             self._object_id_dict[obj] = object_id
             self._new_objects.append(obj)
+
+        self._old_objects.discard(obj)
+        logger.debug("Converted object %s to id %s", obj, object_id)
 
         return {
             OBJECT_KEY: object_id,

--- a/plugins/ui/src/deephaven/ui/renderer/NodeEncoder.py
+++ b/plugins/ui/src/deephaven/ui/renderer/NodeEncoder.py
@@ -104,7 +104,7 @@ class NodeEncoder(json.JSONEncoder):
         self._callable_id_prefix = callable_id_prefix
         self._next_callable_id = 0
         self._callable_dict = WeakKeyDictionary()
-        self._new_objects = list()
+        self._new_objects = []
         self._next_object_id = 0
         self._object_id_dict = {}
 
@@ -133,7 +133,7 @@ class NodeEncoder(json.JSONEncoder):
         """
 
         # Reset the new objects list - they will get set when encoding
-        self._new_objects = list()
+        self._new_objects = []
         self._old_objects = set(self._object_id_dict.keys())
 
         logger.debug("Encoding node with object_id_dict: %s", self._object_id_dict)


### PR DESCRIPTION
- Referenced a table `t` that did not exist, corrected to reference `formatted_table`
- Needed to refactor how exported objects were being handled - server was just using a WeakKeyDictionary, but the objects were not guaranteed to get cleared out on the server and were being reused between re-renders. The client would always dump old objects after a render, so just always clear out the objects on the server from the previous render. Note that the WeakKeyDictionary is still safe for callables; the client just references them by ID and does not hold a reference to an object, so they can be cleared by the server GC.
- Fixes #265
- Tested using the Stock Rollup example fixed in this PR, it now works correctly.
- Also tested with snippet from #128, ensuring the table still does not flicker.
- Added another test to test more than one iteration
