### PR TITLE
feat: ui.text_area

### DIFF
--- a/plugins/ui/src/deephaven/ui/components/__init__.py
+++ b/plugins/ui/src/deephaven/ui/components/__init__.py
@@ -43,6 +43,7 @@ from .tab import tab
 from .table import table
 from .tabs import tabs
 from .text import text
+from .text_area import text_area
 from .text_field import text_field
 from .toggle_button import toggle_button
 from .view import view
@@ -95,6 +96,7 @@ __all__ = [
     "tabs",
     "tab",
     "text",
+    "text_area",
     "text_field",
     "toggle_button",
     "view",

--- a/plugins/ui/src/deephaven/ui/components/text_area.py
+++ b/plugins/ui/src/deephaven/ui/components/text_area.py
@@ -26,7 +26,7 @@ from ..elements import Element
 
 
 def text_area(
-    icon: Element | None = None,
+    icon: Element | str | None = None,
     is_quiet: bool | None = None,
     is_disabled: bool | None = None,
     is_read_only: bool | None = None,

--- a/plugins/ui/src/deephaven/ui/components/text_area.py
+++ b/plugins/ui/src/deephaven/ui/components/text_area.py
@@ -26,6 +26,8 @@ from ..types import Icon
 from .basic import component_element
 from ..elements import Element
 
+from .icon import icon as icon_component
+
 
 def text_area(
     icon: Element | Icon | None = None,
@@ -186,7 +188,7 @@ def text_area(
 
     return component_element(
         "TextArea",
-        icon=icon,
+        icon=icon_component(icon) if type(icon) == str else icon,
         is_quiet=is_quiet,
         is_disabled=is_disabled,
         is_read_only=is_read_only,

--- a/plugins/ui/src/deephaven/ui/components/text_area.py
+++ b/plugins/ui/src/deephaven/ui/components/text_area.py
@@ -1,0 +1,263 @@
+from __future__ import annotations
+from typing import Any, Callable
+from .types import (
+    # Accessibility
+    AriaHasPopup,
+    AriaAutoComplete,
+    # Events
+    FocusEventCallable,
+    KeyboardEventCallable,
+    # Layout
+    AlignSelf,
+    CSSProperties,
+    DimensionValue,
+    JustifySelf,
+    LayoutFlex,
+    Position,
+    LabelPosition,
+    Align,
+    # Validation
+    TextFieldType,
+    TextFieldInputMode,
+    TextFieldValidationState,
+    NecessityIndicator,
+)
+from .basic import component_element
+from ..elements import Element
+
+
+def text_area(
+    icon: Element | None = None,
+    is_quiet: bool | None = None,
+    is_disabled: bool | None = None,
+    is_read_only: bool | None = None,
+    is_required: bool | None = None,
+    description: Any | None = None,
+    error_message: Any | None = None,
+    auto_focus: bool | None = None,
+    value: str | None = None,
+    default_value: str | None = None,
+    label: Any | None = None,
+    auto_complete: str | None = None,
+    max_length: int | None = None,
+    min_length: int | None = None,
+    input_mode: TextFieldInputMode | None = None,
+    name: str | None = None,
+    validation_state: TextFieldValidationState | None = None,
+    label_position: LabelPosition = "top",
+    label_align: Align = "start",
+    necessity_indicator: NecessityIndicator = "icon",
+    contextual_help: Any | None = None,
+    on_focus: FocusEventCallable | None = None,
+    on_blur: FocusEventCallable | None = None,
+    on_focus_change: Callable[[bool], None] | None = None,
+    on_key_down: KeyboardEventCallable | None = None,
+    on_key_up: KeyboardEventCallable | None = None,
+    on_change: Callable[[str], None] | None = None,
+    flex: LayoutFlex | None = None,
+    flex_grow: float | None = None,
+    flex_shrink: float | None = None,
+    flex_basis: DimensionValue | None = None,
+    align_self: AlignSelf | None = None,
+    justify_self: JustifySelf | None = None,
+    order: int | None = None,
+    grid_area: str | None = None,
+    grid_row: str | None = None,
+    grid_row_start: str | None = None,
+    grid_row_end: str | None = None,
+    grid_column: str | None = None,
+    grid_column_start: str | None = None,
+    grid_column_end: str | None = None,
+    margin: DimensionValue | None = None,
+    margin_top: DimensionValue | None = None,
+    margin_bottom: DimensionValue | None = None,
+    margin_start: DimensionValue | None = None,
+    margin_end: DimensionValue | None = None,
+    margin_x: DimensionValue | None = None,
+    margin_y: DimensionValue | None = None,
+    width: DimensionValue | None = None,
+    height: DimensionValue | None = None,
+    min_width: DimensionValue | None = None,
+    min_height: DimensionValue | None = None,
+    max_width: DimensionValue | None = None,
+    max_height: DimensionValue | None = None,
+    position: Position | None = None,
+    top: DimensionValue | None = None,
+    bottom: DimensionValue | None = None,
+    start: DimensionValue | None = None,
+    end: DimensionValue | None = None,
+    left: DimensionValue | None = None,
+    right: DimensionValue | None = None,
+    z_index: int | None = None,
+    is_hidden: bool | None = None,
+    id: str | None = None,
+    exclude_from_tab_order: bool | None = None,
+    aria_active_descendant: str | None = None,
+    aria_auto_complete: AriaAutoComplete | None = None,
+    aria_haspopup: AriaHasPopup | None = None,
+    aria_label: str | None = None,
+    aria_labelledby: str | None = None,
+    aria_describedby: str | None = None,
+    aria_details: str | None = None,
+    aria_errormessage: str | None = None,
+    UNSAFE_class_name: str | None = None,
+    UNSAFE_style: CSSProperties | None = None,
+    # missing properties that are clipboard or composition events
+) -> Element:
+    """
+    TextAreas are multiline text inputs, useful for cases where users have a sizable amount of text to enter. They allow for all customizations that are available to text fields.
+
+    Args:
+        icon: An icon to display at the start of the input
+        is_quiet: Whether the input should be displayed with a quiet style
+        is_disabled: Whether the input should be disabled
+        is_read_only: Whether the input scan be selected but not changed by the user
+        is_required: Whether the input is required before form submission
+        description: A description for the field. Provides a hint such as specific requirements for what to choose.
+        error_message: An error message to display when the field is invalid
+        auto_focus: Whether the input should be focused on page load
+        value: The current value of the input
+        default_value: The default value of the input
+        label: The label for the input
+        auto_complete: Describes the type of autocomplete functionality the input should provide
+        max_length: The maximum number of characters the input can accept
+        input_mode: Hints at the tpye of data that might be entered by the user while editing the element or its contents
+        name: The name of the input, used when submitting an HTML form
+        validation_state: Whether the input should display its "valid" or "invalid" state
+        label_position: The position of the label relative to the input
+        label_align: The alignment of the label relative to the input
+        necessity_indicator: Whether the required state should be shown as an icon or text
+        contextual_help: A ContentualHelp element to place next to the label
+        on_focus: Function called when the button receives focus.
+        on_blur: Function called when the button loses focus.
+        on_focus_change: Function called when the focus state changes.
+        on_key_down: Function called when a key is pressed.
+        on_key_up: Function called when a key is released.
+        on_change: Function called when the input value changes
+        flex: When used in a flex layout, specifies how the element will grow or shrink to fit the space available.
+        flex_grow: When used in a flex layout, specifies how the element will grow to fit the space available.
+        flex_shrink: When used in a flex layout, specifies how the element will shrink to fit the space available.
+        flex_basis: When used in a flex layout, specifies the initial main size of the element.
+        align_self: Overrides the alignItems property of a flex or grid container.
+        justify_self: Species how the element is justified inside a flex or grid container.
+        order: The layout order for the element within a flex or grid container.
+        grid_area: When used in a grid layout specifies, specifies the named grid area that the element should be placed in within the grid.
+        grid_row: When used in a grid layout, specifies the row the element should be placed in within the grid.
+        grid_column: When used in a grid layout, specifies the column the element should be placed in within the grid.
+        grid_row_start: When used in a grid layout, specifies the starting row to span within the grid.
+        grid_row_end: When used in a grid layout, specifies the ending row to span within the grid.
+        grid_column_start: When used in a grid layout, specifies the starting column to span within the grid.
+        grid_column_end: When used in a grid layout, specifies the ending column to span within the grid.
+        margin: The margin for all four sides of the element.
+        margin_top: The margin for the top side of the element.
+        margin_bottom: The margin for the bottom side of the element.
+        margin_start: The margin for the logical start side of the element, depending on layout direction.
+        margin_end: The margin for the logical end side of the element, depending on layout direction.
+        margin_x: The margin for the left and right sides of the element.
+        margin_y: The margin for the top and bottom sides of the element.
+        width: The width of the element.
+        min_width: The minimum width of the element.
+        max_width: The maximum width of the element.
+        height: The height of the element.
+        min_height: The minimum height of the element.
+        max_height: The maximum height of the element.
+        position: The position of the element.
+        top: The distance from the top of the containing element.
+        bottom: The distance from the bottom of the containing element.
+        left: The distance from the left of the containing element.
+        right: The distance from the right of the containing element.
+        start: The distance from the start of the containing element, depending on layout direction.
+        end: The distance from the end of the containing element, depending on layout direction.
+        z_index: The stack order of the element.
+        is_hidden: Whether the element is hidden.
+        id: The unique identifier of the element.
+        exclude_from_tab_order: Whether the element should be excluded from the tab order.
+        aria_active_descendant: Identifies the currently active element when DOM focus is on a composite widget, textbox, group, or application.
+        aria_auto_complete: Indicates whether inputting text could trigger display of one or more predictions of the user's intended value for an input and specifies how predictions would be presented if they are made.
+        aria_label: The label for the element.
+        aria_labelled_by: The id of the element that labels the current element.
+        aria_described_by: The id of the element that describes the current element.
+        aria_details: The id of the element that provides additional information about the current element.
+        aria_errormessage: The id of the element that provides an error message for the current element.
+        UNSAFE_class_name: A CSS class to apply to the element.
+        UNSAFE_style: A CSS style to apply to the element.
+    """
+
+    return component_element(
+        "TextArea",
+        icon=icon,
+        is_quiet=is_quiet,
+        is_disabled=is_disabled,
+        is_read_only=is_read_only,
+        is_required=is_required,
+        description=description,
+        error_message=error_message,
+        auto_focus=auto_focus,
+        value=value,
+        default_value=default_value,
+        label=label,
+        auto_complete=auto_complete,
+        max_length=max_length,
+        min_length=min_length,
+        input_mode=input_mode,
+        name=name,
+        validation_state=validation_state,
+        label_position=label_position,
+        label_align=label_align,
+        necessity_indicator=necessity_indicator,
+        contextual_help=contextual_help,
+        on_focus=on_focus,
+        on_blur=on_blur,
+        on_focus_change=on_focus_change,
+        on_key_down=on_key_down,
+        on_key_up=on_key_up,
+        on_change=on_change,
+        flex=flex,
+        flex_grow=flex_grow,
+        flex_shrink=flex_shrink,
+        flex_basis=flex_basis,
+        align_self=align_self,
+        justify_self=justify_self,
+        order=order,
+        grid_area=grid_area,
+        grid_row=grid_row,
+        grid_row_start=grid_row_start,
+        grid_row_end=grid_row_end,
+        grid_column=grid_column,
+        grid_column_start=grid_column_start,
+        grid_column_end=grid_column_end,
+        margin=margin,
+        margin_top=margin_top,
+        margin_bottom=margin_bottom,
+        margin_start=margin_start,
+        margin_end=margin_end,
+        margin_x=margin_x,
+        margin_y=margin_y,
+        width=width,
+        height=height,
+        min_width=min_width,
+        min_height=min_height,
+        max_width=max_width,
+        max_height=max_height,
+        position=position,
+        top=top,
+        bottom=bottom,
+        start=start,
+        end=end,
+        left=left,
+        right=right,
+        z_index=z_index,
+        is_hidden=is_hidden,
+        id=id,
+        exclude_from_tab_order=exclude_from_tab_order,
+        aria_active_descendant=aria_active_descendant,
+        aria_auto_complete=aria_auto_complete,
+        aria_haspopup=aria_haspopup,
+        aria_label=aria_label,
+        aria_labelledby=aria_labelledby,
+        aria_describedby=aria_describedby,
+        aria_details=aria_details,
+        aria_errormessage=aria_errormessage,
+        UNSAFE_class_name=UNSAFE_class_name,
+        UNSAFE_style=UNSAFE_style,
+    )

--- a/plugins/ui/src/deephaven/ui/components/text_area.py
+++ b/plugins/ui/src/deephaven/ui/components/text_area.py
@@ -21,12 +21,14 @@ from .types import (
     TextFieldValidationState,
     NecessityIndicator,
 )
+
+from ..types import Icon
 from .basic import component_element
 from ..elements import Element
 
 
 def text_area(
-    icon: Element | str | None = None,
+    icon: Element | Icon | None = None,
     is_quiet: bool | None = None,
     is_disabled: bool | None = None,
     is_read_only: bool | None = None,

--- a/plugins/ui/src/deephaven/ui/components/text_area.py
+++ b/plugins/ui/src/deephaven/ui/components/text_area.py
@@ -17,7 +17,6 @@ from .types import (
     LabelPosition,
     Align,
     # Validation
-    TextFieldType,
     TextFieldInputMode,
     TextFieldValidationState,
     NecessityIndicator,
@@ -113,8 +112,8 @@ def text_area(
         is_disabled: Whether the input should be disabled
         is_read_only: Whether the input scan be selected but not changed by the user
         is_required: Whether the input is required before form submission
-        description: A description for the field. Provides a hint such as specific requirements for what to choose.
-        error_message: An error message to display when the field is invalid
+        description: A description for the area. Provides a hint such as specific requirements for what to choose.
+        error_message: An error message to display when the area is invalid
         auto_focus: Whether the input should be focused on page load
         value: The current value of the input
         default_value: The default value of the input

--- a/plugins/ui/src/deephaven/ui/types/types.py
+++ b/plugins/ui/src/deephaven/ui/types/types.py
@@ -27,7 +27,7 @@ DeephavenColor = Literal["salmon", "lemonchiffon"]
 HexColor = str
 Color = Union[DeephavenColor, HexColor]
 
-# TODO: Use list of available icons once created
+# TODO #601: Use list of available icons once created
 Icon = str
 
 

--- a/plugins/ui/src/deephaven/ui/types/types.py
+++ b/plugins/ui/src/deephaven/ui/types/types.py
@@ -27,6 +27,7 @@ DeephavenColor = Literal["salmon", "lemonchiffon"]
 HexColor = str
 Color = Union[DeephavenColor, HexColor]
 
+# TODO: Use list of available icons once created
 Icon = str
 
 

--- a/plugins/ui/src/deephaven/ui/types/types.py
+++ b/plugins/ui/src/deephaven/ui/types/types.py
@@ -27,6 +27,8 @@ DeephavenColor = Literal["salmon", "lemonchiffon"]
 HexColor = str
 Color = Union[DeephavenColor, HexColor]
 
+Icon = str
+
 
 class CellData(TypedDict):
     """

--- a/plugins/ui/src/js/src/elements/TextArea.tsx
+++ b/plugins/ui/src/js/src/elements/TextArea.tsx
@@ -1,14 +1,9 @@
-import React, { useCallback, useState } from 'react';
+import React from 'react';
 import {
   TextArea as DHCTextArea,
   TextAreaProps as DHCTextAreaProps,
 } from '@deephaven/components';
-import Log from '@deephaven/log';
-import { useDebouncedCallback, usePrevious } from '@deephaven/react-hooks';
-
-const log = Log.module('@deephaven/js-plugin-ui/TextArea');
-
-const VALUE_CHANGE_DEBOUNCE = 250;
+import useDebouncedOnChange from './hooks/useDebouncedOnChange';
 
 const EMPTY_FUNCTION = () => undefined;
 
@@ -24,49 +19,19 @@ export function TextArea(props: TextAreaProps): JSX.Element {
     ...otherProps
   } = props;
 
-  const [value, setValue] = useState(propValue ?? defaultValue);
-  const [pending, setPending] = useState(false);
-  const prevPropValue = usePrevious(propValue);
-
-  // Update local value to new propValue if the server sent a new propValue and no user changes have been queued
-  if (
-    propValue !== prevPropValue &&
-    propValue !== value &&
-    propValue !== undefined &&
-    !pending
-  ) {
-    setValue(propValue);
-  }
-
-  const propDebouncedOnChange = useCallback(
-    async (newValue: string) => {
-      try {
-        await propOnChange(newValue);
-      } catch (e) {
-        log.warn('Error returned from onChange', e);
-      }
-      setPending(false);
-    },
-    [propOnChange]
-  );
-
-  const debouncedOnChange = useDebouncedCallback(
-    propDebouncedOnChange,
-    VALUE_CHANGE_DEBOUNCE
-  );
-
-  const onChange = useCallback(
-    (newValue: string) => {
-      setPending(true);
-      debouncedOnChange(newValue);
-      setValue(newValue);
-    },
-    [debouncedOnChange]
+  const [value, onChange] = useDebouncedOnChange<string>(
+    propValue,
+    defaultValue,
+    propOnChange
   );
 
   return (
-    // eslint-disable-next-line react/jsx-props-no-spreading
-    <DHCTextArea value={value} onChange={onChange} {...otherProps} />
+    <DHCTextArea
+      value={value}
+      onChange={onChange}
+      // eslint-disable-next-line react/jsx-props-no-spreading
+      {...otherProps}
+    />
   );
 }
 

--- a/plugins/ui/src/js/src/elements/TextArea.tsx
+++ b/plugins/ui/src/js/src/elements/TextArea.tsx
@@ -12,11 +12,11 @@ const VALUE_CHANGE_DEBOUNCE = 250;
 
 const EMPTY_FUNCTION = () => undefined;
 
-interface TextFieldProps extends DHCTextAreaProps {
+interface TextAreaProps extends DHCTextAreaProps {
   onChange?: (value: string) => Promise<void>;
 }
 
-export function TextArea(props: TextFieldProps): JSX.Element {
+export function TextArea(props: TextAreaProps): JSX.Element {
   const {
     defaultValue = '',
     value: propValue,

--- a/plugins/ui/src/js/src/elements/TextArea.tsx
+++ b/plugins/ui/src/js/src/elements/TextArea.tsx
@@ -1,0 +1,75 @@
+import React, { useCallback, useState } from 'react';
+import {
+  TextArea as DHCTextArea,
+  TextAreaProps as DHCTextAreaProps,
+} from '@deephaven/components';
+import Log from '@deephaven/log';
+import { useDebouncedCallback, usePrevious } from '@deephaven/react-hooks';
+
+const log = Log.module('@deephaven/js-plugin-ui/TextArea');
+
+const VALUE_CHANGE_DEBOUNCE = 250;
+
+const EMPTY_FUNCTION = () => undefined;
+
+interface TextFieldProps extends DHCTextAreaProps {
+  onChange?: (value: string) => Promise<void>;
+}
+
+export function TextArea(props: TextFieldProps): JSX.Element {
+  const {
+    defaultValue = '',
+    value: propValue,
+    onChange: propOnChange = EMPTY_FUNCTION,
+    ...otherProps
+  } = props;
+
+  const [value, setValue] = useState(propValue ?? defaultValue);
+  const [pending, setPending] = useState(false);
+  const prevPropValue = usePrevious(propValue);
+
+  // Update local value to new propValue if the server sent a new propValue and no user changes have been queued
+  if (
+    propValue !== prevPropValue &&
+    propValue !== value &&
+    propValue !== undefined &&
+    !pending
+  ) {
+    setValue(propValue);
+  }
+
+  const propDebouncedOnChange = useCallback(
+    async (newValue: string) => {
+      try {
+        await propOnChange(newValue);
+      } catch (e) {
+        log.warn('Error returned from onChange', e);
+      }
+      setPending(false);
+    },
+    [propOnChange]
+  );
+
+  const debouncedOnChange = useDebouncedCallback(
+    propDebouncedOnChange,
+    VALUE_CHANGE_DEBOUNCE
+  );
+
+  const onChange = useCallback(
+    (newValue: string) => {
+      setPending(true);
+      debouncedOnChange(newValue);
+      setValue(newValue);
+    },
+    [debouncedOnChange]
+  );
+
+  return (
+    // eslint-disable-next-line react/jsx-props-no-spreading
+    <DHCTextArea value={value} onChange={onChange} {...otherProps} />
+  );
+}
+
+TextArea.displayName = 'TextArea';
+
+export default TextArea;

--- a/plugins/ui/src/js/src/elements/TextArea.tsx
+++ b/plugins/ui/src/js/src/elements/TextArea.tsx
@@ -20,8 +20,7 @@ export function TextArea(props: TextAreaProps): JSX.Element {
   } = props;
 
   const [value, onChange] = useDebouncedOnChange<string>(
-    propValue,
-    defaultValue,
+    propValue ?? defaultValue,
     propOnChange
   );
 

--- a/plugins/ui/src/js/src/elements/TextArea.tsx
+++ b/plugins/ui/src/js/src/elements/TextArea.tsx
@@ -9,8 +9,6 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import useDebouncedOnChange from './hooks/useDebouncedOnChange';
 import { getIcon } from './utils/IconElementUtils';
 
-// const EMPTY_FUNCTION = () => undefined;
-
 interface TextAreaProps extends DHCTextAreaProps {
   onChange?: (value: string) => Promise<void>;
 }

--- a/plugins/ui/src/js/src/elements/TextArea.tsx
+++ b/plugins/ui/src/js/src/elements/TextArea.tsx
@@ -2,12 +2,9 @@ import React from 'react';
 import {
   TextArea as DHCTextArea,
   TextAreaProps as DHCTextAreaProps,
-  Icon,
 } from '@deephaven/components';
 import { EMPTY_FUNCTION } from '@deephaven/utils';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import useDebouncedOnChange from './hooks/useDebouncedOnChange';
-import { getIcon } from './utils/IconElementUtils';
 
 interface TextAreaProps extends DHCTextAreaProps {
   onChange?: (value: string) => Promise<void>;
@@ -18,29 +15,18 @@ export function TextArea(props: TextAreaProps): JSX.Element {
     defaultValue = '',
     value: propValue,
     onChange: propOnChange = EMPTY_FUNCTION,
-    icon: propIcon,
     ...otherProps
   } = props;
 
-  const [value, onChange] = useDebouncedOnChange<string>(
+  const [value, onChange] = useDebouncedOnChange(
     propValue ?? defaultValue,
     propOnChange
   );
-
-  const icon =
-    typeof propIcon === 'string' ? (
-      <Icon>
-        <FontAwesomeIcon icon={getIcon(`deephaven.ui.icons.${propIcon}`)} />
-      </Icon>
-    ) : (
-      propIcon
-    );
 
   return (
     <DHCTextArea
       value={value}
       onChange={onChange}
-      icon={icon}
       // eslint-disable-next-line react/jsx-props-no-spreading
       {...otherProps}
     />

--- a/plugins/ui/src/js/src/elements/TextArea.tsx
+++ b/plugins/ui/src/js/src/elements/TextArea.tsx
@@ -4,11 +4,12 @@ import {
   TextAreaProps as DHCTextAreaProps,
   Icon,
 } from '@deephaven/components';
+import { EMPTY_FUNCTION } from '@deephaven/utils';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import useDebouncedOnChange from './hooks/useDebouncedOnChange';
 import { getIcon } from './utils/IconElementUtils';
 
-const EMPTY_FUNCTION = () => undefined;
+// const EMPTY_FUNCTION = () => undefined;
 
 interface TextAreaProps extends DHCTextAreaProps {
   onChange?: (value: string) => Promise<void>;

--- a/plugins/ui/src/js/src/elements/TextArea.tsx
+++ b/plugins/ui/src/js/src/elements/TextArea.tsx
@@ -2,8 +2,11 @@ import React from 'react';
 import {
   TextArea as DHCTextArea,
   TextAreaProps as DHCTextAreaProps,
+  Icon,
 } from '@deephaven/components';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import useDebouncedOnChange from './hooks/useDebouncedOnChange';
+import { getIcon } from './utils/IconElementUtils';
 
 const EMPTY_FUNCTION = () => undefined;
 
@@ -16,6 +19,7 @@ export function TextArea(props: TextAreaProps): JSX.Element {
     defaultValue = '',
     value: propValue,
     onChange: propOnChange = EMPTY_FUNCTION,
+    icon: propIcon,
     ...otherProps
   } = props;
 
@@ -24,10 +28,20 @@ export function TextArea(props: TextAreaProps): JSX.Element {
     propOnChange
   );
 
+  const icon =
+    typeof propIcon === 'string' ? (
+      <Icon>
+        <FontAwesomeIcon icon={getIcon(`deephaven.ui.icons.${propIcon}`)} />
+      </Icon>
+    ) : (
+      propIcon
+    );
+
   return (
     <DHCTextArea
       value={value}
       onChange={onChange}
+      icon={icon}
       // eslint-disable-next-line react/jsx-props-no-spreading
       {...otherProps}
     />

--- a/plugins/ui/src/js/src/elements/TextField.tsx
+++ b/plugins/ui/src/js/src/elements/TextField.tsx
@@ -20,8 +20,7 @@ export function TextField(props: TextFieldProps): JSX.Element {
   } = props;
 
   const [value, onChange] = useDebouncedOnChange<string>(
-    propValue,
-    defaultValue,
+    propValue ?? defaultValue,
     propOnChange
   );
 

--- a/plugins/ui/src/js/src/elements/hooks/index.ts
+++ b/plugins/ui/src/js/src/elements/hooks/index.ts
@@ -6,3 +6,4 @@ export * from './usePickerProps';
 export * from './usePressEventCallback';
 export * from './useReExportedTable';
 export * from './useSelectionProps';
+export * from './useDebouncedOnChange';

--- a/plugins/ui/src/js/src/elements/hooks/useDebouncedOnChange.ts
+++ b/plugins/ui/src/js/src/elements/hooks/useDebouncedOnChange.ts
@@ -1,0 +1,56 @@
+import { useState, useCallback } from 'react';
+import Log from '@deephaven/log';
+import { useDebouncedCallback, usePrevious } from '@deephaven/react-hooks';
+
+const VALUE_CHANGE_DEBOUNCE = 250;
+
+function useDebouncedOnChange<T = string>(
+  propValue: T | undefined,
+  defaultValue: T,
+  propOnChange: (() => undefined) | ((newValue: T) => Promise<void>)
+): [T, (newValue: T) => void] {
+  const [value, setValue] = useState<T>(propValue ?? defaultValue);
+  const [pending, setPending] = useState(false);
+  const prevPropValue = usePrevious(propValue);
+  const log = Log.module('@deephaven/js-plugin-ui/useDebouncedValue');
+
+  // Update local value to new propValue if the server sent a new propValue and no user changes have been queued
+  if (
+    propValue !== prevPropValue &&
+    propValue !== value &&
+    propValue !== undefined &&
+    !pending
+  ) {
+    setValue(propValue);
+  }
+
+  const propDebouncedOnChange = useCallback(
+    async (newValue: T) => {
+      try {
+        await propOnChange(newValue);
+      } catch (e) {
+        log.warn('Error returned from onChange', e);
+      }
+      setPending(false);
+    },
+    [propOnChange]
+  );
+
+  const debouncedOnChange = useDebouncedCallback(
+    propDebouncedOnChange,
+    VALUE_CHANGE_DEBOUNCE
+  );
+
+  const onChange = useCallback(
+    (newValue: T) => {
+      setPending(true);
+      debouncedOnChange(newValue);
+      setValue(newValue);
+    },
+    [debouncedOnChange]
+  );
+
+  return [value, onChange] as const;
+}
+
+export default useDebouncedOnChange;

--- a/plugins/ui/src/js/src/elements/hooks/useDebouncedOnChange.ts
+++ b/plugins/ui/src/js/src/elements/hooks/useDebouncedOnChange.ts
@@ -33,6 +33,7 @@ function useDebouncedOnChange<T = string>(
       }
       setPending(false);
     },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [propOnChange]
   );
 

--- a/plugins/ui/src/js/src/elements/hooks/useDebouncedOnChange.ts
+++ b/plugins/ui/src/js/src/elements/hooks/useDebouncedOnChange.ts
@@ -5,11 +5,10 @@ import { useDebouncedCallback, usePrevious } from '@deephaven/react-hooks';
 const VALUE_CHANGE_DEBOUNCE = 250;
 
 function useDebouncedOnChange<T = string>(
-  propValue: T | undefined,
-  defaultValue: T,
+  propValue: T,
   propOnChange: (() => undefined) | ((newValue: T) => Promise<void>)
 ): [T, (newValue: T) => void] {
-  const [value, setValue] = useState<T>(propValue ?? defaultValue);
+  const [value, setValue] = useState<T>(propValue);
   const [pending, setPending] = useState(false);
   const prevPropValue = usePrevious(propValue);
   const log = Log.module('@deephaven/js-plugin-ui/useDebouncedValue');

--- a/plugins/ui/src/js/src/elements/hooks/useDebouncedOnChange.ts
+++ b/plugins/ui/src/js/src/elements/hooks/useDebouncedOnChange.ts
@@ -6,7 +6,7 @@ const VALUE_CHANGE_DEBOUNCE = 250;
 
 function useDebouncedOnChange<T = string>(
   propValue: T,
-  propOnChange: (() => undefined) | ((newValue: T) => Promise<void>)
+  propOnChange: (() => void) | ((newValue: T) => Promise<void>)
 ): [T, (newValue: T) => void] {
   const [value, setValue] = useState<T>(propValue);
   const [pending, setPending] = useState(false);

--- a/plugins/ui/src/js/src/elements/hooks/useDebouncedOnChange.ts
+++ b/plugins/ui/src/js/src/elements/hooks/useDebouncedOnChange.ts
@@ -4,7 +4,7 @@ import { useDebouncedCallback, usePrevious } from '@deephaven/react-hooks';
 
 const VALUE_CHANGE_DEBOUNCE = 250;
 
-function useDebouncedOnChange<T = string>(
+function useDebouncedOnChange<T>(
   propValue: T,
   propOnChange: (() => void) | ((newValue: T) => Promise<void>)
 ): [T, (newValue: T) => void] {

--- a/plugins/ui/src/js/src/elements/index.ts
+++ b/plugins/ui/src/js/src/elements/index.ts
@@ -18,5 +18,6 @@ export * from './Slider';
 export * from './Tabs';
 export * from './TabPanels';
 export * from './TextField';
+export * from './TextArea';
 export * from './UITable/UITable';
 export * from './utils';

--- a/plugins/ui/src/js/src/elements/model/ElementConstants.ts
+++ b/plugins/ui/src/js/src/elements/model/ElementConstants.ts
@@ -55,6 +55,7 @@ export const ELEMENT_NAME = {
   tabs: uiComponentName('Tabs'),
   tab: uiComponentName('Tab'),
   text: uiComponentName('Text'),
+  textArea: uiComponentName('TextArea'),
   textField: uiComponentName('TextField'),
   toggleButton: uiComponentName('ToggleButton'),
   view: uiComponentName('View'),

--- a/plugins/ui/src/js/src/widget/WidgetUtils.tsx
+++ b/plugins/ui/src/js/src/widget/WidgetUtils.tsx
@@ -61,6 +61,7 @@ import {
   Slider,
   TabPanels,
   TextField,
+  TextArea,
   UITable,
   Tabs,
 } from '../elements';
@@ -124,6 +125,7 @@ export const elementComponentMap = {
   [ELEMENT_NAME.tab]: Item,
   [ELEMENT_NAME.tabs]: Tabs,
   [ELEMENT_NAME.text]: Text,
+  [ELEMENT_NAME.textArea]: TextArea,
   [ELEMENT_NAME.textField]: TextField,
   [ELEMENT_NAME.toggleButton]: ToggleButton,
   [ELEMENT_NAME.view]: View,


### PR DESCRIPTION
Closes #649 

**Additional Info:**
- Did not include `validate` prop based off this comment on Text Field PR: https://github.com/deephaven/deephaven-plugins/pull/357#discussion_r1523474450

Some of the snippets I had tested with:

```
from deephaven import ui

def test_on_change(new_value):
    print(f"Text changed to {new_value}")

t1 = ui.text_area()
t2 = ui.text_area(on_change=test_on_change)
t3 = ui.text_area(label="Test Label", label_position='side', flex_grow=1.0, flex_shrink=0.75)
t4 = ui.text_area(label="Test Label 2", is_required=True)
t5 = ui.text_area(is_disabled=True, is_hidden=False)
t6 = ui.text_area(is_hidden=True)
t7 = ui.text_area(auto_focus=True)
```