### PR TITLE
feat: Add show_search and show_quick_filters to ui.table

### DIFF
--- a/plugins/ui/src/deephaven/ui/components/table.py
+++ b/plugins/ui/src/deephaven/ui/components/table.py
@@ -4,7 +4,9 @@ from deephaven.table import Table
 from ..elements import UITable
 from ..types import (
     CellPressCallback,
+    ColumnName,
     ColumnPressCallback,
+    QuickFilterExpression,
     RowPressCallback,
 )
 
@@ -18,6 +20,7 @@ def table(
     on_cell_double_press: CellPressCallback | None = None,
     on_column_press: ColumnPressCallback | None = None,
     on_column_double_press: ColumnPressCallback | None = None,
+    quick_filters: dict[ColumnName, QuickFilterExpression] | None = None,
     show_search: bool = False,
     show_quick_filters: bool = False,
 ) -> UITable:
@@ -43,6 +46,7 @@ def table(
         on_column_double_press: The callback function to run when a column is double clicked.
             The first parameter is the column name.
         show_search: Whether to show the search bar by default.
+        quick_filters: The quick filters to apply to the table. Dictionary of column name to filter value.
         show_quick_filters: Whether to show the quick filter bar by default.
     """
     props = locals()

--- a/plugins/ui/src/deephaven/ui/components/table.py
+++ b/plugins/ui/src/deephaven/ui/components/table.py
@@ -18,6 +18,8 @@ def table(
     on_cell_double_press: CellPressCallback | None = None,
     on_column_press: ColumnPressCallback | None = None,
     on_column_double_press: ColumnPressCallback | None = None,
+    show_search: bool = False,
+    show_quick_filters: bool = False,
 ) -> UITable:
     """
     Customization to how a table is displayed, how it behaves, and listen to UI events.
@@ -40,6 +42,8 @@ def table(
             The first parameter is the column name.
         on_column_double_press: The callback function to run when a column is double clicked.
             The first parameter is the column name.
+        show_search: Whether to show the search bar by default.
+        show_quick_filters: Whether to show the quick filter bar by default.
     """
     props = locals()
     del props["table"]

--- a/plugins/ui/src/deephaven/ui/elements/UITable.py
+++ b/plugins/ui/src/deephaven/ui/elements/UITable.py
@@ -489,7 +489,7 @@ class UITable(Element):
         Returns:
             A new UITable
         """
-        return self._with_dict_prop("filters", filter)
+        return self._with_dict_prop("quick_filters", filter)
 
     def selection_mode(self, mode: SelectionMode) -> "UITable":
         """

--- a/plugins/ui/src/js/src/elements/UITable.tsx
+++ b/plugins/ui/src/js/src/elements/UITable.tsx
@@ -25,11 +25,11 @@ function UITable({
   onColumnDoublePress,
   onRowPress,
   onRowDoublePress,
-  filters,
+  quickFilters,
   sorts,
   alwaysFetchColumns,
   table: exportedTable,
-  showSearchBar,
+  showSearch: showSearchBar,
   showQuickFilters,
 }: UITableProps): JSX.Element | null {
   const dh = useApi();
@@ -48,12 +48,16 @@ function UITable({
   }, [columns, utils, sorts]);
 
   const hydratedQuickFilters = useMemo(() => {
-    if (filters !== undefined && model !== undefined && columns !== undefined) {
-      log.debug('Hydrating filters', filters);
+    if (
+      quickFilters !== undefined &&
+      model !== undefined &&
+      columns !== undefined
+    ) {
+      log.debug('Hydrating filters', quickFilters);
 
       const dehydratedQuickFilters: DehydratedQuickFilter[] = [];
 
-      Object.entries(filters).forEach(([columnName, filter]) => {
+      Object.entries(quickFilters).forEach(([columnName, filter]) => {
         const columnIndex = model.getColumnIndexByName(columnName);
         if (columnIndex !== undefined) {
           dehydratedQuickFilters.push([columnIndex, { text: filter }]);
@@ -63,7 +67,7 @@ function UITable({
       return utils.hydrateQuickFilters(columns, dehydratedQuickFilters);
     }
     return undefined;
-  }, [filters, model, columns, utils]);
+  }, [quickFilters, model, columns, utils]);
 
   // Just load the object on mount
   useEffect(() => {

--- a/plugins/ui/src/js/src/elements/UITable.tsx
+++ b/plugins/ui/src/js/src/elements/UITable.tsx
@@ -25,11 +25,12 @@ function UITable({
   onColumnDoublePress,
   onRowPress,
   onRowDoublePress,
-  canSearch,
   filters,
   sorts,
   alwaysFetchColumns,
   table: exportedTable,
+  showSearchBar,
+  showQuickFilters,
 }: UITableProps): JSX.Element | null {
   const dh = useApi();
   const [model, setModel] = useState<IrisGridModel>();
@@ -114,15 +115,17 @@ function UITable({
     () => ({
       mouseHandlers,
       alwaysFetchColumns,
-      showSearchBar: canSearch,
+      showSearchBar,
       sorts: hydratedSorts,
       quickFilters: hydratedQuickFilters,
+      isFilterBarShown: showQuickFilters,
       settings,
     }),
     [
       mouseHandlers,
       alwaysFetchColumns,
-      canSearch,
+      showSearchBar,
+      showQuickFilters,
       hydratedSorts,
       hydratedQuickFilters,
       settings,

--- a/plugins/ui/src/js/src/elements/UITableUtils.tsx
+++ b/plugins/ui/src/js/src/elements/UITableUtils.tsx
@@ -30,9 +30,9 @@ export interface UITableProps {
   onColumnPress?: (columnName: ColumnName) => void;
   onColumnDoublePress?: (columnName: ColumnName) => void;
   alwaysFetchColumns?: string[];
-  filters?: Record<string, string>;
+  quickFilters?: Record<string, string>;
   sorts?: DehydratedSort[];
-  showSearchBar?: boolean;
+  showSearch?: boolean;
   showQuickFilters?: boolean;
   [key: string]: unknown;
 }

--- a/plugins/ui/src/js/src/elements/UITableUtils.tsx
+++ b/plugins/ui/src/js/src/elements/UITableUtils.tsx
@@ -30,9 +30,10 @@ export interface UITableProps {
   onColumnPress?: (columnName: ColumnName) => void;
   onColumnDoublePress?: (columnName: ColumnName) => void;
   alwaysFetchColumns?: string[];
-  canSearch?: boolean;
   filters?: Record<string, string>;
   sorts?: DehydratedSort[];
+  showSearchBar?: boolean;
+  showQuickFilters?: boolean;
   [key: string]: unknown;
 }
 


### PR DESCRIPTION
Fixes #443, Fixes #444. Also fixes some inconsistencies w/ the fluent interface and made sure both APIs align with the design doc.

It's unclear to me from the doc if these are props we want in the fluent interface. We said it supports that for some functionality, but did not clarify which. We might want to consider making a public `with_props` (we have a `_with_prop` right now)

```py
from deephaven import empty_table
import deephaven.ui as ui

t = empty_table(1000).update("X=ii")

ui_table = ui.table(t, quick_filters={"X": ">50", "Y": "=20"}, show_quick_filters=True)
ui_table_2 = ui_table.quick_filter({"X": "<=50"})
ui_with_search = ui.table(t, show_search=True)
ui_with_search_and_filter = ui.table(t, show_search=True, show_quick_filters=True)
```