### PR TITLE
fix: gapminder to be compatible with Pandas 2.0.3

### DIFF
--- a/plugins/plotly-express/src/deephaven/plot/express/data/data_generators.py
+++ b/plugins/plotly-express/src/deephaven/plot/express/data/data_generators.py
@@ -654,9 +654,15 @@ def gapminder(ticking: bool = True) -> Table:
     gapminder_no_2007.loc[:, ["year"]] = gapminder_no_2007["year"].apply(
         lambda x: create_years(x, 5)
     )
-    gapminder_no_2007.loc[:, ["lifeExp", "pop", "gdpPercap"]] = gapminder_no_2007[
-        ["lifeExp", "pop", "gdpPercap"]
-    ].map(lambda x: create_empty(x, 5))
+    gapminder_no_2007.loc[:, ["lifeExp"]] = gapminder_no_2007["lifeExp"].apply(
+        lambda x: create_empty(x, 5)
+    )
+    gapminder_no_2007.loc[:, ["pop"]] = gapminder_no_2007["pop"].apply(
+        lambda x: create_empty(x, 5)
+    )
+    gapminder_no_2007.loc[:, ["gdpPercap"]] = gapminder_no_2007["gdpPercap"].apply(
+        lambda x: create_empty(x, 5)
+    )
     gapminder_no_2007 = gapminder_no_2007.explode(
         column=["year", "lifeExp", "pop", "gdpPercap"]
     )
@@ -672,9 +678,15 @@ def gapminder(ticking: bool = True) -> Table:
     )
 
     # expand pre-2007 dataset into consecutive months
-    gapminder_no_2007.loc[:, ["lifeExp", "pop", "gdpPercap"]] = gapminder_no_2007[
-        ["lifeExp", "pop", "gdpPercap"]
-    ].map(lambda x: create_empty(x, 12))
+    gapminder_no_2007.loc[:, ["lifeExp"]] = gapminder_no_2007["lifeExp"].apply(
+        lambda x: create_empty(x, 12)
+    )
+    gapminder_no_2007.loc[:, ["pop"]] = gapminder_no_2007["pop"].apply(
+        lambda x: create_empty(x, 12)
+    )
+    gapminder_no_2007.loc[:, ["gdpPercap"]] = gapminder_no_2007["gdpPercap"].apply(
+        lambda x: create_empty(x, 12)
+    )
     gapminder_no_2007 = gapminder_no_2007.explode(
         column=["month", "lifeExp", "pop", "gdpPercap"]
     )

--- a/plugins/plotly-express/src/deephaven/plot/express/data/data_generators.py
+++ b/plugins/plotly-express/src/deephaven/plot/express/data/data_generators.py
@@ -654,15 +654,10 @@ def gapminder(ticking: bool = True) -> Table:
     gapminder_no_2007.loc[:, ["year"]] = gapminder_no_2007["year"].apply(
         lambda x: create_years(x, 5)
     )
-    gapminder_no_2007.loc[:, ["lifeExp"]] = gapminder_no_2007["lifeExp"].apply(
-        lambda x: create_empty(x, 5)
-    )
-    gapminder_no_2007.loc[:, ["pop"]] = gapminder_no_2007["pop"].apply(
-        lambda x: create_empty(x, 5)
-    )
-    gapminder_no_2007.loc[:, ["gdpPercap"]] = gapminder_no_2007["gdpPercap"].apply(
-        lambda x: create_empty(x, 5)
-    )
+    for col in ["lifeExp", "pop", "gdpPercap"]:
+        gapminder_no_2007.loc[:, [col]] = gapminder_no_2007[col].apply(
+            lambda x: create_empty(x, 5)
+        )
     gapminder_no_2007 = gapminder_no_2007.explode(
         column=["year", "lifeExp", "pop", "gdpPercap"]
     )
@@ -678,15 +673,10 @@ def gapminder(ticking: bool = True) -> Table:
     )
 
     # expand pre-2007 dataset into consecutive months
-    gapminder_no_2007.loc[:, ["lifeExp"]] = gapminder_no_2007["lifeExp"].apply(
-        lambda x: create_empty(x, 12)
-    )
-    gapminder_no_2007.loc[:, ["pop"]] = gapminder_no_2007["pop"].apply(
-        lambda x: create_empty(x, 12)
-    )
-    gapminder_no_2007.loc[:, ["gdpPercap"]] = gapminder_no_2007["gdpPercap"].apply(
-        lambda x: create_empty(x, 12)
-    )
+    for col in ["lifeExp", "pop", "gdpPercap"]:
+        gapminder_no_2007.loc[:, [col]] = gapminder_no_2007[col].apply(
+            lambda x: create_empty(x, 12)
+        )
     gapminder_no_2007 = gapminder_no_2007.explode(
         column=["month", "lifeExp", "pop", "gdpPercap"]
     )


### PR DESCRIPTION
The current version of the ticking Gapminder dataset uses a feature only available in Pandas 2.1.4. Deephaven will work with Python 3.8, but Pandas 2.1 has a minimum Python version of 3.9. So, the feature that Gapminder depends on is not guaranteed to be available to DH. This PR removes that feature and replicates the functionality with an older feature.