### PR TITLE
feat: only require typing_extension for python < 3.11

### DIFF
--- a/plugins/ui/setup.cfg
+++ b/plugins/ui/setup.cfg
@@ -29,7 +29,7 @@ install_requires =
     deephaven-plugin>=0.6.0
     json-rpc
     deephaven-plugin-utilities
-    typing_extensions
+    typing_extensions;python_version<'3.11'
 include_package_data = True
 
 [options.packages.find]


### PR DESCRIPTION
Python version >= 3.11 shouldn't need to install `typing_extensions`. The only current usage we have is in UITable.py.