### PR TITLE
docs: Fix the demo script

### DIFF
--- a/docker/data/storage/notebooks/DEMO.md
+++ b/docker/data/storage/notebooks/DEMO.md
@@ -97,7 +97,7 @@ def picker():
     )
 
 
-p = picker()
+result = picker()
 ```
 
 ## Using Tables
@@ -226,7 +226,7 @@ def hist_demo(source, column):
             x=column,
             nbins=bin_count,
         ),
-        {bin_count, hist_range, source, column},
+        [bin_count, hist_range, source, column],
     )
 
     return [
@@ -322,7 +322,7 @@ def table_tabs(source):
     return ui.tabs(
         ui.tab_list(
             ui.item("Unfiltered", key="Unfiltered"),
-            ui.item(ui.icon("vsGithubAlt"), "CAT", key="CAT"),
+            ui.item(ui.icon("vsGithubAlt"), ui.text("CAT"), key="CAT"),
             ui.item("DOG", key="DOG"),
         ),
         ui.tab_panels(

--- a/docker/data/storage/notebooks/DEMO.md
+++ b/docker/data/storage/notebooks/DEMO.md
@@ -197,7 +197,7 @@ def stock_table_input(source, default_sym="", default_exchange=""):
     return [
         ui.panel(
             # Add a callback for when user double clicks a row in the table
-            ui.table(t1).on_row_double_press(handle_row_double_press),
+            ui.table(t1, on_row_double_press=handle_row_double_press),
             title="Stock Row Press",
         ),
         ui.panel(t2, title="Stock Filtered Table"),

--- a/plugins/ui/examples/README.md
+++ b/plugins/ui/examples/README.md
@@ -758,7 +758,7 @@ def stock_table_input(source, default_sym="", default_exchange=""):
 
     return [
         ui.panel(
-            ui.table(t1).on_row_double_press(handle_row_double_press),
+            ui.table(t1, on_row_double_press=handle_row_double_press),
             title="Stock Table Input",
         ),
         ui.panel(t2, title="Stock Filtered Table"),


### PR DESCRIPTION
- Some results were being assigned to a new variable instead of replacing the existing `result` panel
- Add explicit wrapping around text with icon in ui.item case. Created ticket to automatically wrap raw nodes: https://github.com/deephaven/deephaven-plugins/issues/353
- Fix hist_demo. You cannot pass non-hashable objects into a set; in this case we were passing in a dict to the set of dependencies. Need to use an array instead
- Ran through Demo script and made sure there were no errors