### PR TITLE
test: Bumping test listener timeout from 1 to 2 seconds

### DIFF
--- a/plugins/ui/test/deephaven/ui/test_hooks.py
+++ b/plugins/ui/test/deephaven/ui/test_hooks.py
@@ -6,6 +6,8 @@ from typing import Callable
 from unittest.mock import Mock
 from .BaseTest import BaseTestCase
 
+LISTENER_TIMEOUT = 2.0
+
 
 def render_hook(fn: Callable):
     """
@@ -155,7 +157,7 @@ class HooksTest(BaseTestCase):
 
         table_writer.write_row(*update)
 
-        if not event.wait(timeout=1.0):
+        if not event.wait(timeout=LISTENER_TIMEOUT):
             assert False, "listener was not called"
 
     def test_table_listener(self):


### PR DESCRIPTION
Some hook tests rely on table listeners, and they need a bit more time to finish. This currently causes intermittent failures. Bumping from 1 to 2 seconds should be sufficient.