### PR TITLE
feat: Make RadioGroup orientation prop case insensitive

### DIFF
--- a/plugins/ui/src/js/src/elements/RadioGroup.tsx
+++ b/plugins/ui/src/js/src/elements/RadioGroup.tsx
@@ -2,22 +2,36 @@ import {
   RadioGroup as DHRadioGroup,
   RadioGroupProps as DHRadioGroupProps,
 } from '@deephaven/components';
+import { Orientation } from '@react-types/shared';
 import { SerializedFocusEventProps } from './SerializedPropTypes';
 import { useFocusEventCallback } from './spectrum/useFocusEventCallback';
 
-export type SerializedRadioGroupProps =
-  SerializedFocusEventProps<DHRadioGroupProps>;
+export type SerializedRadioGroupProps = Omit<
+  SerializedFocusEventProps<DHRadioGroupProps>,
+  'orientation'
+> & {
+  orientation?: Orientation | Uppercase<Orientation>;
+};
 
 function RadioGroup({
   onFocus: serializedOnFocus,
   onBlur: serializedOnBlur,
+  orientation: orientationMaybeUppercase,
   ...props
 }: SerializedRadioGroupProps): JSX.Element {
   const onFocus = useFocusEventCallback(serializedOnFocus);
   const onBlur = useFocusEventCallback(serializedOnBlur);
+  const orientationLc = orientationMaybeUppercase?.toLowerCase() as Orientation;
 
-  // eslint-disable-next-line react/jsx-props-no-spreading
-  return <DHRadioGroup {...props} onFocus={onFocus} onBlur={onBlur} />;
+  return (
+    <DHRadioGroup
+      // eslint-disable-next-line react/jsx-props-no-spreading
+      {...props}
+      onFocus={onFocus}
+      onBlur={onBlur}
+      orientation={orientationLc}
+    />
+  );
 }
 
 export default RadioGroup;

--- a/plugins/ui/src/js/src/elements/RadioGroup.tsx
+++ b/plugins/ui/src/js/src/elements/RadioGroup.tsx
@@ -21,7 +21,9 @@ function RadioGroup({
 }: SerializedRadioGroupProps): JSX.Element {
   const onFocus = useFocusEventCallback(serializedOnFocus);
   const onBlur = useFocusEventCallback(serializedOnBlur);
-  const orientationLc = orientationMaybeUppercase?.toLowerCase() as Orientation;
+  const orientationLc = orientationMaybeUppercase?.toLowerCase() as
+    | Orientation
+    | undefined;
 
   return (
     <DHRadioGroup

--- a/plugins/ui/src/js/src/elements/spectrum/useSelectionProps.ts
+++ b/plugins/ui/src/js/src/elements/spectrum/useSelectionProps.ts
@@ -80,8 +80,9 @@ export function useSelectionProps({
   onChange: serializedOnChange,
   onSelectionChange: serializedOnSelectionChange,
 }: SerializedSelectionProps): SelectionProps {
-  const selectionModeLc =
-    selectionModeMaybeUppercase?.toLowerCase() as SelectionMode;
+  const selectionModeLc = selectionModeMaybeUppercase?.toLowerCase() as
+    | SelectionMode
+    | undefined;
 
   const onChange = useSelectionEventCallback(serializedOnChange);
   const onSelectionChange = useSelectionEventCallback(

--- a/plugins/ui/src/js/src/elements/useListViewProps.ts
+++ b/plugins/ui/src/js/src/elements/useListViewProps.ts
@@ -37,13 +37,13 @@ export type SerializedListViewProps = (
  * @returns Wrapped props
  */
 export function useListViewProps({
-  density,
+  density: densityMaybeUppercase,
   selectionMode: selectionModeMaybeUppercase,
   onChange: serializedOnChange,
   onSelectionChange: serializedOnSelectionChange,
   ...otherProps
 }: SerializedListViewProps): DHListViewProps | WrappedDHListViewJSApiProps {
-  const densityLc = density?.toLowerCase() as Density;
+  const densityLc = densityMaybeUppercase?.toLowerCase() as Density | undefined;
 
   const { selectionMode, onChange, onSelectionChange } = useSelectionProps({
     selectionMode: selectionModeMaybeUppercase,


### PR DESCRIPTION
Most of our dh ui string enumerations are "CAPITALIZED". Make RadioGroup `orientation` prop consistent.

```python
from deephaven import ui

@ui.component
def ui_radio_group():
    return ui.radio_group(
        ui.radio('One', value="one"),
        ui.radio('Two', value="two"),
        label="Radio Group",
        orientation="HORIZONTAL"
    )

my_radio_group = ui_radio_group()
```

#425