### PR TITLE
feat: Export plotly-express as a dashboard plugin

### DIFF
--- a/plugins/plotly-express/src/js/src/DashboardPlugin.tsx
+++ b/plugins/plotly-express/src/js/src/DashboardPlugin.tsx
@@ -42,9 +42,8 @@ export function DashboardPlugin(
           id: panelId,
           metadata: {
             ...metadata,
-            name,
+            ...widget,
             figure: name,
-            type,
           },
           fetch,
         },

--- a/plugins/plotly-express/src/js/src/DashboardPlugin.tsx
+++ b/plugins/plotly-express/src/js/src/DashboardPlugin.tsx
@@ -6,7 +6,7 @@ import {
   PanelEvent,
   useListener,
 } from '@deephaven/dashboard';
-import type { VariableDefinition } from '@deephaven/jsapi-types';
+import type { VariableDescriptor } from '@deephaven/jsapi-types';
 import PlotlyExpressChartPanel from './PlotlyExpressChartPanel.js';
 import type { PlotlyChartWidget } from './PlotlyExpressChartUtils.js';
 
@@ -27,9 +27,9 @@ export function DashboardPlugin(
       fetch: () => Promise<PlotlyChartWidget>;
       metadata?: Record<string, unknown>;
       panelId?: string;
-      widget: VariableDefinition;
+      widget: VariableDescriptor;
     }) => {
-      const { type, title } = widget;
+      const { type, name } = widget;
       if (type !== 'deephaven.plot.express.DeephavenFigure') {
         return;
       }
@@ -42,13 +42,13 @@ export function DashboardPlugin(
           id: panelId,
           metadata: {
             ...metadata,
-            name: title,
-            figure: title,
+            name,
+            figure: name,
             type,
           },
           fetch,
         },
-        title,
+        title: name,
         id: panelId,
       };
 

--- a/plugins/plotly-express/src/js/src/DashboardPlugin.tsx
+++ b/plugins/plotly-express/src/js/src/DashboardPlugin.tsx
@@ -1,0 +1,78 @@
+import { useCallback, DragEvent, useEffect } from 'react';
+import shortid from 'shortid';
+import {
+  DashboardPluginComponentProps,
+  LayoutUtils,
+  PanelEvent,
+  useListener,
+} from '@deephaven/dashboard';
+import type { VariableDefinition } from '@deephaven/jsapi-types';
+import PlotlyExpressChartPanel from './PlotlyExpressChartPanel.js';
+import type { PlotlyChartWidget } from './PlotlyExpressChartUtils.js';
+
+export function DashboardPlugin(
+  props: DashboardPluginComponentProps
+): JSX.Element | null {
+  const { id, layout, registerComponent } = props;
+
+  const handlePanelOpen = useCallback(
+    async ({
+      dragEvent,
+      fetch,
+      metadata = {},
+      panelId = shortid.generate(),
+      widget,
+    }: {
+      dragEvent?: DragEvent;
+      fetch: () => Promise<PlotlyChartWidget>;
+      metadata?: Record<string, unknown>;
+      panelId?: string;
+      widget: VariableDefinition;
+    }) => {
+      const { type, title } = widget;
+      if (type !== 'deephaven.plot.express.DeephavenFigure') {
+        return;
+      }
+
+      const config = {
+        type: 'react-component' as const,
+        component: 'PlotlyPanel',
+        props: {
+          localDashboardId: id,
+          id: panelId,
+          metadata: {
+            ...metadata,
+            name: title,
+            figure: title,
+            type,
+          },
+          fetch,
+        },
+        title,
+        id: panelId,
+      };
+
+      const { root } = layout;
+      LayoutUtils.openComponent({ root, config, dragEvent });
+    },
+    [id, layout]
+  );
+
+  useEffect(
+    function registerComponentsAndReturnCleanup() {
+      const cleanups = [
+        registerComponent('PlotlyPanel', PlotlyExpressChartPanel),
+      ];
+      return () => {
+        cleanups.forEach(cleanup => cleanup());
+      };
+    },
+    [registerComponent]
+  );
+
+  useListener(layout.eventHub, PanelEvent.OPEN, handlePanelOpen);
+
+  return null;
+}
+
+export default DashboardPlugin;

--- a/plugins/plotly-express/src/js/src/PlotlyExpressChartUtils.ts
+++ b/plugins/plotly-express/src/js/src/PlotlyExpressChartUtils.ts
@@ -1,5 +1,14 @@
 import type { Data, PlotlyDataLayoutConfig } from 'plotly.js';
-import type { Widget } from '@deephaven/jsapi-types';
+import type { Table, Widget } from '@deephaven/jsapi-types';
+
+export interface PlotlyChartWidget {
+  getDataAsBase64(): string;
+  exportedObjects: { fetch(): Promise<Table> }[];
+  addEventListener(
+    type: string,
+    fn: (event: CustomEvent<PlotlyChartWidget>) => () => void
+  ): void;
+}
 
 export interface PlotlyChartWidgetData {
   type: string;

--- a/plugins/plotly-express/src/js/src/index.ts
+++ b/plugins/plotly-express/src/js/src/index.ts
@@ -1,6 +1,3 @@
-import { PlotlyExpressPlugin } from './PlotlyExpressPlugin.js';
-
+export * from './DashboardPlugin.js';
 export * from './PlotlyExpressChartModel.js';
 export * from './PlotlyExpressChartUtils.js';
-
-export default PlotlyExpressPlugin;

--- a/plugins/plotly-express/src/js/src/index.ts
+++ b/plugins/plotly-express/src/js/src/index.ts
@@ -1,3 +1,8 @@
+import { PlotlyExpressPlugin } from './PlotlyExpressPlugin.js';
+
+// Export legacy dashboard plugin as named export for backwards compatibility
 export * from './DashboardPlugin.js';
 export * from './PlotlyExpressChartModel.js';
 export * from './PlotlyExpressChartUtils.js';
+
+export default PlotlyExpressPlugin;


### PR DESCRIPTION
Tested with DHE V+ (1.20231218.176) Core 0.32.1
Closes #308


BREAKING CHANGE:
- `widget` type in the `PanelEvent.OPEN` event arguments has changed from `VariableDefinition` to `VariableDescriptor`