### PR TITLE
refactor: Removed /app.d volume from root docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,5 @@ services:
       - 10000
     volumes:
       - ./docker/data/:/data
-      - ./tests/app.d:/app.d
     environment:
       - START_OPTS=-Xmx4g -DAuthHandlers=io.deephaven.auth.AnonymousAuthenticationHandler -Ddeephaven.console.type=python -Ddeephaven.application.dir=./app.d


### PR DESCRIPTION
The root `docker-compose.yml` shouldn't need the `/app.d` mapping any more since the `tests/docker-scripts/docker-compose.yml` one handles tests now.