### PR TITLE
fix: Matplotlib widgets unable to open from old dashboards

### DIFF
--- a/plugins/matplotlib/src/js/src/MatplotlibPlugin.ts
+++ b/plugins/matplotlib/src/js/src/MatplotlibPlugin.ts
@@ -3,7 +3,7 @@ import { vsGraph } from '@deephaven/icons';
 import { MatplotlibView } from './MatplotlibView';
 
 export const MatplotlibPlugin: WidgetPlugin = {
-  name: '@deephaven/js-plugin-matplotlib',
+  name: 'MatPlotLibPanel',
   type: PluginType.WIDGET_PLUGIN,
   supportedTypes: 'matplotlib.figure.Figure',
   component: MatplotlibView,


### PR DESCRIPTION
- We changed the name of the registered component from `MatPlotLibPanel` to `@deephaven/js-plugin-matplotlib`, but there was no proper migration path for users
- Just revert the name of the registered component, as that's the simplest fix for MatPlotLib. We can look at one of the following options going forward:
  - Migration of stored dashboard data to adhere to newer format
  - Register plugins with multiple names or aliases
  - Fallback to looking at the widget type stored in the metadata to see if any plugins match
