### PR TITLE
fix: Call listener when do_replay is True for use_table_listener_hook

### DIFF
--- a/plugins/ui/src/deephaven/ui/hooks/use_table_listener.py
+++ b/plugins/ui/src/deephaven/ui/hooks/use_table_listener.py
@@ -84,8 +84,8 @@ def use_table_listener(
         replay_lock: The lock type used during replay, default is ‘shared’, can also be ‘exclusive’.
     """
 
-    if not table.is_refreshing:
-        # if the table is not refreshing, there is nothing to listen to
+    if not table.is_refreshing and not do_replay:
+        # if the table is not refreshing, and is not replaying, there is nothing to listen to
         return
 
     def start_listener() -> Callable[[], None]:

--- a/plugins/ui/test/deephaven/ui/test_hooks.py
+++ b/plugins/ui/test/deephaven/ui/test_hooks.py
@@ -158,6 +158,24 @@ class HooksTest(BaseTestCase):
         if not event.wait(timeout=1.0):
             assert False, "listener was not called"
 
+    def verify_table_replayed(self, table):
+        from deephaven.ui.hooks import use_table_listener
+        from deephaven.table_listener import TableUpdate
+
+        event = threading.Event()
+
+        def listener(update: TableUpdate, is_replay: bool) -> None:
+            nonlocal event
+            event.set()
+
+        def _test_table_listener(replay_table=table, listener_val=listener):
+            use_table_listener(replay_table, listener_val)
+
+        render_hook(_test_table_listener)
+
+        if not event.wait(timeout=1.0):
+            assert False, "listener was not called"
+
     def test_table_listener(self):
         from deephaven import DynamicTableWriter
         import deephaven.dtypes as dht
@@ -168,6 +186,8 @@ class HooksTest(BaseTestCase):
         table = table_writer.table
 
         self.verify_table_updated(table_writer, table, (1, "Testing"))
+
+        self.verify_table_replayed(table)
 
     def test_table_data(self):
         from deephaven.ui.hooks import use_table_data

--- a/plugins/ui/test/deephaven/ui/test_hooks.py
+++ b/plugins/ui/test/deephaven/ui/test_hooks.py
@@ -171,15 +171,16 @@ class HooksTest(BaseTestCase):
             event.set()
 
         def _test_table_listener(replay_table=table, listener_val=listener):
-            use_table_listener(replay_table, listener_val)
+            use_table_listener(replay_table, listener_val, do_replay=True)
 
         render_hook(_test_table_listener)
 
-        if not event.wait(timeout=1.0):
+        if not event.wait(timeout=LISTENER_TIMEOUT):
             assert False, "listener was not called"
 
     def test_table_listener(self):
-        from deephaven import DynamicTableWriter
+        from deephaven import DynamicTableWriter, new_table
+        from deephaven.column import int_col
         import deephaven.dtypes as dht
 
         column_definitions = {"Numbers": dht.int32, "Words": dht.string}
@@ -189,7 +190,13 @@ class HooksTest(BaseTestCase):
 
         self.verify_table_updated(table_writer, table, (1, "Testing"))
 
-        self.verify_table_replayed(table)
+        static_table = new_table(
+            [
+                int_col("Numbers", [1]),
+            ]
+        )
+
+        self.verify_table_replayed(static_table)
 
     def test_table_data(self):
         from deephaven.ui.hooks import use_table_data


### PR DESCRIPTION
Fixes #290

Theoretically, there is some danger in this implementation, as if dependencies change the listener will be called again, but I think it makes more sense than just checking the first time, as the dependencies changing means a completely different call. Maybe we need more danger signs as has been alluded to. Maybe that's a docs issue.