### PR TITLE
fix: buttons not working due to extra prop

### DIFF
--- a/plugins/ui/src/js/src/elements/spectrum/Button.tsx
+++ b/plugins/ui/src/js/src/elements/spectrum/Button.tsx
@@ -6,7 +6,6 @@ import {
 import { SerializedButtonEventProps, useButtonProps } from './useButtonProps';
 
 function Button(
-  variant: SpectrumButtonProps['variant'],
   props: SpectrumButtonProps & SerializedButtonEventProps
 ): JSX.Element {
   const buttonProps = useButtonProps(props);


### PR DESCRIPTION
resolves #419

Broken by #416, extra prop slipped in while adding types and broke things. Removed the uncessary prop.