### PR TITLE
fix: Deephaven express memory leak

### DIFF
--- a/plugins/plotly-express/src/js/src/PlotlyExpressChartModel.ts
+++ b/plugins/plotly-express/src/js/src/PlotlyExpressChartModel.ts
@@ -241,7 +241,7 @@ export class PlotlyExpressChartModel extends ChartModel {
     figureUpdateEvent.columns.forEach(column => {
       const columnData = chartData.getColumn(
         column.name,
-        val => this.chartUtils.unwrapValue(val),
+        this.chartUtils.unwrapValue,
         figureUpdateEvent
       );
       tableData[column.name] = columnData;


### PR DESCRIPTION
Fixes #179 

Tested by running a server with and without this fix and opening the Memory dev tools tab. Then ran the code in the ticket. The tab without this fix grew steadily in memory consumption over several minutes. The tab with the fix stayed fairly consistent over the same period of time.