### PR TITLE
chore: Make example package private

### DIFF
--- a/plugins/example-theme/src/js/package.json
+++ b/plugins/example-theme/src/js/package.json
@@ -14,5 +14,6 @@
     "@deephaven/plugin": "^0.58.0",
     "typescript": "^5.2.2",
     "vite": "^5.0.8"
-  }
+  },
+  "private": true
 }


### PR DESCRIPTION
- There is an error thrown when publishing JS packages right now: https://github.com/deephaven/deephaven-plugins/actions/runs/8210757136/job/22458743570
```
lerna WARN Unable to determine published version, assuming "@deephaven/js-plugin-example-theme" unpublished.

Found 2 packages to publish:
 - @deephaven/js-plugin-example-theme => 0.1.0
 - @deephaven/js-plugin-ui => 0.9.0

lerna info auto-confirmed 
lerna info publish Publishing packages to npm...
lerna ERR! E402 You must sign up for private packages
```
- Make the example package private so it doesn't try to publish it
