### PR TITLE
fix: Fix conditional use_effect in use_table_listener

### DIFF
--- a/plugins/ui/src/deephaven/ui/hooks/use_table_data.py
+++ b/plugins/ui/src/deephaven/ui/hooks/use_table_data.py
@@ -142,6 +142,10 @@ def use_table_data(
 
     table_updated = lambda: _set_new_data(table, sentinel, set_data, set_is_sentinel)
 
+    # call table_updated in the case of new table or sentinel
+    ui.use_effect(table_updated, [table, sentinel])
+
+    # call table_updated every time the table updates
     ui.use_table_listener(
         table, partial(_on_update, ctx, table_updated, executor_name), []
     )

--- a/plugins/ui/src/deephaven/ui/hooks/use_table_listener.py
+++ b/plugins/ui/src/deephaven/ui/hooks/use_table_listener.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from functools import partial
-from typing import Any, Callable, Sequence
+from typing import Callable
 
 from deephaven.table import Table
 from deephaven.table_listener import listen, TableUpdate, TableListener

--- a/plugins/ui/src/deephaven/ui/hooks/use_table_listener.py
+++ b/plugins/ui/src/deephaven/ui/hooks/use_table_listener.py
@@ -86,10 +86,6 @@ def use_table_listener(
         replay_lock: The lock type used during replay, default is ‘shared’, can also be ‘exclusive’.
     """
 
-    if not table.is_refreshing and not do_replay:
-        # if the table is not refreshing, and is not replaying, there is nothing to listen to
-        return
-
     def start_listener() -> Callable[[], None]:
         """
         Start the listener. Returns a function that can be called to stop the listener by the use_effect hook.
@@ -97,6 +93,9 @@ def use_table_listener(
         Returns:
             A function that can be called to stop the listener by the use_effect hook.
         """
+        if not table.is_refreshing and not do_replay:
+            return lambda: None
+
         handle = listen(
             table,
             wrap_listener(listener),


### PR DESCRIPTION
fixes #384 

Moves the refreshing table check to ensure the `use_effect` is always called.
Also added a `use_effect` to `use_table_data` to ensure that when a table is swapped it updates the resulting data

Here is an example of flipping between ticking and static tables

```
import deephaven.ui as ui
from deephaven.table import Table
from deephaven import time_table, empty_table

empty_t = empty_table(0)
time_t = time_table("PT1S").tail(1)

@ui.component
def test_component():
    empty, set_empty = ui.use_state(True)
    val = ui.use_table_data(empty_t if empty else time_t)
    button = ui.action_button(str(empty), on_press=lambda: set_empty(not empty))

    return [button, str(val)]

data = test_component()
```