### PR TITLE
ci: skip running e2e for docs only changes

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -5,10 +5,16 @@ on:
     branches:
       - main
       - 'release/**'
+    paths-ignore:
+      - '**/docs/**'
+      - '**.md'
   pull_request:
     branches:
       - main
       - 'release/**'
+    paths-ignore:
+      - '**/docs/**'
+      - '**.md'
 
 jobs:
   e2e-test:
@@ -21,7 +27,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run tests
-        run: "./tools/run_docker.sh e2e-tests"
+        run: './tools/run_docker.sh e2e-tests'
 
       - name: Upload Playwright report
         uses: actions/upload-artifact@v4
@@ -34,7 +40,7 @@ jobs:
       - name: Dump server logs
         if: failure()
         run: docker logs deephaven-plugins > /tmp/server-log.txt
-  
+
       - name: Upload server logs
         if: failure()
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Adds a  path-ignore for files within /docs folders and .md files anywhere