### PR TITLE
docs: list_view spec

### DIFF
--- a/plugins/ui/DESIGN.md
+++ b/plugins/ui/DESIGN.md
@@ -1225,6 +1225,7 @@ ui.list_view(
 | `**props`              | `Any`                                                                    | Any other [Picker](https://react-spectrum.adobe.com/react-spectrum/Picker.html) prop, with the exception of `items`, `dragAndDropHooks`, and `onLoadMore`.                                                                                                                                                                    |
 
  
+ 
 ```py
 import deephaven.ui as ui
 
@@ -1825,8 +1826,6 @@ PickerItem = Stringable | ItemElement
 Key = Stringable
 Selection = Sequence[Key]
 ListViewItem = Stringable | ItemElement
-DropOperation = Literal["MOVE", "COPY"]
-DragType = str
 
 T = TypeVar("T")
 Combination: TypeAlias = T | set[T] | Sequence[T]

--- a/plugins/ui/DESIGN.md
+++ b/plugins/ui/DESIGN.md
@@ -1186,19 +1186,25 @@ picker7 = ui.picker(
 ```
 
 ###### ui.list_view
-A list view that can be used to create a list of items. Children should be one of two types:
-If children are of type `ListViewItem`, they are the list items.
-If children are of type `Table`, the values in the table are the list items. There can only be one child, the `Table`. 
+A list view that can be used to create a list of items. Children should be one of two types:  
+If children are of type `ListViewItem`, they are the list items.  
+If children are of type `Table`, the values in the table are the list items. There can only be one child, the `Table`.   
+If children are of type `PartitionedTable`, the partitions create navigable sections. The values in the table are the list items. There can only be one child, the `PartitionedTable`.  
 
 ```py
 import deephaven.ui as ui
 ui.list_view(
-    *children: ListViewItem | Table
+    *children: ListViewItem | Table | PartitionedTable,
     key_column: ColumnName | None = None,
     label_column: ColumnName | None = None,
     description_column: ColumnName | None = None,
     icon_column: ColumnName | None = None,
     action_buttons: ActionButtonElement | ActionGroupElement | ActionMenuElement | None = None,
+    section_key_column: ColumnName | None = None,
+    section_label_column: ColumnName | None = None,
+    section_description_column: ColumnName | None = None,
+    section_icon_column: ColumnName | None = None,
+    section_action_buttons: ActionButtonElement | ActionGroupElement | ActionMenuElement | None = None,
     default_selected_keys: Selection | None = None,
     selected_keys: Selection | None = None,
     render_empty_state: Element | None = None,
@@ -1209,23 +1215,27 @@ ui.list_view(
 ```
 
 ###### Parameters
-| Parameter              | Type                                                                     | Description                                                                                                                                                                                                                                                                                                                   |
-|------------------------|--------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `*children`            | `ListViewItem \| Table`                                                  | The options to render within the picker.                                                                                                                                                                                                                                                                                      |
-| `key_column`           | `ColumnName \| None`                                                     | Only valid if children are of type `Table`. The column of values to use as item keys. Defaults to the first column.                                                                                                                                                                                                           |
-| `label_column`         | `ColumnName \| None`                                                     | Only valid if children are of type `Table`. The column of values to display as primary text. Defaults to the `key_column` value.                                                                                                                                                                                              |
-| `description_column`   | `ColumnName \| None`                                                     | Only valid if children are of type `Table`. The column of values to display as descriptions.                                                                                                                                                                                                                                  |
-| `icon_column`          | `ColumnName \| None`                                                     | Only valid if children are of type `Table`. The column of values to map to icons.                                                                                                                                                                                                                                             |
-| `action_buttons`       | `ActionButtonElement \| ActionGroupElement \| ActionMenuElement \| None` | Only valid if any `ListViewItem` `children` do not already have embedded buttons. The action buttons to render for all elements within the list view. The `on_*` event handlers within the passed object will be modified so that the second argument is the `Key` for the `list_view` item that the buttons are embedded in. |
-| `default_selected_keys`| `Selection \| None`                                                      | The initial selected keys in the collection (uncontrolled).                                                                                                                                                                                                                                                                   |
-| `selected_keys`        | `Selection \| None`                                                      | The currently selected keys in the collection (controlled).                                                                                                                                                                                                                                                                   |
-| `render_empty_state`   | `Element \| None`                                                        | Sets what the `list_view` should render when there is no content to display.                                                                                                                                                                                                                                                  |
-| `on_selection_change`  | `Callable[[Selection], None] \| None`                                    | Handler that is called when the selections changes.                                                                                                                                                                                                                                                                           |
-| `on_change`            | `Callable[[Selection], None] \| None`                                    | Alias of `on_selection_change`. Handler that is called when the selections changes.                                                                                                                                                                                                                                           |
-| `**props`              | `Any`                                                                    | Any other [Picker](https://react-spectrum.adobe.com/react-spectrum/Picker.html) prop, with the exception of `items`, `dragAndDropHooks`, and `onLoadMore`.                                                                                                                                                                    |
+| Parameter                    | Type                                                                     | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+|------------------------------|--------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `*children`                  | `ListViewItem \| Table \| PartitionedTable`                              | The options to render within the picker.                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| `key_column`                 | `ColumnName \| None`                                                     | Only valid if children are of type `Table`. The column of values to use as item keys. Defaults to the first column.                                                                                                                                                                                                                                                                                                                                           |
+| `label_column`               | `ColumnName \| None`                                                     | Only valid if children are of type `Table`. The column of values to display as primary text. Defaults to the `key_column` value.                                                                                                                                                                                                                                                                                                                              |
+| `description_column`         | `ColumnName \| None`                                                     | Only valid if children are of type `Table`. The column of values to display as descriptions.                                                                                                                                                                                                                                                                                                                                                                  |
+| `icon_column`                | `ColumnName \| None`                                                     | Only valid if children are of type `Table`. The column of values to map to icons.                                                                                                                                                                                                                                                                                                                                                                             |
+| `action_buttons`             | `ActionButtonElement \| ActionGroupElement \| ActionMenuElement \| None` | Only valid if any `ListViewItem` children do not already have embedded buttons. The action buttons to render for all elements within the list view. The `on_*` event handlers within the passed object will be modified so that the second argument is the key for the `list_view` item that the buttons are embedded in. If children is of type `PartitionedTable`, a third argument is added, which is the section key as outlined in `section_key_column`. |
+| `section_key_column`         | `ColumnName \| None`                                                     | Only valid if children is of type `PartitionedTable`. The column of values to use as section keys. Should be the same for all values in the constituent `Table`. If not specified, the section titles will be created from the `key_columns` of the `PartitionedTable`.                                                                                                                                                                                       |
+| `section_label_column`       | `ColumnName \| None`                                                     | Only valid if children is of type `PartitionedTable`. The column of values to display as section names. Should be the same for all values in the constituent `Table`. If not specified, the label will be set to the `section_key_column` value.                                                                                                                                                                                                              |
+| `section_description_column` | `ColumnName \| None`                                                     | Only valid if children is of type `PartitionedTable`. The column of values to display as section descriptions. Should be the same for all values in the constituent `Table`.                                                                                                                                                                                                                                                                                  |
+| `section_icon_column`        | `ColumnName \| None`                                                     | Only valid if children is of type `PartitionedTable`. The column of values to map to section icons. Should be the same for all values in the constituent `Table`.                                                                                                                                                                                                                                                                                             |
+| `section_action_buttons`     | `ActionButtonElement \| ActionGroupElement \| ActionMenuElement \| None` | Only valid if children is of type `PartitionedTable`. The action buttons to render for all section elements. The `on_*` event handlers within the passed object will be modified so that the second argument is the key for the `list_view` section item that the buttons are embedded in.                                                                                                                                                                    |
+| `default_selected_keys`      | `Selection \| None`                                                      | The initial selected keys in the collection (uncontrolled).                                                                                                                                                                                                                                                                                                                                                                                                   |
+| `selected_keys`              | `Selection \| None`                                                      | The currently selected keys in the collection (controlled).                                                                                                                                                                                                                                                                                                                                                                                                   |
+| `render_empty_state`         | `Element \| None`                                                        | Sets what the `list_view` should render when there is no content to display.                                                                                                                                                                                                                                                                                                                                                                                  |
+| `on_selection_change`        | `Callable[[Selection], None] \| None`                                    | Handler that is called when the selections changes.                                                                                                                                                                                                                                                                                                                                                                                                           |
+| `on_change`                  | `Callable[[Selection], None] \| None`                                    | Alias of `on_selection_change`. Handler that is called when the selections changes.                                                                                                                                                                                                                                                                                                                                                                           |
+| `**props`                    | `Any`                                                                    | Any other [ListView](https://react-spectrum.adobe.com/react-spectrum/ListView.html) prop, with the exception of `items`, `dragAndDropHooks`, and `onLoadMore`.                                                                                                                                                                                                                                                                                                  |
 
- 
- 
+
 ```py
 import deephaven.ui as ui
 
@@ -1239,27 +1249,15 @@ list_view1 = ui.list_view(
 )
 
 # simple list_view that takes list view items directly and is controlled
-options, set_options = ui.use_state(["Option 1", "Option 2"])
+selection, set_selection = ui.use_state(["Option 1", "Option 2"])
 
 list_view2 = ui.list_view(
     "Option 1",
     "Option 2",
     "Option 3",
     "Option 4",
-    selected_keys=option,
-    on_selection_change=set_option
-)
-
-# Buttons can be embedded in the list view. Note list_key is added to the on_press handler, but is not required.
-on_button_action = lambda e, key: print(f"Event {e} was emitted for list item {key}")
-button = ui.action_button("Current Color", on_press=on_button_action)
-
-list_view3 = ui.list_view(
-    "Option 1",
-    "Option 2",
-    "Option 3",
-    "Option 4",
-    action_buttons=button,
+    selected_keys=selection,
+    on_selection_change=selection
 )
 
 from deephaven import empty_table
@@ -1270,12 +1268,12 @@ table1 = empty_table(4).update_view("data=i")
 # this should be avoided as it is not as performant as just passing in the table directly
 options = ui.use_column_data(table1)
 
-list_view4 = ui.list_view(
+list_view3 = ui.list_view(
     children=options
 )
 
 # instead, pass in the table directly
-list_view5 = ui.list_view(
+list_view4 = ui.list_view(
     table1
 )
 
@@ -1283,27 +1281,70 @@ from deephaven import new_table
 from deephaven.column import string_col, int_col
 
 color_table = new_table([
-    string_col("Sections", ["Interesting Colors", 'Interesting Colors', "Other Colors"]),
-    string_col("SectionNames", ["Favorites", 'Favorites', "Other"]),
     int_col("Keys", ["salmon", "lemonchiffon", "black"]),
     string_col("Labels", ["Salmon", "Lemon Chiffon", "Black"]),
     string_col("Descriptions", ["An interesting color", "Another interesting color", "A color"]),
-    string_col("Icons", ["Amusementpark", "Teapot", "Sentiment Negative"])
+    string_col("Icons", ["Amusementpark", "Teapot", "Sentiment Negative"]),
+    string_col("SectionKeys", ["Interesting Colors", "Interesting Colors", "Other Colors"]),
+    string_col("SectionLabels", ["Favorites", "Favorites", "Other"]),
+    string_col("SectionDescriptions", ["Favorite colors", "Favorite colors", "Other colors"]),
+    string_col("SectionIcons", ["Folder", "Folder", "Not Found"])
 ])
+partitioned_color_table = color_table.partition_by("Sections")
 
 colors, set_colors = ui.use_state(["salmon", "lemonchiffon"])
 
 # this will create a controlled list_view with color_table
+list_view5 = ui.list_view(
+    color_table,
+    key_column="Keys",
+    label_column="Labels",
+    description_column="Descriptions",
+    icon_column="Icons",
+    selected_keys=colors,
+    on_selection_change=set_colors
+)
+
+# this will create a list_view with two navigable sections, one for each partition
 list_view6 = ui.list_view(
     color_table,
     key_column="Keys",
     label_column="Labels",
     description_column="Descriptions",
     icon_column="Icons",
-    title_column="SectionNames",
-    selected_keys=colors,
-    on_selection_change=set_colors
+    title_column="SectionLabels",
+    section_key_column="SectionKeys",
+    section_label_column="SectionNames",
+    section_description_column="SectionDescriptions",
+    section_icon_column="SectionIcons",
 )
+
+# Buttons can be embedded in the list view. Note key is added to the on_press handler, but is not required.
+on_button_action = lambda e, key: print(f"Event {e} was emitted for list item {key}")
+button = ui.action_button("Print Item", on_press=on_button_action)
+
+list_view7 = ui.list_view(
+    "Option 1",
+    "Option 2",
+    "Option 3",
+    "Option 4",
+    action_buttons=button,
+)
+
+# Buttons can be embedded in the list view. Note key and section are added to the on_press handler, but they are not required.
+on_button_action = lambda e, key, section: print(f"Event {e} was emitted for list item {key} in section {section}")
+key_button = ui.action_button("Print Item", on_press=on_button_action)
+
+# Buttons can be embeedded in the section items. Note section is added to the on_press handler, but is not required.
+on_section_button_action = lambda e, section: print(f"Event {e} was emitted for section item {section}")
+section_button = ui.action_button("Print Section", on_press=on_section_button_action)
+
+list_view8 = ui.list_view(
+    partitioned_color_table,
+    action_buttons=key_button,
+    section_action_buttons=section_button
+)
+
 ```
 
 #### ui.table

--- a/plugins/ui/DESIGN.md
+++ b/plugins/ui/DESIGN.md
@@ -1071,7 +1071,7 @@ ui.picker(
     on_selection_change: Callable[[Key], None] | None = None, 
     on_change: Callable[[Key], None] | None = None,
     **props: Any
-) -> ItemElement
+) -> PickerElement
 ```
 
 ###### Parameters
@@ -1180,8 +1180,128 @@ picker7 = ui.picker(
     description_column="Descriptions",
     icon_column="Icons",
     title_column="SectionNames",
-    selected_key=option,
+    selected_key=color,
     on_selection_change=set_color
+)
+```
+
+###### ui.list_view
+A list view that can be used to create a list of items. Children should be one of two types:
+If children are of type `ListViewItem`, they are the list items.
+If children are of type `Table`, the values in the table are the list items. There can only be one child, the `Table`. 
+
+```py
+import deephaven.ui as ui
+ui.list_view(
+    *children: ListViewItem | Table
+    key_column: ColumnName | None = None,
+    label_column: ColumnName | None = None,
+    description_column: ColumnName | None = None,
+    icon_column: ColumnName | None = None,
+    action_buttons: ActionButtonElement | ActionGroupElement | ActionMenuElement | None = None,
+    default_selected_keys: Selection | None = None,
+    selected_keys: Selection | None = None,
+    render_empty_state: Element | None = None,
+    on_selection_change: Callable[[Selection], None] | None = None, 
+    on_change: Callable[[Selection], None] | None = None,
+    **props: Any
+) -> ListViewElement
+```
+
+###### Parameters
+| Parameter              | Type                                                                     | Description                                                                                                                                                                                                                                                                                                                   |
+|------------------------|--------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `*children`            | `ListViewItem \| Table`                                                  | The options to render within the picker.                                                                                                                                                                                                                                                                                      |
+| `key_column`           | `ColumnName \| None`                                                     | Only valid if children are of type `Table`. The column of values to use as item keys. Defaults to the first column.                                                                                                                                                                                                           |
+| `label_column`         | `ColumnName \| None`                                                     | Only valid if children are of type `Table`. The column of values to display as primary text. Defaults to the `key_column` value.                                                                                                                                                                                              |
+| `description_column`   | `ColumnName \| None`                                                     | Only valid if children are of type `Table`. The column of values to display as descriptions.                                                                                                                                                                                                                                  |
+| `icon_column`          | `ColumnName \| None`                                                     | Only valid if children are of type `Table`. The column of values to map to icons.                                                                                                                                                                                                                                             |
+| `action_buttons`       | `ActionButtonElement \| ActionGroupElement \| ActionMenuElement \| None` | Only valid if any `ListViewItem` `children` do not already have embedded buttons. The action buttons to render for all elements within the list view. The `on_*` event handlers within the passed object will be modified so that the second argument is the `Key` for the `list_view` item that the buttons are embedded in. |
+| `default_selected_keys`| `Selection \| None`                                                      | The initial selected keys in the collection (uncontrolled).                                                                                                                                                                                                                                                                   |
+| `selected_keys`        | `Selection \| None`                                                      | The currently selected keys in the collection (controlled).                                                                                                                                                                                                                                                                   |
+| `render_empty_state`   | `Element \| None`                                                        | Sets what the `list_view` should render when there is no content to display.                                                                                                                                                                                                                                                  |
+| `on_selection_change`  | `Callable[[Selection], None] \| None`                                    | Handler that is called when the selections changes.                                                                                                                                                                                                                                                                           |
+| `on_change`            | `Callable[[Selection], None] \| None`                                    | Alias of `on_selection_change`. Handler that is called when the selections changes.                                                                                                                                                                                                                                           |
+| `**props`              | `Any`                                                                    | Any other [Picker](https://react-spectrum.adobe.com/react-spectrum/Picker.html) prop, with the exception of `items`, `dragAndDropHooks`, and `onLoadMore`.                                                                                                                                                                    |
+
+ 
+```py
+import deephaven.ui as ui
+
+# simple list_view that takes ui.items and is uncontrolled
+list_view1 = ui.list_view(
+    ui.item("Option 1"),
+    ui.item("Option 2"),
+    ui.item("Option 3"),
+    ui.item("Option 4"),
+    default_selected_keys=["Option 2", "Option 3"]
+)
+
+# simple list_view that takes list view items directly and is controlled
+options, set_options = ui.use_state(["Option 1", "Option 2"])
+
+list_view2 = ui.list_view(
+    "Option 1",
+    "Option 2",
+    "Option 3",
+    "Option 4",
+    selected_keys=option,
+    on_selection_change=set_option
+)
+
+# Buttons can be embedded in the list view. Note list_key is added to the on_press handler, but is not required.
+on_button_action = lambda e, key: print(f"Event {e} was emitted for list item {key}")
+button = ui.action_button("Current Color", on_press=on_button_action)
+
+list_view3 = ui.list_view(
+    "Option 1",
+    "Option 2",
+    "Option 3",
+    "Option 4",
+    action_buttons=button,
+)
+
+from deephaven import empty_table
+
+table1 = empty_table(4).update_view("data=i")
+
+# data hooks can be used to create a list view from a table
+# this should be avoided as it is not as performant as just passing in the table directly
+options = ui.use_column_data(table1)
+
+list_view4 = ui.list_view(
+    children=options
+)
+
+# instead, pass in the table directly
+list_view5 = ui.list_view(
+    table1
+)
+
+from deephaven import new_table
+from deephaven.column import string_col, int_col
+
+color_table = new_table([
+    string_col("Sections", ["Interesting Colors", 'Interesting Colors', "Other Colors"]),
+    string_col("SectionNames", ["Favorites", 'Favorites', "Other"]),
+    int_col("Keys", ["salmon", "lemonchiffon", "black"]),
+    string_col("Labels", ["Salmon", "Lemon Chiffon", "Black"]),
+    string_col("Descriptions", ["An interesting color", "Another interesting color", "A color"]),
+    string_col("Icons", ["Amusementpark", "Teapot", "Sentiment Negative"])
+])
+
+colors, set_colors = ui.use_state(["salmon", "lemonchiffon"])
+
+# this will create a controlled list_view with color_table
+list_view6 = ui.list_view(
+    color_table,
+    key_column="Keys",
+    label_column="Labels",
+    description_column="Descriptions",
+    icon_column="Icons",
+    title_column="SectionNames",
+    selected_keys=colors,
+    on_selection_change=set_colors
 )
 ```
 
@@ -1703,6 +1823,10 @@ TransformedData = Any
 Stringable = str | int | float | bool
 PickerItem = Stringable | ItemElement
 Key = Stringable
+Selection = Sequence[Key]
+ListViewItem = Stringable | ItemElement
+DropOperation = Literal["MOVE", "COPY"]
+DragType = str
 
 T = TypeVar("T")
 Combination: TypeAlias = T | set[T] | Sequence[T]


### PR DESCRIPTION
Adds spec for `list_view`

There are two major additions on top of what has been discussed in the picker spec.

1. Instead of just titles, it seems like `PartitionedTable` can be supported through created section items that themselves have children. These are just "normal" items, but would have (Navigation icons)[https://react-spectrum.adobe.com/react-spectrum/ListView.html#complex-items] that allow collapsing.
2. I see it as an "oversight" to some extent that there's no simple way for embedded buttons to access their parent's keys easily, as far as I can tell. I suppose it's simple enough to bind item keys to button events if you're doing this in React, but I think we'll want a way to do that easily, especially with tables, because it doesn't make sense to pass a button for each item in a ticking table. The least intrusive method here is returning extra args for the item key and section key. that a button is embedded in that can be ignored (using the changes implemented in #271).