### PR TITLE
feat: Support column and row within a panel

### DIFF
--- a/plugins/ui/src/js/src/ReactPanel.tsx
+++ b/plugins/ui/src/js/src/ReactPanel.tsx
@@ -1,4 +1,10 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import ReactDOM from 'react-dom';
 import shortid from 'shortid';
 import {
@@ -12,6 +18,7 @@ import PortalPanel from './PortalPanel';
 import { useReactPanelManager } from './ReactPanelManager';
 import { ReactPanelProps } from './layout/LayoutUtils';
 import { useParentItem } from './layout/ParentItemContext';
+import { ReactPanelContext } from './ReactPanelContext';
 
 const log = Log.module('@deephaven/js-plugin-ui/ReactPanel');
 
@@ -87,7 +94,14 @@ function ReactPanel({ children, title }: ReactPanelProps) {
     }
   }, [parent, metadata, onOpen, panelId, title]);
 
-  return element ? ReactDOM.createPortal(children, element) : null;
+  return element
+    ? ReactDOM.createPortal(
+        <ReactPanelContext.Provider value={panelId}>
+          {children}
+        </ReactPanelContext.Provider>,
+        element
+      )
+    : null;
 }
 
 export default ReactPanel;

--- a/plugins/ui/src/js/src/ReactPanelContext.ts
+++ b/plugins/ui/src/js/src/ReactPanelContext.ts
@@ -1,0 +1,14 @@
+import { createContext, useContext } from 'react';
+
+/**
+ * Context that holds the ID of the panel that we are currently in.
+ */
+export const ReactPanelContext = createContext<string | null>(null);
+
+/**
+ * Gets the panel ID from the nearest panel context.
+ * @returns The panel ID or null if not in a panel
+ */
+export function usePanelId() {
+  return useContext(ReactPanelContext);
+}

--- a/plugins/ui/src/js/src/SpectrumElementUtils.ts
+++ b/plugins/ui/src/js/src/SpectrumElementUtils.ts
@@ -3,7 +3,6 @@ import {
   Checkbox,
   Content,
   ContextualHelp,
-  Flex,
   Grid,
   Heading,
   Icon,
@@ -22,6 +21,7 @@ import { ValueOf } from '@deephaven/utils';
 import {
   ActionButton,
   Button,
+  Flex,
   Form,
   RangeSlider,
   Slider,

--- a/plugins/ui/src/js/src/layout/Column.tsx
+++ b/plugins/ui/src/js/src/layout/Column.tsx
@@ -6,8 +6,13 @@ import {
   type ColumnElementProps,
 } from './LayoutUtils';
 import { ParentItemContext, useParentItem } from './ParentItemContext';
+import { usePanelId } from '../ReactPanelContext';
+import { Flex } from '../spectrum';
 
-function Column({ children, width }: ColumnElementProps): JSX.Element | null {
+function LayoutColumn({
+  children,
+  width,
+}: ColumnElementProps): JSX.Element | null {
   const layoutManager = useLayoutManager();
   const parent = useParentItem();
 
@@ -37,6 +42,20 @@ function Column({ children, width }: ColumnElementProps): JSX.Element | null {
     <ParentItemContext.Provider value={column}>
       {normalizedChildren}
     </ParentItemContext.Provider>
+  );
+}
+
+function Column({ children, width }: ColumnElementProps): JSX.Element {
+  const panelId = usePanelId();
+
+  if (panelId == null) {
+    return <LayoutColumn width={width}>{children}</LayoutColumn>;
+  }
+
+  return (
+    <Flex width={`${width}%`} direction="column">
+      {children}
+    </Flex>
   );
 }
 

--- a/plugins/ui/src/js/src/layout/Row.tsx
+++ b/plugins/ui/src/js/src/layout/Row.tsx
@@ -3,8 +3,10 @@ import { useLayoutManager } from '@deephaven/dashboard';
 import type { RowOrColumn } from '@deephaven/golden-layout';
 import { normalizeRowChildren, type RowElementProps } from './LayoutUtils';
 import { ParentItemContext, useParentItem } from './ParentItemContext';
+import { usePanelId } from '../ReactPanelContext';
+import { Flex } from '../spectrum';
 
-function Row({ children, height }: RowElementProps): JSX.Element | null {
+function LayoutRow({ children, height }: RowElementProps): JSX.Element | null {
   const layoutManager = useLayoutManager();
   const parent = useParentItem();
   const row = useMemo(() => {
@@ -33,6 +35,20 @@ function Row({ children, height }: RowElementProps): JSX.Element | null {
     <ParentItemContext.Provider value={row}>
       {normalizedChildren}
     </ParentItemContext.Provider>
+  );
+}
+
+function Row({ children, height }: RowElementProps): JSX.Element {
+  const panelId = usePanelId();
+
+  if (panelId == null) {
+    return <LayoutRow height={height}>{children}</LayoutRow>;
+  }
+
+  return (
+    <Flex height={`${height}%`} direction="row">
+      {children}
+    </Flex>
   );
 }
 

--- a/plugins/ui/src/js/src/spectrum/Flex.tsx
+++ b/plugins/ui/src/js/src/spectrum/Flex.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { Flex as SpectrumFlex, FlexProps } from '@adobe/react-spectrum';
+
+function Flex(props: FlexProps) {
+  // eslint-disable-next-line react/jsx-props-no-spreading
+  return <SpectrumFlex {...props} />;
+}
+
+Flex.displayName = 'Flex';
+
+export default Flex;

--- a/plugins/ui/src/js/src/spectrum/index.ts
+++ b/plugins/ui/src/js/src/spectrum/index.ts
@@ -6,6 +6,7 @@
  */
 export { default as ActionButton } from './ActionButton';
 export { default as Button } from './Button';
+export { default as Flex } from './Flex';
 export { default as Form } from './Form';
 export { default as RangeSlider } from './RangeSlider';
 export { default as Slider } from './Slider';


### PR DESCRIPTION
Fixes #165 

Some Python that should render the same

```py
import deephaven.ui as ui
from deephaven.ui import use_state

@ui.component
def as_flex():
    text, set_text = use_state("hello")

    return ui.flex(
        ui.flex(
            ui.text("Type a message here"),
            ui.text_field(value=text, on_change=set_text),
            direction="column",
            width="50%"
        ),
        ui.text(f"Message received: {text}"),
        direction="row"
    )

@ui.component
def implicit_panel():
    text, set_text = use_state("hello")

    return ui.row(
        ui.column(
            ui.text("Type a message here"),
            ui.text_field(value=text, on_change=set_text),
            width=50
        ),
        ui.text(f"Message received: {text}")
    )

@ui.component
def explicit_panel():
    text, set_text = use_state("hello")

    return ui.panel(
        implicit_panel(),
        title="My messaging service"
    )

flex = as_flex()
ip = implicit_panel()
ep = explicit_panel()
```