### PR TITLE
fix: deephaven-plugin-ui is compatible with deephaven-core 0.33.5

### DIFF
--- a/plugins/ui/setup.cfg
+++ b/plugins/ui/setup.cfg
@@ -25,7 +25,7 @@ package_dir=
     =src
 packages=find_namespace:
 install_requires =
-    deephaven-core>=0.34.1
+    deephaven-core>=0.33.5
     deephaven-plugin>=0.6.0
     json-rpc
     deephaven-plugin-utilities


### PR DESCRIPTION
- We need to update the version so that you can install alongside deephaven-core 0.33.5