### PR TITLE
fix: Added optional dependencies to root package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,18 @@
         "nx": "15.9.2",
         "prettier": "3.0.0",
         "vite": "~4.1.4"
+      },
+      "optionalDependencies": {
+        "@nrwl/nx-darwin-arm64": "15.9.2",
+        "@nrwl/nx-darwin-x64": "15.9.2",
+        "@nrwl/nx-linux-arm-gnueabihf": "15.9.2",
+        "@nrwl/nx-linux-arm64-gnu": "15.9.2",
+        "@nrwl/nx-linux-arm64-musl": "15.9.2",
+        "@nrwl/nx-linux-x64-gnu": "15.9.2",
+        "@nrwl/nx-linux-x64-musl": "15.9.2",
+        "@nrwl/nx-win32-arm64-msvc": "15.9.2",
+        "@nrwl/nx-win32-x64-msvc": "15.9.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.9.6"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -6118,12 +6130,86 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/@nrwl/nx-darwin-arm64": {
+      "version": "15.9.2",
+      "resolved": "https://registry.npmjs.org/@nrwl/nx-darwin-arm64/-/nx-darwin-arm64-15.9.2.tgz",
+      "integrity": "sha512-Yv+OVsQt3C/hmWOC+YhJZQlsyph5w1BHfbp4jyCvV1ZXBbb8NdvwxgDHPWXxKPTc1EXuB7aEX3qzxM3/OWEUJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nrwl/nx-darwin-x64": {
+      "version": "15.9.2",
+      "resolved": "https://registry.npmjs.org/@nrwl/nx-darwin-x64/-/nx-darwin-x64-15.9.2.tgz",
+      "integrity": "sha512-qHfdluHlPzV0UHOwj1ZJ+qNEhzfLGiBuy1cOth4BSzDlvMnkuqBWoprfaXoztzYcus2NSILY1/7b3Jw4DAWmMw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nrwl/nx-linux-arm-gnueabihf": {
+      "version": "15.9.2",
+      "resolved": "https://registry.npmjs.org/@nrwl/nx-linux-arm-gnueabihf/-/nx-linux-arm-gnueabihf-15.9.2.tgz",
+      "integrity": "sha512-0GzwbablosnYnnJDCJvAeZv8LlelSrNwUnGhe43saeoZdAew35Ay1E34zBrg/GCGTASuz+knEEYFM+gDD9Mc6A==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nrwl/nx-linux-arm64-gnu": {
+      "version": "15.9.2",
+      "resolved": "https://registry.npmjs.org/@nrwl/nx-linux-arm64-gnu/-/nx-linux-arm64-gnu-15.9.2.tgz",
+      "integrity": "sha512-3mFIY7iUTPG45hSIRaM2DmraCy8W6hNoArAGRrTgYw40BIJHtLrW+Rt7DLyvVXaYCvrKugWOKtxC+jG7kpIZVA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nrwl/nx-linux-arm64-musl": {
+      "version": "15.9.2",
+      "resolved": "https://registry.npmjs.org/@nrwl/nx-linux-arm64-musl/-/nx-linux-arm64-musl-15.9.2.tgz",
+      "integrity": "sha512-FNBnXEtockwxZa4I3NqggrJp0YIbNokJvt/clrICP+ijOacdUDkv8mJedavobkFsRsNq9gzCbRbUScKymrOLrg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/@nrwl/nx-linux-x64-gnu": {
       "version": "15.9.2",
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -6137,10 +6223,39 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nrwl/nx-win32-arm64-msvc": {
+      "version": "15.9.2",
+      "resolved": "https://registry.npmjs.org/@nrwl/nx-win32-arm64-msvc/-/nx-win32-arm64-msvc-15.9.2.tgz",
+      "integrity": "sha512-PGAe7QMr51ivx1X3avvs8daNlvv1wGo3OFrobjlu5rSyjC1Y3qHwT9+wdlwzNZ93FIqWOq09s+rE5gfZRfpdAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nrwl/nx-win32-x64-msvc": {
+      "version": "15.9.2",
+      "resolved": "https://registry.npmjs.org/@nrwl/nx-win32-x64-msvc/-/nx-win32-x64-msvc-15.9.2.tgz",
+      "integrity": "sha512-Q8onNzhuAZ0l9DNkm8D4Z1AEIzJr8JiT4L2fVBLYrV/R75C2HS3q7lzvfo6oqMY6mXge1cFPcrTtg3YXBQaSWA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
       ],
       "engines": {
         "node": ">= 10"
@@ -9754,6 +9869,18 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
       }
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.9.6",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.9.6.tgz",
+      "integrity": "sha512-Z3O60yxPtuCYobrtzjo0wlmvDdx2qZfeAWTyfOjEDqd08kthDKexLpV97KfAeUXPosENKd8uyJMRDfFMxcYkDQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
       "version": "4.9.6",
@@ -36351,14 +36478,54 @@
         }
       }
     },
+    "@nrwl/nx-darwin-arm64": {
+      "version": "15.9.2",
+      "resolved": "https://registry.npmjs.org/@nrwl/nx-darwin-arm64/-/nx-darwin-arm64-15.9.2.tgz",
+      "integrity": "sha512-Yv+OVsQt3C/hmWOC+YhJZQlsyph5w1BHfbp4jyCvV1ZXBbb8NdvwxgDHPWXxKPTc1EXuB7aEX3qzxM3/OWEUJg==",
+      "optional": true
+    },
+    "@nrwl/nx-darwin-x64": {
+      "version": "15.9.2",
+      "resolved": "https://registry.npmjs.org/@nrwl/nx-darwin-x64/-/nx-darwin-x64-15.9.2.tgz",
+      "integrity": "sha512-qHfdluHlPzV0UHOwj1ZJ+qNEhzfLGiBuy1cOth4BSzDlvMnkuqBWoprfaXoztzYcus2NSILY1/7b3Jw4DAWmMw==",
+      "optional": true
+    },
+    "@nrwl/nx-linux-arm-gnueabihf": {
+      "version": "15.9.2",
+      "resolved": "https://registry.npmjs.org/@nrwl/nx-linux-arm-gnueabihf/-/nx-linux-arm-gnueabihf-15.9.2.tgz",
+      "integrity": "sha512-0GzwbablosnYnnJDCJvAeZv8LlelSrNwUnGhe43saeoZdAew35Ay1E34zBrg/GCGTASuz+knEEYFM+gDD9Mc6A==",
+      "optional": true
+    },
+    "@nrwl/nx-linux-arm64-gnu": {
+      "version": "15.9.2",
+      "resolved": "https://registry.npmjs.org/@nrwl/nx-linux-arm64-gnu/-/nx-linux-arm64-gnu-15.9.2.tgz",
+      "integrity": "sha512-3mFIY7iUTPG45hSIRaM2DmraCy8W6hNoArAGRrTgYw40BIJHtLrW+Rt7DLyvVXaYCvrKugWOKtxC+jG7kpIZVA==",
+      "optional": true
+    },
+    "@nrwl/nx-linux-arm64-musl": {
+      "version": "15.9.2",
+      "resolved": "https://registry.npmjs.org/@nrwl/nx-linux-arm64-musl/-/nx-linux-arm64-musl-15.9.2.tgz",
+      "integrity": "sha512-FNBnXEtockwxZa4I3NqggrJp0YIbNokJvt/clrICP+ijOacdUDkv8mJedavobkFsRsNq9gzCbRbUScKymrOLrg==",
+      "optional": true
+    },
     "@nrwl/nx-linux-x64-gnu": {
       "version": "15.9.2",
-      "dev": true,
       "optional": true
     },
     "@nrwl/nx-linux-x64-musl": {
       "version": "15.9.2",
-      "dev": true,
+      "optional": true
+    },
+    "@nrwl/nx-win32-arm64-msvc": {
+      "version": "15.9.2",
+      "resolved": "https://registry.npmjs.org/@nrwl/nx-win32-arm64-msvc/-/nx-win32-arm64-msvc-15.9.2.tgz",
+      "integrity": "sha512-PGAe7QMr51ivx1X3avvs8daNlvv1wGo3OFrobjlu5rSyjC1Y3qHwT9+wdlwzNZ93FIqWOq09s+rE5gfZRfpdAg==",
+      "optional": true
+    },
+    "@nrwl/nx-win32-x64-msvc": {
+      "version": "15.9.2",
+      "resolved": "https://registry.npmjs.org/@nrwl/nx-win32-x64-msvc/-/nx-win32-x64-msvc-15.9.2.tgz",
+      "integrity": "sha512-Q8onNzhuAZ0l9DNkm8D4Z1AEIzJr8JiT4L2fVBLYrV/R75C2HS3q7lzvfo6oqMY6mXge1cFPcrTtg3YXBQaSWA==",
       "optional": true
     },
     "@nrwl/tao": {
@@ -39256,6 +39423,12 @@
       "requires": {
         "@react-types/shared": "^3.23.0"
       }
+    },
+    "@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.9.6",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.9.6.tgz",
+      "integrity": "sha512-Z3O60yxPtuCYobrtzjo0wlmvDdx2qZfeAWTyfOjEDqd08kthDKexLpV97KfAeUXPosENKd8uyJMRDfFMxcYkDQ==",
+      "optional": true
     },
     "@rollup/rollup-linux-x64-gnu": {
       "version": "4.9.6",

--- a/package.json
+++ b/package.json
@@ -52,5 +52,17 @@
     "prettier": "3.0.0",
     "vite": "~4.1.4"
   },
+  "optionalDependencies": {
+    "@nrwl/nx-darwin-arm64": "15.9.2",
+    "@nrwl/nx-darwin-x64": "15.9.2",
+    "@nrwl/nx-linux-arm-gnueabihf": "15.9.2",
+    "@nrwl/nx-linux-arm64-gnu": "15.9.2",
+    "@nrwl/nx-linux-arm64-musl": "15.9.2",
+    "@nrwl/nx-linux-x64-gnu": "15.9.2",
+    "@nrwl/nx-linux-x64-musl": "15.9.2",
+    "@nrwl/nx-win32-arm64-msvc": "15.9.2",
+    "@nrwl/nx-win32-x64-msvc": "15.9.2",
+    "@rollup/rollup-linux-arm64-gnu": "4.9.6"
+  },
   "prettier": "@deephaven/prettier-config"
 }


### PR DESCRIPTION
Fixes an issue with optional dependencies not installing in Docker.

- Should be able to run `npm i` locally without package-lock changing
- Should be able to run `docker compose build` on Mac (should also still work on other OSs)