### PR TITLE
fix: ui.text_field value not changing with use_state

### DIFF
--- a/plugins/ui/src/js/src/elements/spectrum/TextField.tsx
+++ b/plugins/ui/src/js/src/elements/spectrum/TextField.tsx
@@ -6,6 +6,8 @@ import {
 import Log from '@deephaven/log';
 import { useDebouncedCallback, usePrevious } from '@deephaven/react-hooks';
 
+const log = Log.module('@deephaven/js-plugin-ui/TextField');
+
 const VALUE_CHANGE_DEBOUNCE = 250;
 
 const EMPTY_FUNCTION = () => undefined;
@@ -40,7 +42,7 @@ function TextField(props: TextFieldProps): JSX.Element {
       try {
         await propOnChange(newValue);
       } catch (e) {
-        Log.warn('Error returned from onChange', e);
+        log.warn('Error returned from onChange', e);
       }
       setPending(false);
     },

--- a/plugins/ui/src/js/src/elements/spectrum/TextField.tsx
+++ b/plugins/ui/src/js/src/elements/spectrum/TextField.tsx
@@ -18,16 +18,18 @@ function TextField(props: DHCTextFieldProps): JSX.Element {
   } = props;
 
   const [value, setValue] = useState(propValue ?? defaultValue);
+  const [prevPropValue, setPrevPropValue] = useState(propValue);
+
+  // update state when propValue changes
+  if (propValue !== prevPropValue) {
+    setPrevPropValue(propValue);
+    setValue(propValue ?? defaultValue);
+  }
 
   const debouncedOnChange = useDebouncedCallback(
     propOnChange,
     VALUE_CHANGE_DEBOUNCE
   );
-
-  // update state when propValue changes
-  useEffect(() => {
-    setValue(propValue ?? defaultValue);
-  }, [propValue, defaultValue]);
 
   const onChange = useCallback(
     newValue => {

--- a/plugins/ui/src/js/src/elements/spectrum/TextField.tsx
+++ b/plugins/ui/src/js/src/elements/spectrum/TextField.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useState } from 'react';
 import {
   TextField as DHCTextField,
   TextFieldProps as DHCTextFieldProps,

--- a/plugins/ui/src/js/src/elements/spectrum/TextField.tsx
+++ b/plugins/ui/src/js/src/elements/spectrum/TextField.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import {
   TextField as DHCTextField,
   TextFieldProps as DHCTextFieldProps,
@@ -23,6 +23,11 @@ function TextField(props: DHCTextFieldProps): JSX.Element {
     propOnChange,
     VALUE_CHANGE_DEBOUNCE
   );
+
+  // update state when propValue changes
+  useEffect(() => {
+    setValue(propValue ?? defaultValue);
+  }, [propValue, defaultValue]);
 
   const onChange = useCallback(
     newValue => {

--- a/plugins/ui/src/js/src/elements/spectrum/TextField.tsx
+++ b/plugins/ui/src/js/src/elements/spectrum/TextField.tsx
@@ -28,6 +28,7 @@ function TextField(props: TextFieldProps): JSX.Element {
   const [pending, setPending] = useState(false);
   const prevPropValue = usePrevious(propValue);
 
+  // Update local value to new propValue if the server sent a new propValue and no user changes have been queued
   if (
     propValue !== prevPropValue &&
     propValue !== value &&

--- a/plugins/ui/src/js/src/elements/spectrum/TextField.tsx
+++ b/plugins/ui/src/js/src/elements/spectrum/TextField.tsx
@@ -3,6 +3,7 @@ import {
   TextField as DHCTextField,
   TextFieldProps as DHCTextFieldProps,
 } from '@deephaven/components';
+import Log from '@deephaven/log';
 import { useDebouncedCallback, usePrevious } from '@deephaven/react-hooks';
 
 const VALUE_CHANGE_DEBOUNCE = 250;
@@ -35,8 +36,12 @@ function TextField(props: TextFieldProps): JSX.Element {
   }
 
   const propDebouncedOnChange = useCallback(
-    (newValue: string) => {
-      propOnChange(newValue);
+    async (newValue: string) => {
+      try {
+        await propOnChange(newValue);
+      } catch (e) {
+        Log.warn('Error returned from onChange', e);
+      }
       setPending(false);
     },
     [propOnChange]
@@ -49,8 +54,8 @@ function TextField(props: TextFieldProps): JSX.Element {
 
   const onChange = useCallback(
     (newValue: string) => {
-      debouncedOnChange(newValue);
       setPending(true);
+      debouncedOnChange(newValue);
       setValue(newValue);
     },
     [debouncedOnChange]

--- a/plugins/ui/src/js/src/elements/spectrum/TextField.tsx
+++ b/plugins/ui/src/js/src/elements/spectrum/TextField.tsx
@@ -7,15 +7,17 @@ import { useDebouncedCallback, usePrevious } from '@deephaven/react-hooks';
 
 const VALUE_CHANGE_DEBOUNCE = 250;
 
+const EMPTY_FUNCTION = () => undefined;
+
 interface TextFieldProps extends DHCTextFieldProps {
-  onChange: (value: string) => Promise<void>;
+  onChange?: (value: string) => Promise<void>;
 }
 
 function TextField(props: TextFieldProps): JSX.Element {
   const {
     defaultValue = '',
     value: propValue,
-    onChange: propOnChange,
+    onChange: propOnChange = EMPTY_FUNCTION,
     ...otherProps
   } = props;
 

--- a/plugins/ui/src/js/src/elements/spectrum/TextField.tsx
+++ b/plugins/ui/src/js/src/elements/spectrum/TextField.tsx
@@ -1,9 +1,9 @@
-import React, { useCallback, useRef, useState } from 'react';
+import React, { useCallback, useState } from 'react';
 import {
   TextField as DHCTextField,
   TextFieldProps as DHCTextFieldProps,
 } from '@deephaven/components';
-import { useDebouncedCallback } from '@deephaven/react-hooks';
+import { useDebouncedCallback, usePrevious } from '@deephaven/react-hooks';
 
 const VALUE_CHANGE_DEBOUNCE = 250;
 
@@ -18,18 +18,15 @@ function TextField(props: DHCTextFieldProps): JSX.Element {
   } = props;
 
   const [value, setValue] = useState(propValue ?? defaultValue);
-  const prevPropValue = useRef(propValue);
-  const pendingUpdate = useRef(false);
+  const prevPropValue = usePrevious(propValue);
 
   if (
-    propValue !== prevPropValue.current &&
+    propValue !== prevPropValue &&
     propValue !== value &&
-    !pendingUpdate.current
+    propValue !== undefined
   ) {
-    setValue(propValue ?? defaultValue);
+    setValue(propValue);
   }
-
-  prevPropValue.current = propValue; // Always up to date after the check and doesn't trigger a re-render if the prop matches the current value
 
   const debouncedOnChange = useDebouncedCallback(
     propOnChange,
@@ -38,10 +35,8 @@ function TextField(props: DHCTextFieldProps): JSX.Element {
 
   const onChange = useCallback(
     newValue => {
-      pendingUpdate.current = true;
       setValue(newValue);
       debouncedOnChange(newValue);
-      pendingUpdate.current = false;
     },
     [debouncedOnChange]
   );


### PR DESCRIPTION
Resolves https://github.com/deephaven/deephaven-plugins/issues/372

**Changes Implemented:**
- Added a `useEffect` that updates the local `value` state in the `TextField` whenever the `propValue` changes, which is the value that would be changed using the `use_state`