### PR TITLE
build: Set distTag to ui-v0.15 for this release branch

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -3,5 +3,13 @@
   "useWorkspaces": true,
   "useNx": true,
   "version": "independent",
-  "packages": ["plugins/*/src/js/"]
+  "packages": ["plugins/*/src/js/"],
+  "command": {
+    "publish": {
+      "distTag": "ui-v0.15"
+    },
+    "version": {
+      "changelogPreset": "conventionalcommits"
+    }
+  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "@types/node": "^20.11.17",
         "@types/prop-types": "^15.7.10",
         "@types/shortid": "^0.0.29",
+        "conventional-changelog-conventionalcommits": "^7.0.0",
         "eslint": "^8.37.0",
         "identity-obj-proxy": "^3.0.0",
         "jest": "^29.6.2",
@@ -13019,6 +13020,18 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/conventional-changelog-conventionalcommits": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-7.0.2.tgz",
+      "integrity": "sha512-NKXYmMR/Hr1DevQegFB4MwfM5Vv0m4UIxKZTTYuD98lpTknaZlSRrDOG4X7wIXpGkfsYxZTghUN+Qq+T0YQI7w==",
+      "dev": true,
+      "dependencies": {
+        "compare-func": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/conventional-changelog-core": {
@@ -42247,6 +42260,15 @@
       "requires": {
         "compare-func": "^2.0.0",
         "q": "^1.5.1"
+      }
+    },
+    "conventional-changelog-conventionalcommits": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-7.0.2.tgz",
+      "integrity": "sha512-NKXYmMR/Hr1DevQegFB4MwfM5Vv0m4UIxKZTTYuD98lpTknaZlSRrDOG4X7wIXpGkfsYxZTghUN+Qq+T0YQI7w==",
+      "dev": true,
+      "requires": {
+        "compare-func": "^2.0.0"
       }
     },
     "conventional-changelog-core": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@types/node": "^20.11.17",
     "@types/prop-types": "^15.7.10",
     "@types/shortid": "^0.0.29",
+    "conventional-changelog-conventionalcommits": "^7.0.0",
     "eslint": "^8.37.0",
     "identity-obj-proxy": "^3.0.0",
     "jest": "^29.6.2",


### PR DESCRIPTION
- Note there's still some weirdness around how we should handle dist-tags, will address with #557 fixes. This just makes sure I don't publish a version "latest" from this branch
- Update the changelogPreset to use conventionalcommits (was done in web-client-ui with https://github.com/deephaven/web-client-ui/pull/2054)