### PR TITLE
chore: Confirm the user wants to proceed when version bumping

### DIFF
--- a/cog.toml
+++ b/cog.toml
@@ -16,7 +16,9 @@ post_bump_hooks = []
 
 # bump hooks for package versions, which is what we actually use
 pre_package_bump_hooks = [
-    "echo Updating {{package}} to version {{version}}",
+    "echo Updating {{package}} from {{latest}} to version {{version}}",
+    # Confirm the user wishes to proceed
+    "../../tools/confirm.sh",
     # make sure user has correct software installed and is authenticated with `gh` cli tool
     "../../tools/validate.sh",
     # change the version number of the given plugin in source, and commit it as a chore(version): commit

--- a/tools/confirm.sh
+++ b/tools/confirm.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# This script just prompts the user to confirm they want to continue
+
+read -p "Continue? (y/n)" -n 1 -r
+echo    # (optional) move to a new line
+if [[ ! $REPLY =~ ^[Yy]$ ]]
+then
+    echo "Aborted."
+    [[ "$0" = "$BASH_SOURCE" ]] && exit 1 || return 1 # handle exits from shell or function but don't exit interactive shell
+fi
+echo "Continuing..."


### PR DESCRIPTION
- Prompt the user with the previous version and the new version when bumping, then ask the user to confirm
- Avoid situations where it bumps to a version we're not expecting
