### PR TITLE
fix: Plotly express widgets don't work in deephaven.ui

### DIFF
--- a/plugins/ui/test/deephaven/ui/test_encoder.py
+++ b/plugins/ui/test/deephaven/ui/test_encoder.py
@@ -18,6 +18,17 @@ class TestObject:
         pass
 
 
+class UnhashableTestObject:
+    """
+    A test object that can be used to represent an exported object type that is unhashable
+    """
+
+    def __init__(self):
+        pass
+
+    __hash__ = None
+
+
 class EncoderTest(BaseTestCase):
     def expect_result(
         self,
@@ -556,6 +567,18 @@ class EncoderTest(BaseTestCase):
             "callables don't match",
         )
         self.assertListEqual(result["new_objects"], delta_objs, "objects don't match")
+
+    def test_exported_unhashable(self):
+        obj1 = UnhashableTestObject()
+
+        self.expect_result(
+            make_node("test_exported", {"children": [obj1]}),
+            {
+                "__dhElemName": "test_exported",
+                "props": {"children": [{"__dhObid": 0}]},
+            },
+            expected_objects=[obj1],
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
fixes #450 

Plotly express' `Figure` object is unhashable, so it couldn't be a dictionary key. 

Tested with the following snippet:
```
df = px.data.tips()
fig_violin = px.violin(df, y="tip", x="smoker", color="sex", box=True, points="all", hover_data=df.columns)
ui_fig_violin = ui.panel(fig_violin)
```
<img width="742" alt="Screenshot 2024-07-18 at 6 05 31 PM" src="https://github.com/user-attachments/assets/2b4a926e-ba73-4678-88b7-2b8cb09d78a7">
