### PR TITLE
build: Update requirements to require a newer version of core

### DIFF
--- a/plugins/ui/setup.cfg
+++ b/plugins/ui/setup.cfg
@@ -25,7 +25,7 @@ package_dir=
     =src
 packages=find_namespace:
 install_requires =
-    deephaven-core>=0.31.0
+    deephaven-core>=0.34.1
     deephaven-plugin>=0.6.0
     json-rpc
     deephaven-plugin-utilities


### PR DESCRIPTION
- This version of deephaven-plugin-ui is not compatible with older versions of core, as some of the functionality is not in the web UI until 0.34.1
- Bump the minimum install_requires version to 0.34.1 in the setup.cfg
