### PR TITLE
fix: Scatter plots rendering at the wrong location

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8971,6 +8971,38 @@
         "elementary-circuits-directed-graph": "^1.0.4"
       }
     },
+    "node_modules/@plotly/mapbox-gl": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/@plotly/mapbox-gl/-/mapbox-gl-1.13.4.tgz",
+      "integrity": "sha512-sR3/Pe5LqT/fhYgp4rT4aSFf1rTsxMbGiH6Hojc7PH36ny5Bn17iVFUjpzycafETURuFbLZUfjODO8LvSI+5zQ==",
+      "dependencies": {
+        "@mapbox/geojson-rewind": "^0.5.2",
+        "@mapbox/geojson-types": "^1.0.2",
+        "@mapbox/jsonlint-lines-primitives": "^2.0.2",
+        "@mapbox/mapbox-gl-supported": "^1.5.0",
+        "@mapbox/point-geometry": "^0.1.0",
+        "@mapbox/tiny-sdf": "^1.1.1",
+        "@mapbox/unitbezier": "^0.0.0",
+        "@mapbox/vector-tile": "^1.3.1",
+        "@mapbox/whoots-js": "^3.1.0",
+        "csscolorparser": "~1.0.3",
+        "earcut": "^2.2.2",
+        "geojson-vt": "^3.2.1",
+        "gl-matrix": "^3.2.1",
+        "grid-index": "^1.1.0",
+        "murmurhash-js": "^1.0.0",
+        "pbf": "^3.2.1",
+        "potpack": "^1.0.1",
+        "quickselect": "^2.0.0",
+        "rw": "^1.3.3",
+        "supercluster": "^7.1.0",
+        "tinyqueue": "^2.0.3",
+        "vt-pbf": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6.4.0"
+      }
+    },
     "node_modules/@plotly/point-cluster": {
       "version": "3.1.9",
       "resolved": "https://registry.npmjs.org/@plotly/point-cluster/-/point-cluster-3.1.9.tgz",
@@ -14292,6 +14324,14 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/base16/-/base16-1.0.0.tgz",
       "integrity": "sha512-pNdYkNPiJUnEhnfXV56+sQy8+AaPcG3POZAUnwr4EeqCUZFz4u2PePbo3e5Gj4ziYPCWGUZT9RHisvJKnwFuBQ=="
+    },
+    "node_modules/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -24492,11 +24532,12 @@
       }
     },
     "node_modules/mapbox-gl": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-1.10.1.tgz",
-      "integrity": "sha512-0aHt+lFUpYfvh0kMIqXqNXqoYMuhuAsMlw87TbhWrw78Tx2zfuPI0Lx31/YPUgJ+Ire0tzQ4JnuBL7acDNXmMg==",
+      "version": "1.13.3",
+      "resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-1.13.3.tgz",
+      "integrity": "sha512-p8lJFEiqmEQlyv+DQxFAOG/XPWN0Wp7j/Psq93Zywz7qt9CcUKFYDBOoOEKzqe6gudHVJY8/Bhqw6VDpX2lSBg==",
+      "peer": true,
       "dependencies": {
-        "@mapbox/geojson-rewind": "^0.5.0",
+        "@mapbox/geojson-rewind": "^0.5.2",
         "@mapbox/geojson-types": "^1.0.2",
         "@mapbox/jsonlint-lines-primitives": "^2.0.2",
         "@mapbox/mapbox-gl-supported": "^1.5.0",
@@ -24510,13 +24551,12 @@
         "geojson-vt": "^3.2.1",
         "gl-matrix": "^3.2.1",
         "grid-index": "^1.1.0",
-        "minimist": "^1.2.5",
         "murmurhash-js": "^1.0.0",
         "pbf": "^3.2.1",
         "potpack": "^1.0.1",
         "quickselect": "^2.0.0",
         "rw": "^1.3.3",
-        "supercluster": "^7.0.0",
+        "supercluster": "^7.1.0",
         "tinyqueue": "^2.0.3",
         "vt-pbf": "^3.1.1"
       },
