### PR TITLE
build: Clean the build directory before building the wheel

### DIFF
--- a/plugins/ui/setup.py
+++ b/plugins/ui/setup.py
@@ -15,4 +15,4 @@ except FileNotFoundError:
 
 package_js(js_dir, dest_dir)
 
-setup()
+setup(package_data={"deephaven.ui._js": ["**"]})

--- a/plugins/ui/setup.py
+++ b/plugins/ui/setup.py
@@ -6,9 +6,10 @@ from deephaven.plugin.packaging import package_js
 js_dir = "src/js/"
 dest_dir = os.path.join("src/deephaven/ui/_js")
 
-# remove the build directory to ensure that the package is built from the latest js files
+# remove the build/dist directory to ensure that the package is built from the latest js files
 try:
     shutil.rmtree("build")
+    shutil.rmtree("dist")
 except FileNotFoundError:
     pass
 

--- a/plugins/ui/setup.py
+++ b/plugins/ui/setup.py
@@ -1,10 +1,17 @@
 from setuptools import setup
 import os
+import shutil
 from deephaven.plugin.packaging import package_js
 
 js_dir = "src/js/"
 dest_dir = os.path.join("src/deephaven/ui/_js")
 
+# remove the build directory to ensure that the package is built from the latest js files
+try:
+    shutil.rmtree("build")
+except FileNotFoundError:
+    pass
+
 package_js(js_dir, dest_dir)
 
-setup(package_data={"deephaven.ui._js": ["**"]})
+setup()


### PR DESCRIPTION
- When rebuilding the wheel, it had stale files for the _js files, which was confusing and annoying
- Clean the build directory so it doesn't have stale files
- Still need to run `npm run build` between builds
- Fixes #380 