### PR TITLE
ci: Fix JS caching

### DIFF
--- a/.github/workflows/test-js-packages.yml
+++ b/.github/workflows/test-js-packages.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           path: |
             .jest-cache
-            plugins/*/.jest-cache
+            plugins/**/.jest-cache
           key: ${{ runner.os }}-jestcache-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-jestcache-
@@ -35,9 +35,9 @@ jobs:
         with:
           path: |
             .eslintcache
-            plugins/*/.eslintcache
+            plugins/**/.eslintcache
             .stylelintcache
-            plugins/*/.stylelintcache
+            plugins/**/.stylelintcache
           key: ${{ runner.os }}-lintcache-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-lintcache-
@@ -48,7 +48,7 @@ jobs:
         with:
           path: |
             node_modules
-            plugins/*/node_modules
+            plugins/**/node_modules
           key: unit-node-modules-${{ hashFiles('package-lock.json')}}
 
       - name: Install dependencies

--- a/.github/workflows/test-js-packages.yml
+++ b/.github/workflows/test-js-packages.yml
@@ -15,13 +15,13 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Use Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'
 
       - name: Cache jest
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             .jest-cache
@@ -31,7 +31,7 @@ jobs:
             ${{ runner.os }}-jestcache-
 
       - name: Cache linters
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             .eslintcache
@@ -44,8 +44,9 @@ jobs:
 
       - name: Cache node modules
         id: cache-node-modules
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
+          save-always: true
           path: |
             node_modules
             plugins/**/node_modules

--- a/.github/workflows/test-js-packages.yml
+++ b/.github/workflows/test-js-packages.yml
@@ -49,7 +49,7 @@ jobs:
           save-always: true
           path: |
             node_modules
-            plugins/*/node_modules
+            plugins/**/node_modules
           key: unit-node-modules-${{ hashFiles('package-lock.json')}}
 
       - name: Install dependencies

--- a/.github/workflows/test-js-packages.yml
+++ b/.github/workflows/test-js-packages.yml
@@ -49,7 +49,7 @@ jobs:
           save-always: true
           path: |
             node_modules
-            plugins/**/node_modules
+            plugins/*/node_modules
           key: unit-node-modules-${{ hashFiles('package-lock.json')}}
 
       - name: Install dependencies

--- a/plugins/ui/src/js/src/ReactPanel.test.tsx
+++ b/plugins/ui/src/js/src/ReactPanel.test.tsx
@@ -134,5 +134,5 @@ it('calls openComponent again after panel is closed only if the metadata changes
   expect(LayoutUtils.openComponent).toHaveBeenCalledTimes(2);
   expect(LayoutUtils.closeComponent).not.toHaveBeenCalled();
   expect(onOpen).toHaveBeenCalledTimes(2);
-  expect(onClose).toHaveBeenCalledTimes(0);
+  expect(onClose).toHaveBeenCalledTimes(1);
 });

--- a/plugins/ui/src/js/src/ReactPanel.test.tsx
+++ b/plugins/ui/src/js/src/ReactPanel.test.tsx
@@ -135,4 +135,5 @@ it('calls openComponent again after panel is closed only if the metadata changes
   expect(LayoutUtils.closeComponent).not.toHaveBeenCalled();
   expect(onOpen).toHaveBeenCalledTimes(2);
   expect(onClose).toHaveBeenCalledTimes(1);
+  // Test
 });

--- a/plugins/ui/src/js/src/ReactPanel.test.tsx
+++ b/plugins/ui/src/js/src/ReactPanel.test.tsx
@@ -134,6 +134,5 @@ it('calls openComponent again after panel is closed only if the metadata changes
   expect(LayoutUtils.openComponent).toHaveBeenCalledTimes(2);
   expect(LayoutUtils.closeComponent).not.toHaveBeenCalled();
   expect(onOpen).toHaveBeenCalledTimes(2);
-  expect(onClose).toHaveBeenCalledTimes(1);
-  // Test
+  expect(onClose).toHaveBeenCalledTimes(0);
 });


### PR DESCRIPTION
Updated CI caching to use a glob for the `node_modules` directories. The previous wildcard would only search 1 level deep which is not valid for our setup. This should fix some edge cases that could cause test failures if the expected package version was installed to the package's local `node_modules`.

Updated cache action to v4. Added the `save-always` flag to the `node_modules` cache which should work whenever it's fixed. Ticket for the flag not working https://github.com/actions/cache/issues/1315. Without that flag functioning, it acts just like v3 cache