### PR TITLE
feat: Add ui.table reverse prop

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32209,6 +32209,7 @@
         "@deephaven/jsapi-bootstrap": "^0.85.1",
         "@deephaven/jsapi-components": "^0.85.1",
         "@deephaven/jsapi-types": "^1.0.0-dev0.35.0",
+        "@deephaven/jsapi-utils": "^0.85.2",
         "@deephaven/log": "^0.85.0",
         "@deephaven/plugin": "^0.85.1",
         "@deephaven/react-hooks": "^0.85.0",
@@ -32654,14 +32655,14 @@
       "integrity": "sha512-X35g2ktmXbiTwjMNF20IkuNawJJ6Tlvrv23VuUVIjWHkpWcmyCYWIBle2zo7QAF6nnJpkccwFKJiC+TIkWl7hg=="
     },
     "plugins/ui/src/js/node_modules/@deephaven/jsapi-utils": {
-      "version": "0.85.1",
-      "resolved": "https://registry.npmjs.org/@deephaven/jsapi-utils/-/jsapi-utils-0.85.1.tgz",
-      "integrity": "sha512-lXC7vdmTGeGzMyGp/Tl7zN6v5+AXkkP56u9AM8Iuauzi9uytwDWb8YPgxHL0nj96h/VcYe8/BPH2zXdnjhkT8w==",
+      "version": "0.85.2",
+      "resolved": "https://registry.npmjs.org/@deephaven/jsapi-utils/-/jsapi-utils-0.85.2.tgz",
+      "integrity": "sha512-vFuIE0NtiTNV2H9hElgkfulRm1LuKmzFhhiCwrmz3wRtEMNDEHUyqSQzk+rjFRiswV/OO+KNA3POd0vagkMzJQ==",
       "dependencies": {
         "@deephaven/filters": "^0.85.0",
         "@deephaven/jsapi-types": "^1.0.0-dev0.34.0",
         "@deephaven/log": "^0.85.0",
-        "@deephaven/utils": "^0.85.0",
+        "@deephaven/utils": "^0.85.2",
         "lodash.clamp": "^4.0.3",
         "nanoid": "^5.0.7"
       },
@@ -32742,9 +32743,9 @@
       }
     },
     "plugins/ui/src/js/node_modules/@deephaven/utils": {
-      "version": "0.85.0",
-      "resolved": "https://registry.npmjs.org/@deephaven/utils/-/utils-0.85.0.tgz",
-      "integrity": "sha512-tlz7rzZ9O9Y1OiMZSt4vKNGFvCH3P6GWU8ZkLLIj83dsXbAO442jCxBvPfMpC4NbSa2294fel+Mnl23ZOY4big==",
+      "version": "0.85.2",
+      "resolved": "https://registry.npmjs.org/@deephaven/utils/-/utils-0.85.2.tgz",
+      "integrity": "sha512-MhKRz7Ijz6ltJCm63ji8XKk4Pwz19v5g/rJxuVprpNCrnjsxxfxXOLORAhly911A7mxcX0/d5JpG0eU4LjY4tQ==",
       "engines": {
         "node": ">=16"
       }
@@ -36231,6 +36232,7 @@
         "@deephaven/jsapi-bootstrap": "^0.85.1",
         "@deephaven/jsapi-components": "^0.85.1",
         "@deephaven/jsapi-types": "^1.0.0-dev0.35.0",
+        "@deephaven/jsapi-utils": "^0.85.2",
         "@deephaven/log": "^0.85.0",
         "@deephaven/plugin": "^0.85.1",
         "@deephaven/react-hooks": "^0.85.0",
@@ -36576,14 +36578,14 @@
           "integrity": "sha512-X35g2ktmXbiTwjMNF20IkuNawJJ6Tlvrv23VuUVIjWHkpWcmyCYWIBle2zo7QAF6nnJpkccwFKJiC+TIkWl7hg=="
         },
         "@deephaven/jsapi-utils": {
-          "version": "0.85.1",
-          "resolved": "https://registry.npmjs.org/@deephaven/jsapi-utils/-/jsapi-utils-0.85.1.tgz",
-          "integrity": "sha512-lXC7vdmTGeGzMyGp/Tl7zN6v5+AXkkP56u9AM8Iuauzi9uytwDWb8YPgxHL0nj96h/VcYe8/BPH2zXdnjhkT8w==",
+          "version": "0.85.2",
+          "resolved": "https://registry.npmjs.org/@deephaven/jsapi-utils/-/jsapi-utils-0.85.2.tgz",
+          "integrity": "sha512-vFuIE0NtiTNV2H9hElgkfulRm1LuKmzFhhiCwrmz3wRtEMNDEHUyqSQzk+rjFRiswV/OO+KNA3POd0vagkMzJQ==",
           "requires": {
             "@deephaven/filters": "^0.85.0",
             "@deephaven/jsapi-types": "^1.0.0-dev0.34.0",
             "@deephaven/log": "^0.85.0",
-            "@deephaven/utils": "^0.85.0",
+            "@deephaven/utils": "^0.85.2",
             "lodash.clamp": "^4.0.3",
             "nanoid": "^5.0.7"
           }
@@ -36640,9 +36642,9 @@
           }
         },
         "@deephaven/utils": {
-          "version": "0.85.0",
-          "resolved": "https://registry.npmjs.org/@deephaven/utils/-/utils-0.85.0.tgz",
-          "integrity": "sha512-tlz7rzZ9O9Y1OiMZSt4vKNGFvCH3P6GWU8ZkLLIj83dsXbAO442jCxBvPfMpC4NbSa2294fel+Mnl23ZOY4big=="
+          "version": "0.85.2",
+          "resolved": "https://registry.npmjs.org/@deephaven/utils/-/utils-0.85.2.tgz",
+          "integrity": "sha512-MhKRz7Ijz6ltJCm63ji8XKk4Pwz19v5g/rJxuVprpNCrnjsxxfxXOLORAhly911A7mxcX0/d5JpG0eU4LjY4tQ=="
         },
         "buffer": {
           "version": "6.0.3",

--- a/plugins/ui/src/deephaven/ui/components/table.py
+++ b/plugins/ui/src/deephaven/ui/components/table.py
@@ -25,6 +25,7 @@ def table(
     quick_filters: dict[ColumnName, QuickFilterExpression] | None = None,
     show_quick_filters: bool = False,
     show_search: bool = False,
+    reverse: bool = False,
     front_columns: list[ColumnName] | None = None,
     back_columns: list[ColumnName] | None = None,
     frozen_columns: list[ColumnName] | None = None,
@@ -59,6 +60,7 @@ def table(
         quick_filters: The quick filters to apply to the table. Dictionary of column name to filter value.
         show_quick_filters: Whether to show the quick filter bar by default.
         show_search: Whether to show the search bar by default.
+        reverse: Whether to reverse the table rows. Applied after any sorts.
         front_columns: The columns to pin to the front of the table. These will not be movable by the user.
         back_columns: The columns to pin to the back of the table. These will not be movable by the user.
         frozen_columns: The columns to freeze by default at the front of the table.

--- a/plugins/ui/src/js/package.json
+++ b/plugins/ui/src/js/package.json
@@ -52,6 +52,7 @@
     "@deephaven/jsapi-bootstrap": "^0.85.1",
     "@deephaven/jsapi-components": "^0.85.1",
     "@deephaven/jsapi-types": "^1.0.0-dev0.35.0",
+    "@deephaven/jsapi-utils": "^0.85.2",
     "@deephaven/log": "^0.85.0",
     "@deephaven/plugin": "^0.85.1",
     "@deephaven/react-hooks": "^0.85.0",

--- a/plugins/ui/src/js/src/elements/UITable/UITable.tsx
+++ b/plugins/ui/src/js/src/elements/UITable/UITable.tsx
@@ -11,6 +11,7 @@ import {
   IrisGridUtils,
 } from '@deephaven/iris-grid';
 import { useApi } from '@deephaven/jsapi-bootstrap';
+import { TableUtils } from '@deephaven/jsapi-utils';
 import type { dh } from '@deephaven/jsapi-types';
 import Log from '@deephaven/log';
 import { getSettings, RootState } from '@deephaven/redux';
@@ -35,6 +36,7 @@ export function UITable({
   table: exportedTable,
   showSearch: showSearchBar,
   showQuickFilters,
+  reverse,
   frontColumns,
   backColumns,
   frozenColumns,
@@ -165,6 +167,9 @@ export function UITable({
         sorts: hydratedSorts,
         quickFilters: hydratedQuickFilters,
         isFilterBarShown: showQuickFilters,
+        reverseType: reverse
+          ? TableUtils.REVERSE_TYPE.POST_SORT
+          : TableUtils.REVERSE_TYPE.NONE,
         settings,
         onContextMenu,
       }) satisfies Partial<IrisGridProps>,
@@ -175,6 +180,7 @@ export function UITable({
       showQuickFilters,
       hydratedSorts,
       hydratedQuickFilters,
+      reverse,
       settings,
       onContextMenu,
     ]

--- a/plugins/ui/src/js/src/elements/UITable/UITableUtils.tsx
+++ b/plugins/ui/src/js/src/elements/UITable/UITableUtils.tsx
@@ -67,6 +67,7 @@ export type UITableProps = {
   sorts?: DehydratedSort[];
   showSearch: boolean;
   showQuickFilters: boolean;
+  reverse: boolean;
   frontColumns?: string[];
   backColumns?: string[];
   frozenColumns?: string[];


### PR DESCRIPTION
Fixes #607

The concern I had about reverse/sort order is that it does matter, but we only apply a post-sort reverse in the UI via the reverse action.

We do however not have that plumbed up properly in IrisGrid (we define pre-sort, but don't use it and don't properly apply the reverse pre-sort if it's specified). But it works for what we want in ui.table

```py
from deephaven import ui
from deephaven.plot import express as dx

_stocks = dx.data.stocks()

stocks_reversed = ui.table(
    _stocks,
    reverse=True
)
```