### PR TITLE
fix: Deephaven express chart title does not update dynamically

### DIFF
--- a/plugins/plotly-express/src/js/src/PlotlyExpressChart.tsx
+++ b/plugins/plotly-express/src/js/src/PlotlyExpressChart.tsx
@@ -14,6 +14,7 @@ export function PlotlyExpressChart(
   const { fetch } = props;
   const containerRef = useRef<HTMLDivElement>(null);
   const [model, setModel] = useState<PlotlyExpressChartModel>();
+  const [widgetRevision, setWidgetRevision] = useState(0); // Used to force a clean chart state on widget change
 
   useEffect(() => {
     let cancelled = false;
@@ -21,6 +22,7 @@ export function PlotlyExpressChart(
       const widgetData = await fetch();
       if (!cancelled) {
         setModel(new PlotlyExpressChartModel(dh, widgetData, fetch));
+        setWidgetRevision(r => r + 1);
       }
     }
 
@@ -37,6 +39,7 @@ export function PlotlyExpressChart(
     <Chart
       // eslint-disable-next-line react/jsx-props-no-spreading, @typescript-eslint/ban-ts-comment
       // @ts-ignore
+      key={widgetRevision}
       containerRef={containerRef}
       model={model}
       Plotly={Plotly}

--- a/plugins/plotly-express/src/js/src/PlotlyExpressChartPanel.tsx
+++ b/plugins/plotly-express/src/js/src/PlotlyExpressChartPanel.tsx
@@ -12,13 +12,11 @@ export function PlotlyExpressChartPanel(props: WidgetPanelProps<Widget>) {
   const { fetch, metadata = {}, ...rest } = props;
   const containerRef = useRef<HTMLDivElement>(null);
   const [model, setModel] = useState<PlotlyExpressChartModel>();
-  const [widgetRevision, setWidgetRevision] = useState(0); // Used to force a clean chart state on widget change
 
   const makeModel = useCallback(async () => {
     const widgetData = await fetch();
     const m = new PlotlyExpressChartModel(dh, widgetData, fetch);
     setModel(m);
-    setWidgetRevision(r => r + 1);
     return m;
   }, [dh, fetch]);
 
@@ -28,7 +26,6 @@ export function PlotlyExpressChartPanel(props: WidgetPanelProps<Widget>) {
     <ChartPanel
       // eslint-disable-next-line react/jsx-props-no-spreading
       {...(rest as ChartPanelProps)}
-      key={widgetRevision}
       containerRef={containerRef}
       makeModel={makeModel}
       Plotly={Plotly}

--- a/plugins/plotly-express/src/js/src/PlotlyExpressChartPanel.tsx
+++ b/plugins/plotly-express/src/js/src/PlotlyExpressChartPanel.tsx
@@ -12,11 +12,13 @@ export function PlotlyExpressChartPanel(props: WidgetPanelProps<Widget>) {
   const { fetch, metadata = {}, ...rest } = props;
   const containerRef = useRef<HTMLDivElement>(null);
   const [model, setModel] = useState<PlotlyExpressChartModel>();
+  const [widgetRevision, setWidgetRevision] = useState(0); // Used to force a clean chart state on widget change
 
   const makeModel = useCallback(async () => {
     const widgetData = await fetch();
     const m = new PlotlyExpressChartModel(dh, widgetData, fetch);
     setModel(m);
+    setWidgetRevision(r => r + 1);
     return m;
   }, [dh, fetch]);
 
@@ -26,6 +28,7 @@ export function PlotlyExpressChartPanel(props: WidgetPanelProps<Widget>) {
     <ChartPanel
       // eslint-disable-next-line react/jsx-props-no-spreading
       {...(rest as ChartPanelProps)}
+      key={widgetRevision}
       containerRef={containerRef}
       makeModel={makeModel}
       Plotly={Plotly}


### PR DESCRIPTION
Fixes #377

The issue was the widget changing and thus the model changing, but the `Chart` component was not resetting. `Chart` puts the model layout into its state, so it wasn't updating when the model changed. This could also be fixed in `Chart`, but this is the simplest fix for the dh.ui scenario in the ticket.

This does not fix a scenario where deephaven-express sends a new title (no widget change) as part of an update as `Chart` will still keep its layout over the model's layout in that case. AFAIK there's currently no way to do this though