### PR TITLE
build: Require deephaven-core>=0.34.0 for plotly-express

### DIFF
--- a/plugins/plotly-express/setup.cfg
+++ b/plugins/plotly-express/setup.cfg
@@ -25,6 +25,7 @@ package_dir=
     =src
 packages=find_namespace:
 install_requires =
+    deephaven-core>=0.34.0
     deephaven-plugin>=0.6.0
     plotly
     deephaven-plugin-utilities


### PR DESCRIPTION
- Needs the runChartDownsample function exposed, which was pushed with PR https://github.com/deephaven/deephaven-core/pull/5409 and in deephaven-core v0.34.0
