### PR TITLE
fix: add on_change to toggle_button

### DIFF
--- a/plugins/ui/src/deephaven/ui/components/spectrum/toggle_button.py
+++ b/plugins/ui/src/deephaven/ui/components/spectrum/toggle_button.py
@@ -31,6 +31,7 @@ def toggle_button(
     is_quiet: bool | None = None,
     static_color: StaticColor | None = None,
     type: ButtonType = "button",
+    on_change: Callable[[bool], None] | None = None,
     on_press: PressEventCallable | None = None,
     on_press_start: PressEventCallable | None = None,
     on_press_end: PressEventCallable | None = None,
@@ -103,6 +104,7 @@ def toggle_button(
         is_quiet: Whether the button should be quiet.
         static_color: The static color style to apply. Useful when the button appears over a color background.
         type: The type of button to render. (default: "button")
+        on_change: Handler that is called when the element's selection state changes.
         on_press: Function called when the button is pressed.
         on_press_start: Function called when the button is pressed.
         on_press_end: Function called when a press interaction ends, either over the target or when the pointer leaves the target.


### PR DESCRIPTION
Fixes #420

The code in the issue works now
```
import deephaven.ui as ui
from deephaven.ui import use_memo, use_state
from deephaven import agg
import deephaven.plot.express as dx

stocks = dx.data.stocks()


def get_by_filter(**byargs):
    """
    Gets a by filter where the arguments are all args passed in where the value is true.
    e.g.
    get_by_filter(sym=True, exchange=False) == ["sym"]
    get_by_filter(exchange=False) == []
    get_by_filter(sym=True, exchange=True) == ["sym", "exchange"]

    """
    return [k for k in byargs if byargs[k]]


@ui.component
def stock_table(source):
    is_sym, set_is_sym = ui.use_state(False)
    is_exchange, set_is_exchange = ui.use_state(False)
    highlight, set_highlight = ui.use_state("")
    aggs, set_aggs = ui.use_state(agg.avg(cols=["size", "price", "dollars"]))

    by = get_by_filter(sym=is_sym, exchange=is_exchange)

    formatted_table = ui.use_memo(
        lambda: source.format_row_where(f"sym=`{highlight}`", "LEMONCHIFFON"),
        [source, highlight],
    )
    rolled_table = ui.use_memo(
        lambda: (
            formatted_table
            if len(by) == 0
            else formatted_table.rollup(aggs=aggs, by=by)
        ),
        [formatted_table, aggs, by],
    )

    return ui.flex(
        ui.flex(
            ui.toggle_button(ui.icon("vsSymbolMisc"), "By Sym", on_change=set_is_sym),
            ui.toggle_button(
                ui.icon("vsBell"), "By Exchange", on_change=set_is_exchange
            ),
            (
                ui.fragment(
                    ui.text_field(
                        label="Highlight Sym",
                        label_position="side",
                        value=highlight,
                        on_change=set_highlight,
                    ),
                    ui.contextual_help(
                        ui.heading("Highlight Sym"),
                        ui.content("Enter a sym you would like highlighted."),
                    ),
                )
                if not is_sym and not is_exchange
                else None
            ),
            align_items="center",
            gap="size-100",
            margin="size-100",
            margin_bottom="0",
        ),
        rolled_table,
        direction="column",
        flex_grow=1,
    )


st = stock_table(stocks)
```