### PR TITLE
feat: Support for dropping extra callback args

### DIFF
--- a/plugins/ui/src/deephaven/ui/_internal/__init__.py
+++ b/plugins/ui/src/deephaven/ui/_internal/__init__.py
@@ -14,4 +14,5 @@ from .utils import (
     to_camel_case,
     dict_to_camel_case,
     remove_empty_keys,
+    wrap_callable,
 )

--- a/plugins/ui/src/deephaven/ui/_internal/utils.py
+++ b/plugins/ui/src/deephaven/ui/_internal/utils.py
@@ -112,12 +112,11 @@ def remove_empty_keys(dict: dict[str, Any]) -> dict[str, Any]:
     return {k: v for k, v in dict.items() if v is not None}
 
 
-def wrapper(
+def wrapped_callable(
     max_args: int | str, kwargs_set: set[str] | str, func, *args, **kwargs
 ) -> None:
     """
-    Wrapper for the function that will be called by the dispatcher.
-    This wrapper will handle calling the function with the correct arguments.
+    Function that will be called by the dispatcher.
 
     Args:
         max_args: The maximum number of positional arguments to pass to the function
@@ -167,4 +166,4 @@ def wrap_callable(func: Callable) -> Callable:
         elif param.kind == param.VAR_KEYWORD:
             kwargs = "any"
 
-    return partial(wrapper, max_args, kwargs, func)
+    return partial(wrapped_callable, max_args, kwargs, func)

--- a/plugins/ui/src/deephaven/ui/object_types/ElementMessageStream.py
+++ b/plugins/ui/src/deephaven/ui/object_types/ElementMessageStream.py
@@ -248,7 +248,6 @@ class ElementMessageStream(MessageStream):
         """
         decoded_payload = io.BytesIO(payload).read().decode()
         logger.debug("Payload received: %s", decoded_payload)
-        print("Payload received: %s", decoded_payload)
 
         def handle_message():
             response = self._manager.handle(decoded_payload, self._dispatcher)

--- a/plugins/ui/test/deephaven/ui/test_utils.py
+++ b/plugins/ui/test/deephaven/ui/test_utils.py
@@ -86,6 +86,134 @@ class UtilsTest(BaseTestCase):
             {"foo": "bar", "baz": 0},
         )
 
+    def test_wrap_callable(self):
+        from deephaven.ui._internal.utils import wrap_callable
+
+        result = None
+
+        def test_func_with_no_args():
+            nonlocal result
+            result = 42
+
+        wrapped = wrap_callable(test_func_with_no_args)
+
+        wrapped()
+        self.assertEqual(result, 42)
+        result = None
+
+        wrapped("event", ignored="metadata")
+        self.assertEqual(result, 42)
+        result = None
+
+        def test_func_with_arg(a):
+            nonlocal result
+            result = a
+
+        wrapped = wrap_callable(test_func_with_arg)
+
+        wrapped(3, "event", ignored="metadata")
+        self.assertEqual(result, 3)
+        result = None
+
+        def test_func_with_multiple_args(a, b=1):
+            nonlocal result
+            result = a + b
+
+        wrapped = wrap_callable(test_func_with_multiple_args)
+
+        wrapped(2)
+        self.assertEqual(result, 3)
+        result = None
+
+        wrapped(b=2, a=2)
+        self.assertEqual(result, 4)
+        result = None
+
+        wrapped(2, 3, "event", ignored="metadata")
+        self.assertEqual(result, 5)
+        result = None
+
+        def test_func_with_positional_arg(a, /):
+            nonlocal result
+            result = a
+
+        wrapped = wrap_callable(test_func_with_positional_arg)
+
+        wrapped(3)
+        self.assertEqual(result, 3)
+        result = None
+
+        wrapped(3, "event", ignored="metadata")
+        self.assertEqual(result, 3)
+        result = None
+
+        def test_func_with_positional_arg(a, b=1, /):
+            nonlocal result
+            result = a + b
+
+        wrapped = wrap_callable(test_func_with_positional_arg)
+
+        wrapped(2)
+        self.assertEqual(result, 3)
+        result = None
+
+        wrapped(2, 2)
+        self.assertEqual(result, 4)
+        result = None
+
+        wrapped(2, 3, "event", ignored="metadata")
+        self.assertEqual(result, 5)
+        result = None
+
+        def test_func_with_kw_only_args(*args, a, b=1):
+            nonlocal result
+            result = args[0] + a + b
+
+        wrapped = wrap_callable(test_func_with_kw_only_args)
+
+        wrapped(3, a=2)
+        self.assertEqual(result, 6)
+        result = None
+
+        wrapped(3, a=2, b=4)
+        self.assertEqual(result, 9)
+        result = None
+
+        wrapped(3, b=1, a=4, ignored="metadata")
+        self.assertEqual(result, 8)
+        result = None
+
+        def test_func_with_args(a, /, b, c=1):
+            nonlocal result
+            result = a + b + c
+
+        wrapped = wrap_callable(test_func_with_args)
+
+        wrapped(1, 2)
+        self.assertEqual(result, 4)
+        result = None
+
+        wrapped(1, c=3, b=4)
+        self.assertEqual(result, 8)
+        result = None
+
+        wrapped(1, 2, 3, "event", ignored="metadata")
+        self.assertEqual(result, 6)
+        result = None
+
+        def test_func_with_all_args(a, /, b, *args, c=1, **kwargs):
+            nonlocal result
+            result = a + b + args[0] + c + kwargs["d"]
+
+        wrapped = wrap_callable(test_func_with_all_args)
+
+        wrapped(1, 2, 3, d=1)
+        self.assertEqual(result, 8)
+        result = None
+
+        wrapped(1, 2, 3, "event", d=1, c=2, ignored="metadata")
+        self.assertEqual(result, 9)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fixes #260 

This snippet now works:
```
import deephaven.ui as ui
from deephaven.ui import use_state


@ui.component
def counter():
    count, set_count = use_state(0)
    return [
      # Pass in a function that accepts the event argument
      ui.action_button(f"Foo {count}", on_press=lambda e: set_count(count + 1)),
      # Pass in a function that does not have any positional arguments
      ui.action_button(f"Bar {count}", on_press=lambda: set_count(count + 1))
    ]


c = counter()
```

This implementation is more robust than that though. It supports:
1. Dropping any number of positional args. For example, if the callback supports 3 positional args but only two are defined, the third will be not be passed in.
3. Dropping any unused keyword args. 
4. If `*args` or `**kwargs` are used, all of the relevant args are passed in.