### PR TITLE
fix: Use correct formatting settings for ui.table

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36301,10 +36301,12 @@
         "@deephaven/log": "0.62.0",
         "@deephaven/plugin": "0.62.0",
         "@deephaven/react-hooks": "0.62.0",
+        "@deephaven/redux": "0.62.0",
         "@deephaven/utils": "0.62.0",
         "@fortawesome/react-fontawesome": "^0.2.0",
         "@react-types/shared": "^3.22.0",
         "json-rpc-2.0": "^1.6.0",
+        "react-redux": "^7.x",
         "shortid": "^2.2.16"
       },
       "devDependencies": {
@@ -41221,6 +41223,7 @@
         "@deephaven/log": "0.62.0",
         "@deephaven/plugin": "0.62.0",
         "@deephaven/react-hooks": "0.62.0",
+        "@deephaven/redux": "0.62.0",
         "@deephaven/utils": "0.62.0",
         "@fortawesome/react-fontawesome": "^0.2.0",
         "@react-types/shared": "^3.22.0",
@@ -41229,6 +41232,7 @@
         "json-rpc-2.0": "^1.6.0",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
+        "react-redux": "^7.x",
         "shortid": "^2.2.16",
         "typescript": "^4.5.4",
         "vite": "~4.1.4"

--- a/plugins/ui/src/js/package.json
+++ b/plugins/ui/src/js/package.json
@@ -53,9 +53,11 @@
     "@deephaven/log": "0.62.0",
     "@deephaven/plugin": "0.62.0",
     "@deephaven/react-hooks": "0.62.0",
+    "@deephaven/redux": "0.62.0",
     "@deephaven/utils": "0.62.0",
     "@fortawesome/react-fontawesome": "^0.2.0",
     "@react-types/shared": "^3.22.0",
+    "react-redux": "^7.x",
     "json-rpc-2.0": "^1.6.0",
     "shortid": "^2.2.16"
   },

--- a/plugins/ui/src/js/src/elements/UITable.tsx
+++ b/plugins/ui/src/js/src/elements/UITable.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react';
+import { useSelector } from 'react-redux';
 import {
   DehydratedQuickFilter,
   IrisGrid,
@@ -10,6 +11,7 @@ import {
 import { useApi } from '@deephaven/jsapi-bootstrap';
 import type { Table } from '@deephaven/jsapi-types';
 import Log from '@deephaven/log';
+import { getSettings } from '@deephaven/redux';
 import { UITableProps } from './UITableUtils';
 
 const log = Log.module('@deephaven/js-plugin-ui/UITable');
@@ -26,6 +28,7 @@ function UITable({
   const [model, setModel] = useState<IrisGridModel>();
   const [columns, setColumns] = useState<Table['columns']>();
   const utils = useMemo(() => new IrisGridUtils(dh), [dh]);
+  const settings = useSelector(getSettings);
 
   const hydratedSorts = useMemo(() => {
     if (sorts !== undefined && columns !== undefined) {
@@ -81,6 +84,7 @@ function UITable({
       showSearchBar: canSearch,
       sorts: hydratedSorts,
       quickFilters: hydratedQuickFilters,
+      settings,
     }),
     [
       onRowDoublePress,
@@ -88,6 +92,7 @@ function UITable({
       canSearch,
       hydratedSorts,
       hydratedQuickFilters,
+      settings,
     ]
   );
 


### PR DESCRIPTION
- Wasn't passing the settings into `IrisGrid`
- Pull the settings from redux and pass them to `IrisGrid`
- Fixes #315
- Verified using the steps in the ticket. The table uses the correct time zone.