@@ -29244,16 +29284,18 @@
       }
     },
     "node_modules/plotly.js": {
-      "version": "2.27.1",
-      "resolved": "https://registry.npmjs.org/plotly.js/-/plotly.js-2.27.1.tgz",
-      "integrity": "sha512-XeE0zTJWTxURYrUJqzf73l8lTb+HnyRvvhHkoSIEvWf58ins4saopo9l25kCm+xHAGz8E/2EOncE4DyXsJ34kA==",
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/plotly.js/-/plotly.js-2.29.1.tgz",
+      "integrity": "sha512-+XirhgCh42JF/iVu/RtBRbhcs328ipinajy7hd3mnZdnQv2Th6F441DSXer5S+P0nNluNs10vAFTELo4k/icjg==",
       "dependencies": {
         "@plotly/d3": "3.8.1",
         "@plotly/d3-sankey": "0.7.2",
         "@plotly/d3-sankey-circular": "0.33.1",
+        "@plotly/mapbox-gl": "v1.13.4",
         "@turf/area": "^6.4.0",
         "@turf/bbox": "^6.4.0",
         "@turf/centroid": "^6.0.2",
+        "base64-arraybuffer": "^1.0.2",
         "canvas-fit": "^1.5.0",
         "color-alpha": "1.0.4",
         "color-normalize": "1.5.0",
@@ -29275,7 +29317,6 @@
         "has-hover": "^1.0.1",
         "has-passive-events": "^1.0.0",
         "is-mobile": "^4.0.0",
-        "mapbox-gl": "1.10.1",
         "mouse-change": "^1.4.0",
         "mouse-event-offset": "^3.0.2",
         "mouse-wheel": "^1.2.0",
@@ -29287,7 +29328,7 @@
         "regl": "npm:@plotly/regl@^2.1.2",
         "regl-error2d": "^2.0.12",
         "regl-line2d": "^3.1.2",
-        "regl-scatter2d": "^3.2.9",
+        "regl-scatter2d": "^3.3.1",
         "regl-splom": "^1.0.14",
         "strongly-connected-components": "^1.0.1",
         "superscript-text": "^1.0.0",
@@ -29300,9 +29341,9 @@
       }
     },
     "node_modules/plotly.js-dist-min": {
-      "version": "2.27.1",
-      "resolved": "https://registry.npmjs.org/plotly.js-dist-min/-/plotly.js-dist-min-2.27.1.tgz",
-      "integrity": "sha512-fFPFityhOkDtjoIVd/9IJQbEEuKEjfmNALBVLZyHwLIkry5ygE4ZC/XENRqLnWR3rNJdTtEaxhM5zflcWTRlDA=="
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/plotly.js-dist-min/-/plotly.js-dist-min-2.29.1.tgz",
+      "integrity": "sha512-YvqX5TISWsJVTDIaUh2Qgt9uhLl0bWcQhO2rLPF0/hIY9BlinFa1JwSO2jFKcEmG0AJXSo4DnVdgKpsk9/8Apg=="
     },
     "node_modules/point-in-polygon": {
       "version": "1.1.0",
@@ -30483,9 +30524,9 @@
       }
     },
     "node_modules/regl-scatter2d": {
-      "version": "3.2.9",
-      "resolved": "https://registry.npmjs.org/regl-scatter2d/-/regl-scatter2d-3.2.9.tgz",
-      "integrity": "sha512-PNrXs+xaCClKpiB2b3HZ2j3qXQXhC5kcTh/Nfgx9rLO0EpEhab0BSQDqAsbdbpdf+pSHSJvbgitB7ulbGeQ+Fg==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/regl-scatter2d/-/regl-scatter2d-3.3.1.tgz",
+      "integrity": "sha512-seOmMIVwaCwemSYz/y4WE0dbSO9svNFSqtTh5RE57I7PjGo3tcUYKtH0MTSoshcAsreoqN8HoCtnn8wfHXXfKQ==",
       "dependencies": {
         "@plotly/point-cluster": "^3.1.9",
         "array-range": "^1.0.1",
@@ -35965,8 +36006,8 @@
         "@deephaven/plugin": "0.64.0",
         "@deephaven/utils": "0.64.0",
         "deep-equal": "^2.2.1",
-        "plotly.js": "^2.23.0",
-        "plotly.js-dist-min": "^2.23.0",
+        "plotly.js": "^2.29.1",
+        "plotly.js-dist-min": "^2.29.1",
         "react-plotly.js": "^2.4.0",
         "react-redux": "^7.2.9",
         "shortid": "^2.2.16"
@@ -36183,7 +36224,7 @@
         "@deephaven/jsapi-types": "^0.40.0",
         "@deephaven/log": "^0.40.0",
         "@deephaven/utils": "^0.40.0",
-        "plotly.js-dist-min": "^2.20.0",
+        "plotly.js-dist-min": "^2.29.1",
         "prop-types": "^15.8.1",
         "react-plotly.js": "^2.4.0",
         "shortid": "^2.2.16"
@@ -40973,7 +41014,7 @@
         "@deephaven/utils": "^0.40.0",
         "@types/react": "^17.0.2",
         "@vitejs/plugin-react-swc": "^3.0.0",
-        "plotly.js-dist-min": "^2.20.0",
+        "plotly.js-dist-min": "^2.29.1",
         "prop-types": "^15.8.1",
         "react": "^17.0.2",
         "react-plotly.js": "^2.4.0",
@@ -41008,8 +41049,8 @@
         "@types/react-plotly.js": "^2.6.0",
         "@vitejs/plugin-react-swc": "^3.0.0",
         "deep-equal": "^2.2.1",
-        "plotly.js": "^2.23.0",
-        "plotly.js-dist-min": "^2.23.0",
+        "plotly.js": "^2.29.1",
+        "plotly.js-dist-min": "^2.29.1",
         "react": "^17.0.2",
         "react-plotly.js": "^2.4.0",
         "react-redux": "^7.2.9",
@@ -44442,6 +44483,35 @@
         "d3-collection": "^1.0.4",
         "d3-shape": "^1.2.0",
         "elementary-circuits-directed-graph": "^1.0.4"
+      }
+    },
+    "@plotly/mapbox-gl": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/@plotly/mapbox-gl/-/mapbox-gl-1.13.4.tgz",
+      "integrity": "sha512-sR3/Pe5LqT/fhYgp4rT4aSFf1rTsxMbGiH6Hojc7PH36ny5Bn17iVFUjpzycafETURuFbLZUfjODO8LvSI+5zQ==",
+      "requires": {
+        "@mapbox/geojson-rewind": "^0.5.2",
+        "@mapbox/geojson-types": "^1.0.2",
+        "@mapbox/jsonlint-lines-primitives": "^2.0.2",
+        "@mapbox/mapbox-gl-supported": "^1.5.0",
+        "@mapbox/point-geometry": "^0.1.0",
+        "@mapbox/tiny-sdf": "^1.1.1",
+        "@mapbox/unitbezier": "^0.0.0",
+        "@mapbox/vector-tile": "^1.3.1",
+        "@mapbox/whoots-js": "^3.1.0",
+        "csscolorparser": "~1.0.3",
+        "earcut": "^2.2.2",
+        "geojson-vt": "^3.2.1",
+        "gl-matrix": "^3.2.1",
+        "grid-index": "^1.1.0",
+        "murmurhash-js": "^1.0.0",
+        "pbf": "^3.2.1",
+        "potpack": "^1.0.1",
+        "quickselect": "^2.0.0",
+        "rw": "^1.3.3",
+        "supercluster": "^7.1.0",
+        "tinyqueue": "^2.0.3",
+        "vt-pbf": "^3.1.1"
       }
     },
     "@plotly/point-cluster": {
@@ -48550,6 +48620,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/base16/-/base16-1.0.0.tgz",
       "integrity": "sha512-pNdYkNPiJUnEhnfXV56+sQy8+AaPcG3POZAUnwr4EeqCUZFz4u2PePbo3e5Gj4ziYPCWGUZT9RHisvJKnwFuBQ=="
+    },
+    "base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ=="
     },
     "base64-js": {
       "version": "1.5.1",
@@ -56337,11 +56412,12 @@
       "dev": true
     },
     "mapbox-gl": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-1.10.1.tgz",
