### PR TITLE
fix: Ensure title is added to default figure

### DIFF
--- a/plugins/plotly-express/src/deephaven/plot/express/plots/PartitionManager.py
+++ b/plugins/plotly-express/src/deephaven/plot/express/plots/PartitionManager.py
@@ -603,7 +603,9 @@ class PartitionManager:
         # this is very hacky but it's needed to prevent errors when
         # there are no partitions until a better solution can be done
         # also need the px template to be set
-        default_fig = px.scatter(x=[0], y=[0])
+        # the title can also be set here as it will never change
+        title = self.args.get("title")
+        default_fig = px.scatter(x=[0], y=[0], title=title)
         default_fig.update_traces(x=[], y=[])
         return DeephavenFigure(default_fig)
 

--- a/plugins/plotly-express/test/deephaven/plot/express/plots/test_layout.py
+++ b/plugins/plotly-express/test/deephaven/plot/express/plots/test_layout.py
@@ -1,0 +1,26 @@
+import unittest
+
+from ..BaseTest import BaseTestCase
+
+
+class ScatterTestCase(BaseTestCase):
+    def setUp(self) -> None:
+        from deephaven import empty_table
+
+        self.source = empty_table(0).update(["x=i", "y=i*Math.random()*i", "z=i%5"])
+
+    def test_empty_title(self):
+        import src.deephaven.plot.express as dx
+
+        chart = dx.line(
+            self.source, x="x", y="y", by=["z"], title="Hello World0"
+        ).to_dict(self.exporter)
+        plotly, deephaven = chart["plotly"], chart["deephaven"]
+
+        expected_title = {"text": "Hello World0"}
+
+        self.assertEqual(plotly["layout"]["title"], expected_title)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #147 

This was because the title was not being added to the default figure, but it should be as it is assumed to never change.

Tested with the code in the issue as well
```
from deephaven import empty_table, merge, time_table
from deephaven.plot import express as dx

t0 = empty_table(0).update(["x=i", "y=i*Math.random()*i", "z=i%5"])
t1 = empty_table(10).update(["x=i", "y=i*Math.random()*i", "z=i%5"])
t2 = time_table("PT1s").update(["x=i", "y=i*Math.random()*i", "z=i%5"]).drop_columns(["Timestamp"])
t3 = t2.where("x > 1")
p0 = dx.line(t0, x="x", y="y", by=["z"], title="Hello World0")
p1 = dx.line(t1, x="x", y="y", by=["z"], title="Hello World1")
p2 = dx.line(t2, x="x", y="y", by=["z"], title="Hello World2")
p3 = dx.line(t3, x="x", y="y", by=["z"], title="Hello World3")
```