### PR TITLE
build: Fix build script to commit all files post version bump

### DIFF
--- a/cog.toml
+++ b/cog.toml
@@ -29,7 +29,7 @@ post_package_bump_hooks = [
     "../../tools/extract_changelog.sh CHANGELOG.md > ../../releases/GITHUB_CHANGELOG-{{package}}.md",
     # update the version number to have a `dev0` suffix
     "../../tools/update_version.sh {{package}} {{version}} --dev",
-    "git commit -m 'chore(version): update {{package}} version to {{version}}'",
+    "git commit --all --message 'chore(version): update {{package}} version to {{version}}'",
     # push the tag and the commits to main 
     "git push origin {{package}}-v{{version}}",
     "git push origin main",

--- a/tools/update_version.sh
+++ b/tools/update_version.sh
@@ -107,19 +107,12 @@ function update_file() {
         else
             sed -e "s/${prefix}.*/${expected}/g" -i "$ROOT_DIR/plugins/$file"
         fi
-        git add "$ROOT_DIR/plugins/$file"
     fi
 }
 
 extra=
 [ "$dev" = true ] && extra=".dev0"
 case "$package" in
-        auth-keycloak)
-            update_file auth-keycloak/src/js/package.json '"version": "' '",'
-            ;;
-        dashboard-object-viewer)
-            update_file dashboard-object-viewer/src/js/package.json '"version": "' '",'
-            ;;
         json)
             update_file json/src/deephaven/plugin/json/__init__.py '__version__ = "' '"' "$extra"
             ;;
@@ -131,9 +124,6 @@ case "$package" in
             ;;
         plotly-express)
             update_file plotly-express/setup.cfg 'version = ' '' "$extra"
-            ;;
-        table-example)
-            update_file table-example/src/js/package.json '"version": "' '",'
             ;;
         ui)
             update_file ui/setup.cfg 'version = ' '' "$extra"
@@ -155,7 +145,7 @@ esac
 npm_version="${version}"
 [ "$dev" = true ] && npm_version="${version}-dev0"
 case "$package" in
-    matplotlib | plotly | plotly-express | ui)
+    auth-keycloak | dashboard-object-viewer | matplotlib | plotly | plotly-express | table-example | ui)
         # The working directory is already `plugins/<package-name>`, so we just specify workspace as `src/js` and it does the right thing
         npm version "$npm_version" --workspace=src/js
         ;;

--- a/tools/update_version.sh
+++ b/tools/update_version.sh
@@ -134,6 +134,9 @@ case "$package" in
         packaging)
             update_file packaging/setup.cfg 'version = ' '' "$extra"
             ;;
+        auth-keycloak | dashboard-object-viewer | table-example)
+            # Packages that don't have any Python to publish, just ignore
+            ;;
         *)
         {
             log_error "Unhandled plugin $package.  You will need to add wiring in $SCRIPT_NAME"
@@ -149,6 +152,14 @@ case "$package" in
         # The working directory is already `plugins/<package-name>`, so we just specify workspace as `src/js` and it does the right thing
         npm version "$npm_version" --workspace=src/js
         ;;
+    json | packaging | utilities)
+        # Packages that don't have any JS to publish, just ignore
+        ;;
+    *)
+    {
+        log_error "Unhandled JS plugin $package.  You will need to add JS wiring in $SCRIPT_NAME"
+        exit 90
+    }
 esac
 
 log_info "Done updating $package version to $version${extra}"


### PR DESCRIPTION
- package.json files weren't being included in the commit, just commit everything
- We can assume we're already at a clean slate in the post_package_bump
- Move other JS plugins to use `npm` for the bump