-      "integrity": "sha512-0aHt+lFUpYfvh0kMIqXqNXqoYMuhuAsMlw87TbhWrw78Tx2zfuPI0Lx31/YPUgJ+Ire0tzQ4JnuBL7acDNXmMg==",
+      "version": "1.13.3",
+      "resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-1.13.3.tgz",
+      "integrity": "sha512-p8lJFEiqmEQlyv+DQxFAOG/XPWN0Wp7j/Psq93Zywz7qt9CcUKFYDBOoOEKzqe6gudHVJY8/Bhqw6VDpX2lSBg==",
+      "peer": true,
       "requires": {
-        "@mapbox/geojson-rewind": "^0.5.0",
+        "@mapbox/geojson-rewind": "^0.5.2",
         "@mapbox/geojson-types": "^1.0.2",
         "@mapbox/jsonlint-lines-primitives": "^2.0.2",
         "@mapbox/mapbox-gl-supported": "^1.5.0",
@@ -56355,13 +56431,12 @@
         "geojson-vt": "^3.2.1",
         "gl-matrix": "^3.2.1",
         "grid-index": "^1.1.0",
-        "minimist": "^1.2.5",
         "murmurhash-js": "^1.0.0",
         "pbf": "^3.2.1",
         "potpack": "^1.0.1",
         "quickselect": "^2.0.0",
         "rw": "^1.3.3",
-        "supercluster": "^7.0.0",
+        "supercluster": "^7.1.0",
         "tinyqueue": "^2.0.3",
         "vt-pbf": "^3.1.1"
       }
