### PR TITLE
docs: Update some information about Matplotlib

### DIFF
--- a/plugins/matplotlib/README.md
+++ b/plugins/matplotlib/README.md
@@ -1,6 +1,6 @@
-# Deephaven Plugin for matplotlib
+# Deephaven Plugin for Matplotlib
 
-The Deephaven Plugin for matplotlib. Allows for opening matplotlib plots in a Deephaven environment. Any matplotlib plot
+The Deephaven Plugin for Matplotlib. Allows for opening Matplotlib plots in a Deephaven environment. Any Matplotlib plot
 should be viewable by default. For example:
 
 ```python
@@ -15,7 +15,7 @@ You can also use `TableAnimation`, which allows updating a plot whenever a Deeph
 
 ## `TableAnimation` Usage
 
-`TableAnimation` is a matplotlib `Animation` that is driven by updates in a Deephaven Table. Every time the table that
+`TableAnimation` is a Matplotlib `Animation` that is driven by updates in a Deephaven Table. Every time the table that
 is being listened to updates, the provided function will run again.
 
 ### Line Plot

--- a/plugins/matplotlib/src/js/package.json
+++ b/plugins/matplotlib/src/js/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@deephaven/js-plugin-matplotlib",
   "version": "0.4.0",
-  "description": "Deephaven matplotlib plugin",
+  "description": "Deephaven Matplotlib plugin",
   "keywords": [
     "Deephaven",
     "plugin",
@@ -13,12 +13,13 @@
   "main": "dist/index.js",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/deephaven/web-client-ui"
+    "url": "git+https://github.com/deephaven/deephaven-plugins",
+    "directory": "plugins/matplotlib"
   },
   "bugs": {
-    "url": "https://github.com/deephaven/web-client-ui/issues"
+    "url": "https://github.com/deephaven/deephaven-plugins/issues"
   },
-  "homepage": "https://github.com/deephaven/web-client-ui",
+  "homepage": "https://github.com/deephaven/deephaven-plugins/tree/main/plugins/matplotlib",
   "scripts": {
     "start": "vite build --watch",
     "build": "vite build",


### PR DESCRIPTION
- Fix the repository links in the package.json
- Update casing of matplotlib to Matplotlib in README (that's how it is on the matplotlib site)
