### PR TITLE
refactor: Remove row and column indexes from table press handlers

### DIFF
--- a/plugins/ui/src/deephaven/ui/components/table.py
+++ b/plugins/ui/src/deephaven/ui/components/table.py
@@ -37,21 +37,19 @@ def table(
     Args:
         table: The table to wrap
         on_row_press: The callback function to run when a row is clicked.
-            The first parameter is the row index, and the second is the visible row data provided in a dictionary where the
+            The callback is invoked with the visible row data provided in a dictionary where the
             column names are the keys.
         on_row_double_press: The callback function to run when a row is double clicked.
-            The first parameter is the row index, and the second is the visible row data provided in a dictionary where the
+            The callback is invoked with the visible row data provided in a dictionary where the
             column names are the keys.
         on_cell_press: The callback function to run when a cell is clicked.
-            The first parameter is the cell index, and the second is the cell data provided in a dictionary where the
-            column names are the keys.
+            The callback is invoked with the cell data.
         on_cell_double_press: The callback function to run when a cell is double clicked.
-            The first parameter is the cell index, and the second is the cell data provided in a dictionary where the
-            column names are the keys.
+            The callback is invoked with the cell data.
         on_column_press: The callback function to run when a column is clicked.
-            The first parameter is the column name.
+            The callback is invoked with the column name.
         on_column_double_press: The callback function to run when a column is double clicked.
-            The first parameter is the column name.
+            The callback is invoked with the column name.
         quick_filters: The quick filters to apply to the table. Dictionary of column name to filter value.
         show_quick_filters: Whether to show the quick filter bar by default.
         show_search: Whether to show the search bar by default.

--- a/plugins/ui/src/deephaven/ui/types/types.py
+++ b/plugins/ui/src/deephaven/ui/types/types.py
@@ -178,32 +178,10 @@ class SliderChange(TypedDict):
 
 SliderChangeCallable = Callable[[SliderChange], None]
 
-
-ColumnIndex = int
-"""
-Index of a column in a table.
-"""
-
-RowIndex = int
-"""
-Index of a row in a table.
-"""
-
-CellIndex = Tuple[ColumnIndex, RowIndex]
-"""
-Index of a cell in a table.
-"""
-
-GridIndex = Tuple[Union[ColumnIndex, None], Union[RowIndex, None]]
-"""
-Index of a spot on the grid. A value of None indicates a header row or column.
-"""
-
-
 ColumnName = str
 RowDataMap = Dict[str, Any]
-RowPressCallback = Callable[[RowIndex, RowDataMap], None]
-CellPressCallback = Callable[[CellIndex, CellData], None]
+RowPressCallback = Callable[[RowDataMap], None]
+CellPressCallback = Callable[[CellData], None]
 ColumnPressCallback = Callable[[ColumnName], None]
 AggregationOperation = Literal[
     "COUNT",

--- a/plugins/ui/src/deephaven/ui/types/types.py
+++ b/plugins/ui/src/deephaven/ui/types/types.py
@@ -179,7 +179,7 @@ class SliderChange(TypedDict):
 SliderChangeCallable = Callable[[SliderChange], None]
 
 ColumnName = str
-RowDataMap = Dict[str, Any]
+RowDataMap = Dict[ColumnName, RowDataValue]
 RowPressCallback = Callable[[RowDataMap], None]
 CellPressCallback = Callable[[CellData], None]
 ColumnPressCallback = Callable[[ColumnName], None]

--- a/plugins/ui/src/js/src/elements/UITable.tsx
+++ b/plugins/ui/src/js/src/elements/UITable.tsx
@@ -3,7 +3,7 @@ import { useSelector } from 'react-redux';
 import {
   DehydratedQuickFilter,
   IrisGrid,
-  IrisGridType,
+  type IrisGridType,
   type IrisGridContextMenuData,
   IrisGridModel,
   IrisGridModelFactory,

--- a/plugins/ui/src/js/src/elements/utils/UITableMouseHandler.ts
+++ b/plugins/ui/src/js/src/elements/utils/UITableMouseHandler.ts
@@ -95,13 +95,14 @@ class UITableMouseHandler extends GridMouseHandler {
   onClick(gridPoint: GridPoint): EventHandlerResult {
     const { column, row } = gridPoint;
     const { model, onCellPress, onRowPress, onColumnPress } = this;
+
     if (onCellPress != null && column != null && row != null) {
       const cellData = getCellData(column, row, model);
-      onCellPress([column, row], cellData);
+      onCellPress(cellData);
     }
     if (onRowPress != null && row != null) {
       const rowData = getRowDataMap(row, model);
-      onRowPress(row, rowData);
+      onRowPress(rowData);
     }
     if (onColumnPress && column != null) {
       onColumnPress(model.columns[column].name);
@@ -113,13 +114,14 @@ class UITableMouseHandler extends GridMouseHandler {
     const { column, row } = gridPoint;
     const { model, onCellDoublePress, onRowDoublePress, onColumnDoublePress } =
       this;
+
     if (onCellDoublePress != null && column != null && row != null) {
       const cellData = getCellData(column, row, model);
-      onCellDoublePress([column, row], cellData);
+      onCellDoublePress(cellData);
     }
     if (onRowDoublePress != null && row != null) {
       const rowData = getRowDataMap(row, model);
-      onRowDoublePress(row, rowData);
+      onRowDoublePress(rowData);
     }
     if (onColumnDoublePress && column != null) {
       onColumnDoublePress(model.columns[column].name);

--- a/plugins/ui/src/js/src/elements/utils/UITableUtils.tsx
+++ b/plugins/ui/src/js/src/elements/utils/UITableUtils.tsx
@@ -3,7 +3,6 @@ import type {
   ColumnName,
   DehydratedSort,
   IrisGridContextMenuData,
-  RowIndex,
 } from '@deephaven/iris-grid';
 import type {
   ContextAction,
@@ -56,13 +55,10 @@ type ResolvableUIContextItem =
 
 export interface UITableProps {
   table: dh.WidgetExportedObject;
-  onCellPress?: (cellIndex: [ColumnIndex, RowIndex], data: CellData) => void;
-  onCellDoublePress?: (
-    cellIndex: [ColumnIndex, RowIndex],
-    data: CellData
-  ) => void;
-  onRowPress?: (rowIndex: RowIndex, rowData: RowDataMap) => void;
-  onRowDoublePress?: (rowIndex: RowIndex, rowData: RowDataMap) => void;
+  onCellPress?: (data: CellData) => void;
+  onCellDoublePress?: (data: CellData) => void;
+  onRowPress?: (rowData: RowDataMap) => void;
+  onRowDoublePress?: (rowData: RowDataMap) => void;
   onColumnPress?: (columnName: ColumnName) => void;
   onColumnDoublePress?: (columnName: ColumnName) => void;
   alwaysFetchColumns?: string[];


### PR DESCRIPTION
Fixes #528 

BREAKING CHANGE:
`ui.table` row and cell press handlers had their first parameters of row/column index removed. These were an unsafe way to index the table as the index matches the user's view of the table, not the server's view.

For row events, you can add your own key column and use `always_fetch_columns=["my_key_column"]`. This column's data will be included with every row press.

For cell events, switch to a row event with the change above if you need to identify the row of the cell.