@@ -59618,16 +59693,18 @@
       }
     },
     "plotly.js": {
-      "version": "2.27.1",
-      "resolved": "https://registry.npmjs.org/plotly.js/-/plotly.js-2.27.1.tgz",
-      "integrity": "sha512-XeE0zTJWTxURYrUJqzf73l8lTb+HnyRvvhHkoSIEvWf58ins4saopo9l25kCm+xHAGz8E/2EOncE4DyXsJ34kA==",
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/plotly.js/-/plotly.js-2.29.1.tgz",
+      "integrity": "sha512-+XirhgCh42JF/iVu/RtBRbhcs328ipinajy7hd3mnZdnQv2Th6F441DSXer5S+P0nNluNs10vAFTELo4k/icjg==",
       "requires": {
         "@plotly/d3": "3.8.1",
         "@plotly/d3-sankey": "0.7.2",
         "@plotly/d3-sankey-circular": "0.33.1",
+        "@plotly/mapbox-gl": "v1.13.4",
         "@turf/area": "^6.4.0",
         "@turf/bbox": "^6.4.0",
         "@turf/centroid": "^6.0.2",
+        "base64-arraybuffer": "^1.0.2",
         "canvas-fit": "^1.5.0",
         "color-alpha": "1.0.4",
         "color-normalize": "1.5.0",
@@ -59649,7 +59726,6 @@
         "has-hover": "^1.0.1",
         "has-passive-events": "^1.0.0",
         "is-mobile": "^4.0.0",
-        "mapbox-gl": "1.10.1",
         "mouse-change": "^1.4.0",
         "mouse-event-offset": "^3.0.2",
         "mouse-wheel": "^1.2.0",
@@ -59661,7 +59737,7 @@
         "regl": "npm:@plotly/regl@^2.1.2",
         "regl-error2d": "^2.0.12",
         "regl-line2d": "^3.1.2",
-        "regl-scatter2d": "^3.2.9",
+        "regl-scatter2d": "^3.3.1",
         "regl-splom": "^1.0.14",
         "strongly-connected-components": "^1.0.1",
         "superscript-text": "^1.0.0",
@@ -59674,9 +59750,9 @@
       }
     },
     "plotly.js-dist-min": {
-      "version": "2.27.1",
-      "resolved": "https://registry.npmjs.org/plotly.js-dist-min/-/plotly.js-dist-min-2.27.1.tgz",
-      "integrity": "sha512-fFPFityhOkDtjoIVd/9IJQbEEuKEjfmNALBVLZyHwLIkry5ygE4ZC/XENRqLnWR3rNJdTtEaxhM5zflcWTRlDA=="
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/plotly.js-dist-min/-/plotly.js-dist-min-2.29.1.tgz",
+      "integrity": "sha512-YvqX5TISWsJVTDIaUh2Qgt9uhLl0bWcQhO2rLPF0/hIY9BlinFa1JwSO2jFKcEmG0AJXSo4DnVdgKpsk9/8Apg=="
     },
     "point-in-polygon": {
       "version": "1.1.0",
@@ -60569,9 +60645,9 @@
       }
     },
     "regl-scatter2d": {
-      "version": "3.2.9",
-      "resolved": "https://registry.npmjs.org/regl-scatter2d/-/regl-scatter2d-3.2.9.tgz",
-      "integrity": "sha512-PNrXs+xaCClKpiB2b3HZ2j3qXQXhC5kcTh/Nfgx9rLO0EpEhab0BSQDqAsbdbpdf+pSHSJvbgitB7ulbGeQ+Fg==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/regl-scatter2d/-/regl-scatter2d-3.3.1.tgz",
+      "integrity": "sha512-seOmMIVwaCwemSYz/y4WE0dbSO9svNFSqtTh5RE57I7PjGo3tcUYKtH0MTSoshcAsreoqN8HoCtnn8wfHXXfKQ==",
       "requires": {
         "@plotly/point-cluster": "^3.1.9",
         "array-range": "^1.0.1",

--- a/plugins/plotly-express/src/js/package.json
+++ b/plugins/plotly-express/src/js/package.json
@@ -60,8 +60,8 @@
     "@deephaven/plugin": "0.64.0",
     "@deephaven/utils": "0.64.0",
     "deep-equal": "^2.2.1",
-    "plotly.js": "^2.23.0",
-    "plotly.js-dist-min": "^2.23.0",
+    "plotly.js": "^2.29.1",
+    "plotly.js-dist-min": "^2.29.1",
     "react-plotly.js": "^2.4.0",
     "react-redux": "^7.2.9",
     "shortid": "^2.2.16"

--- a/plugins/plotly/src/js/package.json
+++ b/plugins/plotly/src/js/package.json
@@ -39,7 +39,7 @@
     "@deephaven/jsapi-types": "^0.40.0",
     "@deephaven/log": "^0.40.0",
     "@deephaven/utils": "^0.40.0",
-    "plotly.js-dist-min": "^2.20.0",
+    "plotly.js-dist-min": "^2.29.1",
     "prop-types": "^15.8.1",
     "react-plotly.js": "^2.4.0",
     "shortid": "^2.2.16"


### PR DESCRIPTION
- Update plotly.js to fix the issue
- Fixes #323
- Verified using the steps in the issue on my M1 mac (issue was reproducible before this change)
