### PR TITLE
fix: Memoize use_table_data listener

### DIFF
--- a/plugins/ui/src/deephaven/ui/hooks/use_table_data.py
+++ b/plugins/ui/src/deephaven/ui/hooks/use_table_data.py
@@ -141,15 +141,15 @@ def use_table_data(
         executor_name = "concurrent"
 
     # memoize table_updated (and listener) so that they don't cause a start and stop of the listener
-    table_updated = ui.use_memo(
-        lambda: lambda: _set_new_data(table, sentinel, set_data, set_is_sentinel),
+    table_updated = ui.use_callback(
+        lambda: _set_new_data(table, sentinel, set_data, set_is_sentinel),
         [table, sentinel],
     )
 
     # call table_updated in the case of new table or sentinel
     ui.use_effect(table_updated, [table, sentinel])
-    listener = ui.use_memo(
-        lambda: partial(_on_update, ctx, table_updated, executor_name),
+    listener = ui.use_callback(
+        partial(_on_update, ctx, table_updated, executor_name),
         [table_updated, executor_name, ctx],
     )
 

--- a/plugins/ui/src/deephaven/ui/hooks/use_table_data.py
+++ b/plugins/ui/src/deephaven/ui/hooks/use_table_data.py
@@ -141,15 +141,15 @@ def use_table_data(
         executor_name = "concurrent"
 
     # memoize table_updated (and listener) so that they don't cause a start and stop of the listener
-    table_updated = ui.use_callback(
-        lambda: _set_new_data(table, sentinel, set_data, set_is_sentinel),
+    table_updated = ui.use_memo(
+        lambda: lambda: _set_new_data(table, sentinel, set_data, set_is_sentinel),
         [table, sentinel],
     )
 
     # call table_updated in the case of new table or sentinel
     ui.use_effect(table_updated, [table, sentinel])
-    listener = ui.use_callback(
-        partial(_on_update, ctx, table_updated, executor_name),
+    listener = ui.use_memo(
+        lambda: partial(_on_update, ctx, table_updated, executor_name),
         [table_updated, executor_name, ctx],
     )
 

--- a/plugins/ui/src/deephaven/ui/hooks/use_table_listener.py
+++ b/plugins/ui/src/deephaven/ui/hooks/use_table_listener.py
@@ -74,6 +74,8 @@ def use_table_listener(
 ) -> None:
     """
     Listen to a table and call a listener when the table updates.
+    If any dependencies change, the listener will be recreated.
+    In this case, updates may be missed if the table updates while the listener is being recreated.
 
     Args:
         table: The table to listen to.

--- a/plugins/ui/test/deephaven/ui/test_hooks.py
+++ b/plugins/ui/test/deephaven/ui/test_hooks.py
@@ -341,9 +341,7 @@ class HooksTest(BaseTestCase):
         queue.call_after_put(check_size)
 
         # call now in case the queue is (or was) already at the correct size
-        if check_size(queue):
-            queue.unregister_notify()
-            return
+        check_size(queue)
 
         if not event.wait(timeout=QUEUE_TIMEOUT):
             assert False, f"queue did not reach size {size}"


### PR DESCRIPTION
Because the listener function was not memoized in `use_table_data`, the `use_effect` within `use_table_listener` was getting called unnecessarily, which means in some cases table updates can be missed during the start and stop of the listener.

Added fix and caution message in `use_table_listener` for now.

It might be worthwhile making `use_table_listener` more robust in cases where arguments changed, but the table specifically did not. This is not trivial though.