### PR TITLE
build: Don't bump JS packages for the dev builds

### DIFF
--- a/cog.toml
+++ b/cog.toml
@@ -29,7 +29,7 @@ post_package_bump_hooks = [
     "../../tools/extract_changelog.sh CHANGELOG.md > ../../releases/GITHUB_CHANGELOG-{{package}}.md",
     # update the version number to have a `dev0` suffix
     "../../tools/update_version.sh {{package}} {{version}} --dev",
-    "git commit --all --message 'chore(version): update {{package}} version to {{version}}'",
+    "git commit --all --message 'chore(version): update {{package}} version to {{version}}.dev0'",
     # push the tag and the commits to main 
     "git push origin {{package}}-v{{version}}",
     "git push origin main",

--- a/tools/update_version.sh
+++ b/tools/update_version.sh
@@ -128,20 +128,21 @@ esac
 
 # We still need to bump these JS packages for Enterprise legacy reasons, even though they're packaged with Python
 npm_version="${version}"
-[ "$dev" = true ] && npm_version="${version}-dev0"
-case "$package" in
-    auth-keycloak | dashboard-object-viewer | matplotlib | plotly | plotly-express | table-example | ui)
-        # The working directory is already `plugins/<package-name>`, so we just specify workspace as `src/js` and it does the right thing
-        npm version "$npm_version" --workspace=src/js
-        ;;
-    json | packaging | utilities)
-        # Packages that don't have any JS to publish, just ignore
-        ;;
-    *)
-    {
-        log_error "Unhandled JS plugin $package.  You will need to add JS wiring in $SCRIPT_NAME"
-        exit 90
-    }
-esac
+if [ ! "$dev" = true ]; then
+    case "$package" in
+        auth-keycloak | dashboard-object-viewer | matplotlib | plotly | plotly-express | table-example | ui)
+            # The working directory is already `plugins/<package-name>`, so we just specify workspace as `src/js` and it does the right thing
+            npm version "$npm_version" --workspace=src/js
+            ;;
+        json | packaging | utilities)
+            # Packages that don't have any JS to publish, just ignore
+            ;;
+        *)
+        {
+            log_error "Unhandled JS plugin $package.  You will need to add JS wiring in $SCRIPT_NAME"
+            exit 90
+        }
+    esac
+fi
 
 log_info "Done updating $package version to $version${extra}"

--- a/tools/update_version.sh
+++ b/tools/update_version.sh
@@ -128,7 +128,7 @@ esac
 
 # We still need to bump these JS packages for Enterprise legacy reasons, even though they're packaged with Python
 npm_version="${version}"
-if [ ! "$dev" = true ]; then
+if [ "$dev" != true ]; then
     case "$package" in
         auth-keycloak | dashboard-object-viewer | matplotlib | plotly | plotly-express | table-example | ui)
             # The working directory is already `plugins/<package-name>`, so we just specify workspace as `src/js` and it does the right thing


### PR DESCRIPTION
- We only want to bump python packages for that, since it's common to build a wheel and then install it. With JS, the flow isn't like that
- Don't bother bumping the npm package to a dev build
