### PR TITLE
fix: Don't use a key for the ErrorBoundary in a Panel

### DIFF
--- a/plugins/ui/src/js/src/layout/ReactPanel.tsx
+++ b/plugins/ui/src/js/src/layout/ReactPanel.tsx
@@ -100,10 +100,6 @@ function ReactPanel({
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const contentKey = useMemo(() => shortid.generate(), [metadata]);
 
-  // We want to regenerate the error boundary key every time the children change, so that the error is cleared
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  const errorKey = useMemo(() => shortid.generate(), [children]);
-
   const parent = useParentItem();
   const { eventHub } = layoutManager;
 
@@ -210,7 +206,7 @@ function ReactPanel({
               columnGap={columnGap}
             >
               {/* Have an ErrorBoundary around the children to display an error in the panel if there's any errors thrown when rendering the children */}
-              <ErrorBoundary key={errorKey}>{children}</ErrorBoundary>
+              <ErrorBoundary>{children}</ErrorBoundary>
             </Flex>
           </View>
           <ReactPanelContentOverlay />


### PR DESCRIPTION
- Changing the key whenever the children changed resulted in the key changing every render, which is not what we want
- Don't bother with an error key; when the widget is re-opened, there's already a new key at a higher level so the ErrorBoundary gets reset
