### PR TITLE
fix: Bind unwrapValue to this.chartUtils

### DIFF
--- a/plugins/plotly-express/src/js/src/PlotlyExpressChartModel.ts
+++ b/plugins/plotly-express/src/js/src/PlotlyExpressChartModel.ts
@@ -25,6 +25,7 @@ export class PlotlyExpressChartModel extends ChartModel {
     this.widget = widget;
     this.refetch = refetch;
     this.chartUtils = new ChartUtils(dh);
+    this.unwrapValue = this.chartUtils.unwrapValue.bind(this.chartUtils);
 
     this.handleFigureUpdated = this.handleFigureUpdated.bind(this);
     this.handleWidgetUpdated = this.handleWidgetUpdated.bind(this);
@@ -46,6 +47,8 @@ export class PlotlyExpressChartModel extends ChartModel {
   widget?: Widget;
 
   widgetUnsubscribe?: () => void;
+
+  unwrapValue: (value: unknown) => unknown;
 
   /**
    * Map of table index to Table object.
@@ -241,7 +244,7 @@ export class PlotlyExpressChartModel extends ChartModel {
     figureUpdateEvent.columns.forEach(column => {
       const columnData = chartData.getColumn(
         column.name,
-        this.chartUtils.unwrapValue,
+        this.unwrapValue,
         figureUpdateEvent
       );
       tableData[column.name] = columnData;


### PR DESCRIPTION
Plotly-express plugin throws an error in DHE:
```
User callback ( (e2) => this.handleFigureUpdated(e2, id) ) of type  updated  failed:  JavaScriptException {stackTrace: null, backingJsObject: TypeError: Cannot destructure property 'dh' of 'this' as it is undefined. at unwrapValue
```

Fix by binding the function to `this.chartUtils`.