### PR TITLE
docs: Demo used marginX which doesn't exist

### DIFF
--- a/docker/data/storage/notebooks/DEMO.md
+++ b/docker/data/storage/notebooks/DEMO.md
@@ -166,8 +166,6 @@ def filterable_plot(source):
             on_change=set_value,
             label="Sym",
             label_position="side",
-            marginX=10,
-            marginTop=10,
         ),
         dx.line(t, x="timestamp", y="price", by=["exchange"]),
     ]


### PR DESCRIPTION
- `marginX` is not a valid prop and was throwing an error
- No need to use it, since the new styling looks good without explicitly setting a margin
