### PR TITLE
fix: DH-17393: Add matplotlib legacy dashboard plugin for DHE

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3000,13 +3000,6 @@
         "url": "https://github.com/sponsors/mysticatea"
       }
     },
-    "node_modules/@deephaven/dashboard-core-plugins/node_modules/redux-thunk": {
-      "version": "2.4.1",
-      "license": "MIT",
-      "peerDependencies": {
-        "redux": "^4"
-      }
-    },
     "node_modules/@deephaven/dashboard/node_modules/@deephaven/react-hooks": {
       "version": "0.40.1",
       "license": "Apache-2.0",
@@ -3957,13 +3950,6 @@
       },
       "peerDependencies": {
         "redux": "^4.2.0"
-      }
-    },
-    "node_modules/@deephaven/redux/node_modules/redux-thunk": {
-      "version": "2.4.1",
-      "license": "MIT",
-      "peerDependencies": {
-        "redux": "^4"
       }
     },
     "node_modules/@deephaven/storage": {
@@ -13456,6 +13442,7 @@
     },
     "node_modules/color-convert": {
       "version": "1.9.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "1.1.3"
@@ -15790,6 +15777,7 @@
     },
     "node_modules/event-target-shim": {
       "version": "5.0.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -26965,6 +26953,14 @@
         "@babel/runtime": "^7.9.2"
       }
     },
+    "node_modules/redux-thunk": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.4.1.tgz",
+      "integrity": "sha512-OOYGNY5Jy2TWvTL1KgAlVy6dcx3siPJ1wTq741EPyUKfn6W6nChdICjZwCd0p8AZBs5kWpZlbkXW2nE/zjUa+Q==",
+      "peerDependencies": {
+        "redux": "^4"
+      }
+    },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.4",
       "dev": true,
@@ -31238,65 +31234,46 @@
       "version": "0.4.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@deephaven/components": "^0.58.0",
-        "@deephaven/dashboard": "^0.58.0",
-        "@deephaven/icons": "^0.58.0",
-        "@deephaven/jsapi-bootstrap": "^0.58.0",
-        "@deephaven/jsapi-types": "^0.58.0",
-        "@deephaven/log": "^0.58.0",
-        "@deephaven/plugin": "^0.58.0"
+        "@deephaven/components": "^0.87.0",
+        "@deephaven/dashboard": "^0.86.0",
+        "@deephaven/icons": "^0.87.0",
+        "@deephaven/jsapi-bootstrap": "^0.87.0",
+        "@deephaven/jsapi-types": "1.0.0-dev0.35.2",
+        "@deephaven/log": "^0.87.0",
+        "@deephaven/plugin": "^0.86.0",
+        "nanoid": "^5.0.7"
       },
       "devDependencies": {
         "@types/react": "^17.0.2",
         "@types/react-dom": "^17.0.2",
         "@vitejs/plugin-react-swc": "^3.0.0",
         "react": "^17.0.2",
+        "react-dom": "^17.0.2",
         "typescript": "^4.5.4",
         "vite": "~4.1.4"
       },
       "peerDependencies": {
-        "react": "^17.0.2"
-      }
-    },
-    "plugins/matplotlib/src/js/node_modules/@deephaven/chart": {
-      "version": "0.58.0",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@deephaven/components": "^0.58.0",
-        "@deephaven/icons": "^0.58.0",
-        "@deephaven/jsapi-types": "^0.58.0",
-        "@deephaven/jsapi-utils": "^0.58.0",
-        "@deephaven/log": "^0.58.0",
-        "@deephaven/react-hooks": "^0.58.0",
-        "@deephaven/utils": "^0.58.0",
-        "deep-equal": "^2.0.5",
-        "lodash.debounce": "^4.0.8",
-        "lodash.set": "^4.3.2",
-        "memoize-one": "^5.1.1",
-        "memoizee": "^0.4.15",
-        "plotly.js": "^2.18.2",
-        "prop-types": "^15.7.2",
-        "react-plotly.js": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "peerDependencies": {
-        "react": "^17.x"
+        "react": "^17.0.2",
+        "react-dom": "^17.0.2"
       }
     },
     "plugins/matplotlib/src/js/node_modules/@deephaven/components": {
-      "version": "0.58.0",
-      "license": "Apache-2.0",
+      "version": "0.87.0",
+      "resolved": "https://registry.npmjs.org/@deephaven/components/-/components-0.87.0.tgz",
+      "integrity": "sha512-X/I7qkkZie0UKKf9T9CvVkEu5l2BzvoURx3+mIOvYXf5yRwUdSrPgI5GCnZepNWfyY1f6kzwtUiSt8J7OHPj9Q==",
       "dependencies": {
-        "@adobe/react-spectrum": "^3.29.0",
-        "@deephaven/icons": "^0.58.0",
-        "@deephaven/log": "^0.58.0",
-        "@deephaven/react-hooks": "^0.58.0",
-        "@deephaven/utils": "^0.58.0",
+        "@adobe/react-spectrum": "3.35.1",
+        "@deephaven/icons": "^0.87.0",
+        "@deephaven/log": "^0.87.0",
+        "@deephaven/react-hooks": "^0.87.0",
+        "@deephaven/utils": "^0.87.0",
         "@fortawesome/fontawesome-svg-core": "^6.2.1",
         "@fortawesome/react-fontawesome": "^0.2.0",
         "@react-spectrum/theme-default": "^3.5.1",
+        "@react-spectrum/utils": "^3.11.5",
+        "@react-types/radio": "^3.8.1",
+        "@react-types/shared": "^3.22.1",
+        "@react-types/textfield": "^3.9.1",
         "bootstrap": "4.6.2",
         "classnames": "^2.3.1",
         "event-target-shim": "^6.0.2",
@@ -31304,35 +31281,426 @@
         "lodash.debounce": "^4.0.8",
         "lodash.flatten": "^4.4.0",
         "memoizee": "^0.4.15",
+        "nanoid": "^5.0.7",
         "popper.js": "^1.16.1",
         "prop-types": "^15.7.2",
         "react-beautiful-dnd": "^13.1.0",
         "react-transition-group": "^4.4.2",
         "react-virtualized-auto-sizer": "1.0.6",
-        "react-window": "^1.8.6",
-        "shortid": "^2.2.16"
+        "react-window": "^1.8.6"
       },
       "engines": {
         "node": ">=10"
       },
       "peerDependencies": {
-        "react": "^17.x",
-        "react-dom": "^17.x"
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0",
+        "react-is": ">=16.8.0"
       }
     },
-    "plugins/matplotlib/src/js/node_modules/@deephaven/console": {
-      "version": "0.58.0",
-      "license": "Apache-2.0",
+    "plugins/matplotlib/src/js/node_modules/@deephaven/components/node_modules/@deephaven/react-hooks": {
+      "version": "0.87.0",
+      "resolved": "https://registry.npmjs.org/@deephaven/react-hooks/-/react-hooks-0.87.0.tgz",
+      "integrity": "sha512-5PMDsHAAGawF53Th4vEqsyImJdioqIbw0+1o2X0pnQSOfhIda/OqCoq1a16cCHxwcpjWaMvI5BvTRe45HMZHIw==",
       "dependencies": {
-        "@deephaven/chart": "^0.58.0",
-        "@deephaven/components": "^0.58.0",
-        "@deephaven/icons": "^0.58.0",
-        "@deephaven/jsapi-bootstrap": "^0.58.0",
-        "@deephaven/jsapi-types": "^0.58.0",
-        "@deephaven/log": "^0.58.0",
-        "@deephaven/react-hooks": "^0.58.0",
-        "@deephaven/storage": "^0.58.0",
-        "@deephaven/utils": "^0.58.0",
+        "@adobe/react-spectrum": "3.35.1",
+        "@deephaven/log": "^0.87.0",
+        "@deephaven/utils": "^0.87.0",
+        "lodash.debounce": "^4.0.8",
+        "lodash.throttle": "^4.1.1",
+        "nanoid": "^5.0.7"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "plugins/matplotlib/src/js/node_modules/@deephaven/dashboard": {
+      "version": "0.86.0",
+      "resolved": "https://registry.npmjs.org/@deephaven/dashboard/-/dashboard-0.86.0.tgz",
+      "integrity": "sha512-zhWC7xTS+lxOJTEjhvjAI3JSFhU1BKz1SsjkzbJklaiBLa8yQNQmwM4WViMCyjApNhJMcmo3RdCMrF9aDLI/QA==",
+      "dependencies": {
+        "@deephaven/components": "^0.86.0",
+        "@deephaven/golden-layout": "^0.86.0",
+        "@deephaven/log": "^0.86.0",
+        "@deephaven/react-hooks": "^0.86.0",
+        "@deephaven/redux": "^0.86.0",
+        "@deephaven/utils": "^0.86.0",
+        "fast-deep-equal": "^3.1.3",
+        "lodash.ismatch": "^4.1.1",
+        "lodash.throttle": "^4.1.1",
+        "nanoid": "^5.0.7",
+        "prop-types": "^15.7.2"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0",
+        "react-redux": "^7.2.4"
+      }
+    },
+    "plugins/matplotlib/src/js/node_modules/@deephaven/dashboard/node_modules/@deephaven/components": {
+      "version": "0.86.0",
+      "resolved": "https://registry.npmjs.org/@deephaven/components/-/components-0.86.0.tgz",
+      "integrity": "sha512-DZslAyK5SDI8bV/u8eIrIcILY7rX53lkAIBepRgbbONV/e9uJYvEcB3m81ggmHB0j5hlGioomY9SmTSpwMwlmQ==",
+      "dependencies": {
+        "@adobe/react-spectrum": "3.35.1",
+        "@deephaven/icons": "^0.86.0",
+        "@deephaven/log": "^0.86.0",
+        "@deephaven/react-hooks": "^0.86.0",
+        "@deephaven/utils": "^0.86.0",
+        "@fortawesome/fontawesome-svg-core": "^6.2.1",
+        "@fortawesome/react-fontawesome": "^0.2.0",
+        "@react-spectrum/theme-default": "^3.5.1",
+        "@react-spectrum/utils": "^3.11.5",
+        "@react-types/radio": "^3.8.1",
+        "@react-types/shared": "^3.22.1",
+        "@react-types/textfield": "^3.9.1",
+        "bootstrap": "4.6.2",
+        "classnames": "^2.3.1",
+        "event-target-shim": "^6.0.2",
+        "lodash.clamp": "^4.0.3",
+        "lodash.debounce": "^4.0.8",
+        "lodash.flatten": "^4.4.0",
+        "memoizee": "^0.4.15",
+        "nanoid": "^5.0.7",
+        "popper.js": "^1.16.1",
+        "prop-types": "^15.7.2",
+        "react-beautiful-dnd": "^13.1.0",
+        "react-transition-group": "^4.4.2",
+        "react-virtualized-auto-sizer": "1.0.6",
+        "react-window": "^1.8.6"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0",
+        "react-is": ">=16.8.0"
+      }
+    },
+    "plugins/matplotlib/src/js/node_modules/@deephaven/dashboard/node_modules/@deephaven/components/node_modules/@deephaven/icons": {
+      "version": "0.86.0",
+      "resolved": "https://registry.npmjs.org/@deephaven/icons/-/icons-0.86.0.tgz",
+      "integrity": "sha512-/sMhQ4eW1J6K/8mppoGkBBV64g9jNINWZAIgu5yl1zBXqdKNysYgvBz+YYjpP752P/fCZhZVpmVbEBwpQvHYwg==",
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "^6.1.1"
+      },
+      "peerDependencies": {
+        "@fortawesome/fontawesome-svg-core": "^6.2.1",
+        "@fortawesome/react-fontawesome": "^0.2.0"
+      }
+    },
+    "plugins/matplotlib/src/js/node_modules/@deephaven/dashboard/node_modules/@deephaven/golden-layout": {
+      "version": "0.86.0",
+      "resolved": "https://registry.npmjs.org/@deephaven/golden-layout/-/golden-layout-0.86.0.tgz",
+      "integrity": "sha512-S9lckwF482Is3E8+HGx98rvvV9GuOblWNW09UI7kuNNkynnOUIcTW8bVdDWfVGIvXMawkKso2uCtJAXzDiRK2w==",
+      "dependencies": {
+        "@deephaven/components": "^0.86.0",
+        "jquery": "^3.6.0",
+        "nanoid": "^5.0.7"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "plugins/matplotlib/src/js/node_modules/@deephaven/dashboard/node_modules/@deephaven/log": {
+      "version": "0.86.0",
+      "resolved": "https://registry.npmjs.org/@deephaven/log/-/log-0.86.0.tgz",
+      "integrity": "sha512-VgldfD7weCUhtsSFy2KLBRGcgfmIVepZ0rSkyCVVwNLxtu+7BwsJ68uKxOtsUvD+HXHpJkzJZ0MBA8K29lTH6g==",
+      "dependencies": {
+        "event-target-shim": "^6.0.2"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "plugins/matplotlib/src/js/node_modules/@deephaven/dashboard/node_modules/@deephaven/react-hooks": {
+      "version": "0.86.0",
+      "resolved": "https://registry.npmjs.org/@deephaven/react-hooks/-/react-hooks-0.86.0.tgz",
+      "integrity": "sha512-wm3GRJvf6k2+6Uf3fVotf2BeD0DGW0rwIz7etPtlyi1AxTvJcFN6mKLz0iV27Z36i0GG5QkiCPpiou5meML0Rg==",
+      "dependencies": {
+        "@adobe/react-spectrum": "3.35.1",
+        "@deephaven/log": "^0.86.0",
+        "@deephaven/utils": "^0.86.0",
+        "lodash.debounce": "^4.0.8",
+        "lodash.throttle": "^4.1.1",
+        "nanoid": "^5.0.7"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "plugins/matplotlib/src/js/node_modules/@deephaven/dashboard/node_modules/@deephaven/utils": {
+      "version": "0.86.0",
+      "resolved": "https://registry.npmjs.org/@deephaven/utils/-/utils-0.86.0.tgz",
+      "integrity": "sha512-zZdxoHxhuSSxQpCZWlJFo1jEoNThIyyGosMUvFyaMiwgsQbvR+4LxBFXXkXBfqNrUPqYWXhgcSIOcdr/+pL1Gg==",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "plugins/matplotlib/src/js/node_modules/@deephaven/filters": {
+      "version": "0.86.0",
+      "resolved": "https://registry.npmjs.org/@deephaven/filters/-/filters-0.86.0.tgz",
+      "integrity": "sha512-iAjO1hcuE9m73YyzWnZJLSyDJfgcOluFljMDLop6IRI3ie7bFwCoLnnPEeJdP3wkDNVGH3sUtfrkFE3uLfxiUw==",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "plugins/matplotlib/src/js/node_modules/@deephaven/icons": {
+      "version": "0.87.0",
+      "resolved": "https://registry.npmjs.org/@deephaven/icons/-/icons-0.87.0.tgz",
+      "integrity": "sha512-2q+HUkW9pByPG81LLqRo/reem6EcZhgC/NKISOR9roeL2rASq8E+Xq4Yg2gW2zlXy6fSGi8e5q887Ynby4TGgQ==",
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "^6.1.1"
+      },
+      "peerDependencies": {
+        "@fortawesome/fontawesome-svg-core": "^6.2.1",
+        "@fortawesome/react-fontawesome": "^0.2.0"
+      }
+    },
+    "plugins/matplotlib/src/js/node_modules/@deephaven/jsapi-bootstrap": {
+      "version": "0.87.0",
+      "resolved": "https://registry.npmjs.org/@deephaven/jsapi-bootstrap/-/jsapi-bootstrap-0.87.0.tgz",
+      "integrity": "sha512-rsrrPe5JzMlOZV3JmeDGv0V12NkEVtmggzRauA28brBatiEd+TRE0iBbjcmavinhtXB/4NAQ5Xcl6FcvX67Pfg==",
+      "dependencies": {
+        "@deephaven/components": "^0.87.0",
+        "@deephaven/jsapi-types": "^1.0.0-dev0.34.0",
+        "@deephaven/log": "^0.87.0",
+        "@deephaven/react-hooks": "^0.87.0",
+        "@deephaven/utils": "^0.87.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "plugins/matplotlib/src/js/node_modules/@deephaven/jsapi-bootstrap/node_modules/@deephaven/react-hooks": {
+      "version": "0.87.0",
+      "resolved": "https://registry.npmjs.org/@deephaven/react-hooks/-/react-hooks-0.87.0.tgz",
+      "integrity": "sha512-5PMDsHAAGawF53Th4vEqsyImJdioqIbw0+1o2X0pnQSOfhIda/OqCoq1a16cCHxwcpjWaMvI5BvTRe45HMZHIw==",
+      "dependencies": {
+        "@adobe/react-spectrum": "3.35.1",
+        "@deephaven/log": "^0.87.0",
+        "@deephaven/utils": "^0.87.0",
+        "lodash.debounce": "^4.0.8",
+        "lodash.throttle": "^4.1.1",
+        "nanoid": "^5.0.7"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "plugins/matplotlib/src/js/node_modules/@deephaven/jsapi-types": {
+      "version": "1.0.0-dev0.35.2",
+      "resolved": "https://registry.npmjs.org/@deephaven/jsapi-types/-/jsapi-types-1.0.0-dev0.35.2.tgz",
+      "integrity": "sha512-VM1WAps/+KEXdxIiaEGutcjgaf5p1LNf6AA+Hv7sTIaENYYJpndZqD6bGFcuuiUVTYDlnFF0hohN4l6lOsjcQw=="
+    },
+    "plugins/matplotlib/src/js/node_modules/@deephaven/jsapi-utils": {
+      "version": "0.86.0",
+      "resolved": "https://registry.npmjs.org/@deephaven/jsapi-utils/-/jsapi-utils-0.86.0.tgz",
+      "integrity": "sha512-HnKAEWLwZuF7KRt5sU6CIdS2P+NSIj9UfV2SLRoFB+eN70dLm6+E+Rsw2Q1msPRC9SYa4sdtoF6qKp7Djf/7iw==",
+      "dependencies": {
+        "@deephaven/filters": "^0.86.0",
+        "@deephaven/jsapi-types": "^1.0.0-dev0.34.0",
+        "@deephaven/log": "^0.86.0",
+        "@deephaven/utils": "^0.86.0",
+        "lodash.clamp": "^4.0.3",
+        "nanoid": "^5.0.7"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "plugins/matplotlib/src/js/node_modules/@deephaven/jsapi-utils/node_modules/@deephaven/log": {
+      "version": "0.86.0",
+      "resolved": "https://registry.npmjs.org/@deephaven/log/-/log-0.86.0.tgz",
+      "integrity": "sha512-VgldfD7weCUhtsSFy2KLBRGcgfmIVepZ0rSkyCVVwNLxtu+7BwsJ68uKxOtsUvD+HXHpJkzJZ0MBA8K29lTH6g==",
+      "dependencies": {
+        "event-target-shim": "^6.0.2"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "plugins/matplotlib/src/js/node_modules/@deephaven/jsapi-utils/node_modules/@deephaven/utils": {
+      "version": "0.86.0",
+      "resolved": "https://registry.npmjs.org/@deephaven/utils/-/utils-0.86.0.tgz",
+      "integrity": "sha512-zZdxoHxhuSSxQpCZWlJFo1jEoNThIyyGosMUvFyaMiwgsQbvR+4LxBFXXkXBfqNrUPqYWXhgcSIOcdr/+pL1Gg==",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "plugins/matplotlib/src/js/node_modules/@deephaven/log": {
+      "version": "0.87.0",
+      "resolved": "https://registry.npmjs.org/@deephaven/log/-/log-0.87.0.tgz",
+      "integrity": "sha512-hq2szL3DRBVPuv5OrIfEiFIg4MYHwICiALWFNCPNkX7isESOv/6LBxpFXOgnUAtzFsL7X1Cv3bbUtMacxw9uvA==",
+      "dependencies": {
+        "event-target-shim": "^6.0.2"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "plugins/matplotlib/src/js/node_modules/@deephaven/plugin": {
+      "version": "0.86.0",
+      "resolved": "https://registry.npmjs.org/@deephaven/plugin/-/plugin-0.86.0.tgz",
+      "integrity": "sha512-oXwidAEE3QMycEjzxturHnG00i0zEli7d4AlDKZ/Yu14vBNcN/uB00Duyrw2AvEXTKspFrtRSKKIGXUJUpWqxA==",
+      "dependencies": {
+        "@deephaven/components": "^0.86.0",
+        "@deephaven/golden-layout": "^0.86.0",
+        "@deephaven/icons": "^0.86.0",
+        "@deephaven/iris-grid": "^0.86.0",
+        "@deephaven/jsapi-types": "^1.0.0-dev0.34.0",
+        "@deephaven/log": "^0.86.0",
+        "@deephaven/react-hooks": "^0.86.0",
+        "@fortawesome/fontawesome-common-types": "^6.1.1",
+        "@fortawesome/react-fontawesome": "^0.2.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "plugins/matplotlib/src/js/node_modules/@deephaven/plugin/node_modules/@deephaven/components": {
+      "version": "0.86.0",
+      "resolved": "https://registry.npmjs.org/@deephaven/components/-/components-0.86.0.tgz",
+      "integrity": "sha512-DZslAyK5SDI8bV/u8eIrIcILY7rX53lkAIBepRgbbONV/e9uJYvEcB3m81ggmHB0j5hlGioomY9SmTSpwMwlmQ==",
+      "dependencies": {
+        "@adobe/react-spectrum": "3.35.1",
+        "@deephaven/icons": "^0.86.0",
+        "@deephaven/log": "^0.86.0",
+        "@deephaven/react-hooks": "^0.86.0",
+        "@deephaven/utils": "^0.86.0",
+        "@fortawesome/fontawesome-svg-core": "^6.2.1",
+        "@fortawesome/react-fontawesome": "^0.2.0",
+        "@react-spectrum/theme-default": "^3.5.1",
+        "@react-spectrum/utils": "^3.11.5",
+        "@react-types/radio": "^3.8.1",
+        "@react-types/shared": "^3.22.1",
+        "@react-types/textfield": "^3.9.1",
+        "bootstrap": "4.6.2",
+        "classnames": "^2.3.1",
+        "event-target-shim": "^6.0.2",
+        "lodash.clamp": "^4.0.3",
+        "lodash.debounce": "^4.0.8",
+        "lodash.flatten": "^4.4.0",
+        "memoizee": "^0.4.15",
+        "nanoid": "^5.0.7",
+        "popper.js": "^1.16.1",
+        "prop-types": "^15.7.2",
+        "react-beautiful-dnd": "^13.1.0",
+        "react-transition-group": "^4.4.2",
+        "react-virtualized-auto-sizer": "1.0.6",
+        "react-window": "^1.8.6"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0",
+        "react-is": ">=16.8.0"
+      }
+    },
+    "plugins/matplotlib/src/js/node_modules/@deephaven/plugin/node_modules/@deephaven/golden-layout": {
+      "version": "0.86.0",
+      "resolved": "https://registry.npmjs.org/@deephaven/golden-layout/-/golden-layout-0.86.0.tgz",
+      "integrity": "sha512-S9lckwF482Is3E8+HGx98rvvV9GuOblWNW09UI7kuNNkynnOUIcTW8bVdDWfVGIvXMawkKso2uCtJAXzDiRK2w==",
+      "dependencies": {
+        "@deephaven/components": "^0.86.0",
+        "jquery": "^3.6.0",
+        "nanoid": "^5.0.7"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "plugins/matplotlib/src/js/node_modules/@deephaven/plugin/node_modules/@deephaven/icons": {
+      "version": "0.86.0",
+      "resolved": "https://registry.npmjs.org/@deephaven/icons/-/icons-0.86.0.tgz",
+      "integrity": "sha512-/sMhQ4eW1J6K/8mppoGkBBV64g9jNINWZAIgu5yl1zBXqdKNysYgvBz+YYjpP752P/fCZhZVpmVbEBwpQvHYwg==",
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "^6.1.1"
+      },
+      "peerDependencies": {
+        "@fortawesome/fontawesome-svg-core": "^6.2.1",
+        "@fortawesome/react-fontawesome": "^0.2.0"
+      }
+    },
+    "plugins/matplotlib/src/js/node_modules/@deephaven/plugin/node_modules/@deephaven/iris-grid": {
+      "version": "0.86.0",
+      "resolved": "https://registry.npmjs.org/@deephaven/iris-grid/-/iris-grid-0.86.0.tgz",
+      "integrity": "sha512-g5M5YoWZGe6MCr8ltnTDEtK7QvlHnd1d5cXwZkpLOfEYsFOf6mcmJVK/p7XmjcyElsdLe9dT93YQiTfVzNnQrQ==",
+      "dependencies": {
+        "@deephaven/components": "^0.86.0",
+        "@deephaven/console": "^0.86.0",
+        "@deephaven/filters": "^0.86.0",
+        "@deephaven/grid": "^0.86.0",
+        "@deephaven/icons": "^0.86.0",
+        "@deephaven/jsapi-components": "^0.86.0",
+        "@deephaven/jsapi-types": "^1.0.0-dev0.34.0",
+        "@deephaven/jsapi-utils": "^0.86.0",
+        "@deephaven/log": "^0.86.0",
+        "@deephaven/react-hooks": "^0.86.0",
+        "@deephaven/storage": "^0.86.0",
+        "@deephaven/utils": "^0.86.0",
+        "@dnd-kit/core": "^6.1.0",
+        "@dnd-kit/sortable": "^7.0.2",
+        "@dnd-kit/utilities": "^3.2.2",
+        "@fortawesome/react-fontawesome": "^0.2.0",
+        "classnames": "^2.3.1",
+        "fast-deep-equal": "^3.1.3",
+        "lodash.clamp": "^4.0.3",
+        "lodash.debounce": "^4.0.8",
+        "lodash.throttle": "^4.1.1",
+        "memoize-one": "^5.1.1",
+        "memoizee": "^0.4.15",
+        "monaco-editor": "^0.41.0",
+        "nanoid": "^5.0.7",
+        "prop-types": "^15.7.2",
+        "react-beautiful-dnd": "^13.1.0",
+        "react-transition-group": "^4.4.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "plugins/matplotlib/src/js/node_modules/@deephaven/plugin/node_modules/@deephaven/iris-grid/node_modules/@deephaven/console": {
+      "version": "0.86.0",
+      "resolved": "https://registry.npmjs.org/@deephaven/console/-/console-0.86.0.tgz",
+      "integrity": "sha512-BLCi1o9oNXAY/cdHnXQURASnCznXwFQUScQwe0wUpXt/9MYrqJkblP96Iv1Egs+TW3O8XHsO3e5/g6dw9juTBQ==",
+      "dependencies": {
+        "@deephaven/chart": "^0.86.0",
+        "@deephaven/components": "^0.86.0",
+        "@deephaven/icons": "^0.86.0",
+        "@deephaven/jsapi-bootstrap": "^0.86.0",
+        "@deephaven/jsapi-types": "^1.0.0-dev0.34.0",
+        "@deephaven/log": "^0.86.0",
+        "@deephaven/react-hooks": "^0.86.0",
+        "@deephaven/storage": "^0.86.0",
+        "@deephaven/utils": "^0.86.0",
         "@fortawesome/react-fontawesome": "^0.2.0",
         "classnames": "^2.3.1",
         "linkifyjs": "^4.1.0",
@@ -31341,70 +31709,73 @@
         "memoize-one": "^5.1.1",
         "memoizee": "^0.4.15",
         "monaco-editor": "^0.41.0",
+        "nanoid": "^5.0.7",
         "papaparse": "5.3.2",
         "popper.js": "^1.16.1",
         "prop-types": "^15.7.2",
-        "shell-quote": "^1.7.2",
-        "shortid": "^2.2.16"
+        "shell-quote": "^1.7.2"
       },
       "engines": {
         "node": ">=16"
       },
       "peerDependencies": {
-        "react": "^17.x",
-        "react-dom": "^17.x"
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
       }
     },
-    "plugins/matplotlib/src/js/node_modules/@deephaven/dashboard": {
-      "version": "0.58.0",
-      "license": "Apache-2.0",
+    "plugins/matplotlib/src/js/node_modules/@deephaven/plugin/node_modules/@deephaven/iris-grid/node_modules/@deephaven/console/node_modules/@deephaven/chart": {
+      "version": "0.86.0",
+      "resolved": "https://registry.npmjs.org/@deephaven/chart/-/chart-0.86.0.tgz",
+      "integrity": "sha512-e9Fk2KCsKjGiNlNPJbBUilhdVCp61wTNkWCC4JA7o3zSO1DFO75e9fWvfNQTr4AVCIDTLSbqv2AoRLXnmvD86w==",
       "dependencies": {
-        "@deephaven/components": "^0.58.0",
-        "@deephaven/golden-layout": "^0.58.0",
-        "@deephaven/log": "^0.58.0",
-        "@deephaven/react-hooks": "^0.58.0",
-        "@deephaven/redux": "^0.58.0",
-        "@deephaven/utils": "^0.58.0",
-        "deep-equal": "^2.0.5",
-        "lodash.ismatch": "^4.1.1",
-        "lodash.throttle": "^4.1.1",
+        "@deephaven/components": "^0.86.0",
+        "@deephaven/icons": "^0.86.0",
+        "@deephaven/jsapi-types": "^1.0.0-dev0.34.0",
+        "@deephaven/jsapi-utils": "^0.86.0",
+        "@deephaven/log": "^0.86.0",
+        "@deephaven/react-hooks": "^0.86.0",
+        "@deephaven/utils": "^0.86.0",
+        "buffer": "^6.0.3",
+        "fast-deep-equal": "^3.1.3",
+        "lodash.debounce": "^4.0.8",
+        "lodash.set": "^4.3.2",
+        "memoize-one": "^5.1.1",
+        "memoizee": "^0.4.15",
+        "plotly.js": "^2.29.1",
         "prop-types": "^15.7.2",
-        "shortid": "^2.2.16"
+        "react-plotly.js": "^2.6.0"
       },
       "engines": {
         "node": ">=16"
       },
       "peerDependencies": {
-        "react": "^17.0.0",
-        "react-dom": "^17.0.0",
-        "react-is": "^17.0.0",
-        "react-redux": "^7.2.4"
+        "react": ">=16.8.0"
       }
     },
-    "plugins/matplotlib/src/js/node_modules/@deephaven/filters": {
-      "version": "0.58.0",
-      "license": "Apache-2.0",
+    "plugins/matplotlib/src/js/node_modules/@deephaven/plugin/node_modules/@deephaven/iris-grid/node_modules/@deephaven/console/node_modules/@deephaven/jsapi-bootstrap": {
+      "version": "0.86.0",
+      "resolved": "https://registry.npmjs.org/@deephaven/jsapi-bootstrap/-/jsapi-bootstrap-0.86.0.tgz",
+      "integrity": "sha512-pVlPxcEsIwAv7rvBlAhmVeqFdWRwfXpoAbJC6AgdFM8v/CNbTnlBOyocaifE99dnQTGtJTrjheCNrEpJgm372g==",
+      "dependencies": {
+        "@deephaven/components": "^0.86.0",
+        "@deephaven/jsapi-types": "^1.0.0-dev0.34.0",
+        "@deephaven/log": "^0.86.0",
+        "@deephaven/react-hooks": "^0.86.0",
+        "@deephaven/utils": "^0.86.0"
+      },
       "engines": {
         "node": ">=16"
-      }
-    },
-    "plugins/matplotlib/src/js/node_modules/@deephaven/golden-layout": {
-      "version": "0.58.0",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@deephaven/components": "^0.58.0",
-        "jquery": "^3.6.0"
       },
       "peerDependencies": {
-        "react": "^17.x",
-        "react-dom": "^17.x"
+        "react": ">=16.8.0"
       }
     },
-    "plugins/matplotlib/src/js/node_modules/@deephaven/grid": {
-      "version": "0.58.0",
-      "license": "Apache-2.0",
+    "plugins/matplotlib/src/js/node_modules/@deephaven/plugin/node_modules/@deephaven/iris-grid/node_modules/@deephaven/grid": {
+      "version": "0.86.0",
+      "resolved": "https://registry.npmjs.org/@deephaven/grid/-/grid-0.86.0.tgz",
+      "integrity": "sha512-lRCn4Cjd05jU58vfeZN8QTm9MRwWtUBdXfpGrkIBBHJytG/I9D8+abNyG3TQ1z4NPTzqf+51IGnr/E8Fgim8Ew==",
       "dependencies": {
-        "@deephaven/utils": "^0.58.0",
+        "@deephaven/utils": "^0.86.0",
         "classnames": "^2.3.1",
         "color-convert": "^2.0.1",
         "event-target-shim": "^6.0.2",
@@ -31418,101 +31789,72 @@
         "node": ">=16"
       },
       "peerDependencies": {
-        "react": "^17.x"
+        "react": ">=16.8.0"
       }
     },
-    "plugins/matplotlib/src/js/node_modules/@deephaven/icons": {
-      "version": "0.58.0",
-      "license": "Apache-2.0",
+    "plugins/matplotlib/src/js/node_modules/@deephaven/plugin/node_modules/@deephaven/iris-grid/node_modules/@deephaven/jsapi-components": {
+      "version": "0.86.0",
+      "resolved": "https://registry.npmjs.org/@deephaven/jsapi-components/-/jsapi-components-0.86.0.tgz",
+      "integrity": "sha512-hWRk6JFC3MxSG8UP9FdCt5OK8Q9lPbIVGB/bDMChS9w/qQcrD87ry+KmGJqnggyKouUoMj2ljdL99xhwhurF8g==",
       "dependencies": {
-        "@fortawesome/fontawesome-common-types": "^6.1.1"
-      },
-      "peerDependencies": {
-        "@fortawesome/fontawesome-svg-core": "^6.2.1",
-        "@fortawesome/react-fontawesome": "^0.2.0"
-      }
-    },
-    "plugins/matplotlib/src/js/node_modules/@deephaven/iris-grid": {
-      "version": "0.58.0",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@deephaven/components": "^0.58.0",
-        "@deephaven/console": "^0.58.0",
-        "@deephaven/filters": "^0.58.0",
-        "@deephaven/grid": "^0.58.0",
-        "@deephaven/icons": "^0.58.0",
-        "@deephaven/jsapi-types": "^0.58.0",
-        "@deephaven/jsapi-utils": "^0.58.0",
-        "@deephaven/log": "^0.58.0",
-        "@deephaven/react-hooks": "^0.58.0",
-        "@deephaven/storage": "^0.58.0",
-        "@deephaven/utils": "^0.58.0",
-        "@dnd-kit/core": "^6.0.5",
-        "@dnd-kit/sortable": "^7.0.0",
-        "@dnd-kit/utilities": "^3.2.0",
-        "@fortawesome/react-fontawesome": "^0.2.0",
-        "classnames": "^2.3.1",
-        "deep-equal": "^2.0.5",
-        "lodash.clamp": "^4.0.3",
+        "@deephaven/components": "^0.86.0",
+        "@deephaven/jsapi-bootstrap": "^0.86.0",
+        "@deephaven/jsapi-types": "^1.0.0-dev0.34.0",
+        "@deephaven/jsapi-utils": "^0.86.0",
+        "@deephaven/log": "^0.86.0",
+        "@deephaven/react-hooks": "^0.86.0",
+        "@deephaven/utils": "^0.86.0",
+        "@types/js-cookie": "^3.0.3",
+        "classnames": "^2.3.2",
+        "js-cookie": "^3.0.5",
         "lodash.debounce": "^4.0.8",
-        "lodash.throttle": "^4.1.1",
-        "memoize-one": "^5.1.1",
-        "memoizee": "^0.4.15",
-        "monaco-editor": "^0.41.0",
-        "prop-types": "^15.7.2",
-        "react-beautiful-dnd": "^13.1.0",
-        "react-transition-group": "^4.4.2",
-        "shortid": "^2.2.16"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "react": "^17.x",
-        "react-dom": "^17.x"
-      }
-    },
-    "plugins/matplotlib/src/js/node_modules/@deephaven/jsapi-bootstrap": {
-      "version": "0.58.0",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@deephaven/components": "^0.58.0",
-        "@deephaven/jsapi-types": "^0.58.0",
-        "@deephaven/log": "^0.58.0",
-        "@deephaven/react-hooks": "^0.58.0"
+        "prop-types": "^15.8.1"
       },
       "engines": {
         "node": ">=16"
       },
       "peerDependencies": {
-        "react": "^17.x"
+        "react": ">=16.8.0"
       }
     },
-    "plugins/matplotlib/src/js/node_modules/@deephaven/jsapi-types": {
-      "version": "0.58.0",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "plugins/matplotlib/src/js/node_modules/@deephaven/jsapi-utils": {
-      "version": "0.58.0",
-      "license": "Apache-2.0",
+    "plugins/matplotlib/src/js/node_modules/@deephaven/plugin/node_modules/@deephaven/iris-grid/node_modules/@deephaven/jsapi-components/node_modules/@deephaven/jsapi-bootstrap": {
+      "version": "0.86.0",
+      "resolved": "https://registry.npmjs.org/@deephaven/jsapi-bootstrap/-/jsapi-bootstrap-0.86.0.tgz",
+      "integrity": "sha512-pVlPxcEsIwAv7rvBlAhmVeqFdWRwfXpoAbJC6AgdFM8v/CNbTnlBOyocaifE99dnQTGtJTrjheCNrEpJgm372g==",
       "dependencies": {
-        "@deephaven/filters": "^0.58.0",
-        "@deephaven/jsapi-types": "^0.58.0",
-        "@deephaven/log": "^0.58.0",
-        "@deephaven/utils": "^0.58.0",
-        "lodash.clamp": "^4.0.3",
-        "shortid": "^2.2.16"
+        "@deephaven/components": "^0.86.0",
+        "@deephaven/jsapi-types": "^1.0.0-dev0.34.0",
+        "@deephaven/log": "^0.86.0",
+        "@deephaven/react-hooks": "^0.86.0",
+        "@deephaven/utils": "^0.86.0"
       },
       "engines": {
         "node": ">=16"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
-    "plugins/matplotlib/src/js/node_modules/@deephaven/log": {
-      "version": "0.58.0",
-      "license": "Apache-2.0",
+    "plugins/matplotlib/src/js/node_modules/@deephaven/plugin/node_modules/@deephaven/iris-grid/node_modules/@deephaven/storage": {
+      "version": "0.86.0",
+      "resolved": "https://registry.npmjs.org/@deephaven/storage/-/storage-0.86.0.tgz",
+      "integrity": "sha512-YN1q47KVVgyY8UXmZgF9nIZYBVZZLHv01VyRWMViwVMT7obEw0HInYq6JTg4DbzFcJOiTtwy7hQq9V7kreIPNQ==",
+      "dependencies": {
+        "@deephaven/filters": "^0.86.0",
+        "@deephaven/log": "^0.86.0",
+        "lodash.throttle": "^4.1.1"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "plugins/matplotlib/src/js/node_modules/@deephaven/plugin/node_modules/@deephaven/log": {
+      "version": "0.86.0",
+      "resolved": "https://registry.npmjs.org/@deephaven/log/-/log-0.86.0.tgz",
+      "integrity": "sha512-VgldfD7weCUhtsSFy2KLBRGcgfmIVepZ0rSkyCVVwNLxtu+7BwsJ68uKxOtsUvD+HXHpJkzJZ0MBA8K29lTH6g==",
       "dependencies": {
         "event-target-shim": "^6.0.2"
       },
@@ -31520,53 +31862,44 @@
         "node": ">=16"
       }
     },
-    "plugins/matplotlib/src/js/node_modules/@deephaven/plugin": {
-      "version": "0.58.0",
-      "license": "Apache-2.0",
+    "plugins/matplotlib/src/js/node_modules/@deephaven/plugin/node_modules/@deephaven/react-hooks": {
+      "version": "0.86.0",
+      "resolved": "https://registry.npmjs.org/@deephaven/react-hooks/-/react-hooks-0.86.0.tgz",
+      "integrity": "sha512-wm3GRJvf6k2+6Uf3fVotf2BeD0DGW0rwIz7etPtlyi1AxTvJcFN6mKLz0iV27Z36i0GG5QkiCPpiou5meML0Rg==",
       "dependencies": {
-        "@deephaven/components": "^0.58.0",
-        "@deephaven/golden-layout": "^0.58.0",
-        "@deephaven/icons": "^0.58.0",
-        "@deephaven/iris-grid": "^0.58.0",
-        "@deephaven/jsapi-types": "^0.58.0",
-        "@deephaven/log": "^0.58.0",
-        "@deephaven/react-hooks": "^0.58.0",
-        "@fortawesome/fontawesome-common-types": "^6.1.1",
-        "@fortawesome/react-fontawesome": "^0.2.0"
+        "@adobe/react-spectrum": "3.35.1",
+        "@deephaven/log": "^0.86.0",
+        "@deephaven/utils": "^0.86.0",
+        "lodash.debounce": "^4.0.8",
+        "lodash.throttle": "^4.1.1",
+        "nanoid": "^5.0.7"
       },
       "engines": {
         "node": ">=16"
       },
       "peerDependencies": {
-        "react": "^17.x"
+        "react": ">=16.8.0"
       }
     },
-    "plugins/matplotlib/src/js/node_modules/@deephaven/react-hooks": {
-      "version": "0.58.0",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@adobe/react-spectrum": "^3.29.0",
-        "@deephaven/log": "^0.58.0",
-        "@deephaven/utils": "^0.58.0",
-        "lodash.debounce": "^4.0.8",
-        "shortid": "^2.2.16"
-      },
+    "plugins/matplotlib/src/js/node_modules/@deephaven/plugin/node_modules/@deephaven/utils": {
+      "version": "0.86.0",
+      "resolved": "https://registry.npmjs.org/@deephaven/utils/-/utils-0.86.0.tgz",
+      "integrity": "sha512-zZdxoHxhuSSxQpCZWlJFo1jEoNThIyyGosMUvFyaMiwgsQbvR+4LxBFXXkXBfqNrUPqYWXhgcSIOcdr/+pL1Gg==",
       "engines": {
         "node": ">=16"
-      },
-      "peerDependencies": {
-        "react": "^17.x"
       }
     },
     "plugins/matplotlib/src/js/node_modules/@deephaven/redux": {
-      "version": "0.58.0",
-      "license": "Apache-2.0",
+      "version": "0.86.0",
+      "resolved": "https://registry.npmjs.org/@deephaven/redux/-/redux-0.86.0.tgz",
+      "integrity": "sha512-3EcgwYyXzkzQTmWa5DB57b4wfVfWO4tZefXf2VdQnfyJEhiD25/QJ9kAS6SHdR4vEjmK5MZA+hxLa9/2so47Mw==",
       "dependencies": {
-        "@deephaven/jsapi-types": "^0.58.0",
-        "@deephaven/jsapi-utils": "^0.58.0",
-        "@deephaven/log": "^0.58.0",
-        "@deephaven/plugin": "^0.58.0",
-        "deep-equal": "^2.0.5",
+        "@deephaven/jsapi-types": "^1.0.0-dev0.34.0",
+        "@deephaven/jsapi-utils": "^0.86.0",
+        "@deephaven/log": "^0.86.0",
+        "@deephaven/plugin": "^0.86.0",
+        "fast-deep-equal": "^3.1.3",
+        "proxy-memoize": "^3.0.0",
         "redux-thunk": "2.4.1"
       },
       "engines": {
@@ -31576,33 +31909,73 @@
         "redux": "^4.2.0"
       }
     },
-    "plugins/matplotlib/src/js/node_modules/@deephaven/storage": {
-      "version": "0.58.0",
-      "license": "Apache-2.0",
+    "plugins/matplotlib/src/js/node_modules/@deephaven/redux/node_modules/@deephaven/log": {
+      "version": "0.86.0",
+      "resolved": "https://registry.npmjs.org/@deephaven/log/-/log-0.86.0.tgz",
+      "integrity": "sha512-VgldfD7weCUhtsSFy2KLBRGcgfmIVepZ0rSkyCVVwNLxtu+7BwsJ68uKxOtsUvD+HXHpJkzJZ0MBA8K29lTH6g==",
       "dependencies": {
-        "@deephaven/filters": "^0.58.0",
-        "@deephaven/log": "^0.58.0",
-        "lodash.throttle": "^4.1.1"
+        "event-target-shim": "^6.0.2"
       },
       "engines": {
         "node": ">=16"
-      },
-      "peerDependencies": {
-        "react": "^17.x"
       }
     },
     "plugins/matplotlib/src/js/node_modules/@deephaven/utils": {
-      "version": "0.58.0",
-      "license": "Apache-2.0",
+      "version": "0.87.0",
+      "resolved": "https://registry.npmjs.org/@deephaven/utils/-/utils-0.87.0.tgz",
+      "integrity": "sha512-hgvOZQfOMznKX4YeyfBJFjck0IbzAOcPhr9uQO5EDgPvuFQF3b0XKqurqs8plWmSHDv+wDYaubu83dW++EYRcw==",
       "engines": {
         "node": ">=16"
       }
     },
-    "plugins/matplotlib/src/js/node_modules/redux-thunk": {
-      "version": "2.4.1",
-      "license": "MIT",
-      "peerDependencies": {
-        "redux": "^4"
+    "plugins/matplotlib/src/js/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "plugins/matplotlib/src/js/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "plugins/matplotlib/src/js/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "plugins/matplotlib/src/js/node_modules/event-target-shim": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-6.0.2.tgz",
+      "integrity": "sha512-8q3LsZjRezbFZ2PN+uP+Q7pnHUMmAOziU2vA2OwoFaKIXxlxl38IylhSSgUorWu/rf4er67w0ikBqjBFk/pomA==",
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mysticatea"
       }
     },
     "plugins/matplotlib/src/js/node_modules/typescript": {
@@ -32101,13 +32474,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/mysticatea"
-      }
-    },
-    "plugins/plotly-express/src/js/node_modules/redux-thunk": {
-      "version": "2.4.1",
-      "license": "MIT",
-      "peerDependencies": {
-        "redux": "^4"
       }
     },
     "plugins/plotly-express/src/js/node_modules/typescript": {
@@ -32783,14 +33149,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/mysticatea"
-      }
-    },
-    "plugins/ui/src/js/node_modules/redux-thunk": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.4.1.tgz",
-      "integrity": "sha512-OOYGNY5Jy2TWvTL1KgAlVy6dcx3siPJ1wTq741EPyUKfn6W6nChdICjZwCd0p8AZBs5kWpZlbkXW2nE/zjUa+Q==",
-      "peerDependencies": {
-        "redux": "^4"
       }
     },
     "plugins/ui/src/js/node_modules/typescript": {
@@ -34657,10 +35015,6 @@
         },
         "event-target-shim": {
           "version": "6.0.2"
-        },
-        "redux-thunk": {
-          "version": "2.4.1",
-          "requires": {}
         }
       }
     },
@@ -35531,52 +35885,40 @@
     "@deephaven/js-plugin-matplotlib": {
       "version": "file:plugins/matplotlib/src/js",
       "requires": {
-        "@deephaven/components": "^0.58.0",
-        "@deephaven/dashboard": "^0.58.0",
-        "@deephaven/icons": "^0.58.0",
-        "@deephaven/jsapi-bootstrap": "^0.58.0",
-        "@deephaven/jsapi-types": "^0.58.0",
-        "@deephaven/log": "^0.58.0",
-        "@deephaven/plugin": "^0.58.0",
+        "@deephaven/components": "^0.87.0",
+        "@deephaven/dashboard": "^0.86.0",
+        "@deephaven/icons": "^0.87.0",
+        "@deephaven/jsapi-bootstrap": "^0.87.0",
+        "@deephaven/jsapi-types": "1.0.0-dev0.35.2",
+        "@deephaven/log": "^0.87.0",
+        "@deephaven/plugin": "^0.86.0",
         "@types/react": "^17.0.2",
         "@types/react-dom": "^17.0.2",
         "@vitejs/plugin-react-swc": "^3.0.0",
+        "nanoid": "^5.0.7",
         "react": "^17.0.2",
+        "react-dom": "^17.0.2",
         "typescript": "^4.5.4",
         "vite": "~4.1.4"
       },
       "dependencies": {
-        "@deephaven/chart": {
-          "version": "0.58.0",
-          "requires": {
-            "@deephaven/components": "^0.58.0",
-            "@deephaven/icons": "^0.58.0",
-            "@deephaven/jsapi-types": "^0.58.0",
-            "@deephaven/jsapi-utils": "^0.58.0",
-            "@deephaven/log": "^0.58.0",
-            "@deephaven/react-hooks": "^0.58.0",
-            "@deephaven/utils": "^0.58.0",
-            "deep-equal": "^2.0.5",
-            "lodash.debounce": "^4.0.8",
-            "lodash.set": "^4.3.2",
-            "memoize-one": "^5.1.1",
-            "memoizee": "^0.4.15",
-            "plotly.js": "^2.18.2",
-            "prop-types": "^15.7.2",
-            "react-plotly.js": "^2.6.0"
-          }
-        },
         "@deephaven/components": {
-          "version": "0.58.0",
+          "version": "0.87.0",
+          "resolved": "https://registry.npmjs.org/@deephaven/components/-/components-0.87.0.tgz",
+          "integrity": "sha512-X/I7qkkZie0UKKf9T9CvVkEu5l2BzvoURx3+mIOvYXf5yRwUdSrPgI5GCnZepNWfyY1f6kzwtUiSt8J7OHPj9Q==",
           "requires": {
-            "@adobe/react-spectrum": "^3.29.0",
-            "@deephaven/icons": "^0.58.0",
-            "@deephaven/log": "^0.58.0",
-            "@deephaven/react-hooks": "^0.58.0",
-            "@deephaven/utils": "^0.58.0",
+            "@adobe/react-spectrum": "3.35.1",
+            "@deephaven/icons": "^0.87.0",
+            "@deephaven/log": "^0.87.0",
+            "@deephaven/react-hooks": "^0.87.0",
+            "@deephaven/utils": "^0.87.0",
             "@fortawesome/fontawesome-svg-core": "^6.2.1",
             "@fortawesome/react-fontawesome": "^0.2.0",
             "@react-spectrum/theme-default": "^3.5.1",
+            "@react-spectrum/utils": "^3.11.5",
+            "@react-types/radio": "^3.8.1",
+            "@react-types/shared": "^3.22.1",
+            "@react-types/textfield": "^3.9.1",
             "bootstrap": "4.6.2",
             "classnames": "^2.3.1",
             "event-target-shim": "^6.0.2",
@@ -35584,198 +35926,522 @@
             "lodash.debounce": "^4.0.8",
             "lodash.flatten": "^4.4.0",
             "memoizee": "^0.4.15",
+            "nanoid": "^5.0.7",
             "popper.js": "^1.16.1",
             "prop-types": "^15.7.2",
             "react-beautiful-dnd": "^13.1.0",
             "react-transition-group": "^4.4.2",
             "react-virtualized-auto-sizer": "1.0.6",
-            "react-window": "^1.8.6",
-            "shortid": "^2.2.16"
-          }
-        },
-        "@deephaven/console": {
-          "version": "0.58.0",
-          "requires": {
-            "@deephaven/chart": "^0.58.0",
-            "@deephaven/components": "^0.58.0",
-            "@deephaven/icons": "^0.58.0",
-            "@deephaven/jsapi-bootstrap": "^0.58.0",
-            "@deephaven/jsapi-types": "^0.58.0",
-            "@deephaven/log": "^0.58.0",
-            "@deephaven/react-hooks": "^0.58.0",
-            "@deephaven/storage": "^0.58.0",
-            "@deephaven/utils": "^0.58.0",
-            "@fortawesome/react-fontawesome": "^0.2.0",
-            "classnames": "^2.3.1",
-            "linkifyjs": "^4.1.0",
-            "lodash.debounce": "^4.0.8",
-            "lodash.throttle": "^4.1.1",
-            "memoize-one": "^5.1.1",
-            "memoizee": "^0.4.15",
-            "monaco-editor": "^0.41.0",
-            "papaparse": "5.3.2",
-            "popper.js": "^1.16.1",
-            "prop-types": "^15.7.2",
-            "shell-quote": "^1.7.2",
-            "shortid": "^2.2.16"
+            "react-window": "^1.8.6"
+          },
+          "dependencies": {
+            "@deephaven/react-hooks": {
+              "version": "0.87.0",
+              "resolved": "https://registry.npmjs.org/@deephaven/react-hooks/-/react-hooks-0.87.0.tgz",
+              "integrity": "sha512-5PMDsHAAGawF53Th4vEqsyImJdioqIbw0+1o2X0pnQSOfhIda/OqCoq1a16cCHxwcpjWaMvI5BvTRe45HMZHIw==",
+              "requires": {
+                "@adobe/react-spectrum": "3.35.1",
+                "@deephaven/log": "^0.87.0",
+                "@deephaven/utils": "^0.87.0",
+                "lodash.debounce": "^4.0.8",
+                "lodash.throttle": "^4.1.1",
+                "nanoid": "^5.0.7"
+              }
+            }
           }
         },
         "@deephaven/dashboard": {
-          "version": "0.58.0",
+          "version": "0.86.0",
+          "resolved": "https://registry.npmjs.org/@deephaven/dashboard/-/dashboard-0.86.0.tgz",
+          "integrity": "sha512-zhWC7xTS+lxOJTEjhvjAI3JSFhU1BKz1SsjkzbJklaiBLa8yQNQmwM4WViMCyjApNhJMcmo3RdCMrF9aDLI/QA==",
           "requires": {
-            "@deephaven/components": "^0.58.0",
-            "@deephaven/golden-layout": "^0.58.0",
-            "@deephaven/log": "^0.58.0",
-            "@deephaven/react-hooks": "^0.58.0",
-            "@deephaven/redux": "^0.58.0",
-            "@deephaven/utils": "^0.58.0",
-            "deep-equal": "^2.0.5",
+            "@deephaven/components": "^0.86.0",
+            "@deephaven/golden-layout": "^0.86.0",
+            "@deephaven/log": "^0.86.0",
+            "@deephaven/react-hooks": "^0.86.0",
+            "@deephaven/redux": "^0.86.0",
+            "@deephaven/utils": "^0.86.0",
+            "fast-deep-equal": "^3.1.3",
             "lodash.ismatch": "^4.1.1",
             "lodash.throttle": "^4.1.1",
-            "prop-types": "^15.7.2",
-            "shortid": "^2.2.16"
+            "nanoid": "^5.0.7",
+            "prop-types": "^15.7.2"
+          },
+          "dependencies": {
+            "@deephaven/components": {
+              "version": "0.86.0",
+              "resolved": "https://registry.npmjs.org/@deephaven/components/-/components-0.86.0.tgz",
+              "integrity": "sha512-DZslAyK5SDI8bV/u8eIrIcILY7rX53lkAIBepRgbbONV/e9uJYvEcB3m81ggmHB0j5hlGioomY9SmTSpwMwlmQ==",
+              "requires": {
+                "@adobe/react-spectrum": "3.35.1",
+                "@deephaven/icons": "^0.86.0",
+                "@deephaven/log": "^0.86.0",
+                "@deephaven/react-hooks": "^0.86.0",
+                "@deephaven/utils": "^0.86.0",
+                "@fortawesome/fontawesome-svg-core": "^6.2.1",
+                "@fortawesome/react-fontawesome": "^0.2.0",
+                "@react-spectrum/theme-default": "^3.5.1",
+                "@react-spectrum/utils": "^3.11.5",
+                "@react-types/radio": "^3.8.1",
+                "@react-types/shared": "^3.22.1",
+                "@react-types/textfield": "^3.9.1",
+                "bootstrap": "4.6.2",
+                "classnames": "^2.3.1",
+                "event-target-shim": "^6.0.2",
+                "lodash.clamp": "^4.0.3",
+                "lodash.debounce": "^4.0.8",
+                "lodash.flatten": "^4.4.0",
+                "memoizee": "^0.4.15",
+                "nanoid": "^5.0.7",
+                "popper.js": "^1.16.1",
+                "prop-types": "^15.7.2",
+                "react-beautiful-dnd": "^13.1.0",
+                "react-transition-group": "^4.4.2",
+                "react-virtualized-auto-sizer": "1.0.6",
+                "react-window": "^1.8.6"
+              },
+              "dependencies": {
+                "@deephaven/icons": {
+                  "version": "0.86.0",
+                  "resolved": "https://registry.npmjs.org/@deephaven/icons/-/icons-0.86.0.tgz",
+                  "integrity": "sha512-/sMhQ4eW1J6K/8mppoGkBBV64g9jNINWZAIgu5yl1zBXqdKNysYgvBz+YYjpP752P/fCZhZVpmVbEBwpQvHYwg==",
+                  "requires": {
+                    "@fortawesome/fontawesome-common-types": "^6.1.1"
+                  }
+                }
+              }
+            },
+            "@deephaven/golden-layout": {
+              "version": "0.86.0",
+              "resolved": "https://registry.npmjs.org/@deephaven/golden-layout/-/golden-layout-0.86.0.tgz",
+              "integrity": "sha512-S9lckwF482Is3E8+HGx98rvvV9GuOblWNW09UI7kuNNkynnOUIcTW8bVdDWfVGIvXMawkKso2uCtJAXzDiRK2w==",
+              "requires": {
+                "@deephaven/components": "^0.86.0",
+                "jquery": "^3.6.0",
+                "nanoid": "^5.0.7"
+              }
+            },
+            "@deephaven/log": {
+              "version": "0.86.0",
+              "resolved": "https://registry.npmjs.org/@deephaven/log/-/log-0.86.0.tgz",
+              "integrity": "sha512-VgldfD7weCUhtsSFy2KLBRGcgfmIVepZ0rSkyCVVwNLxtu+7BwsJ68uKxOtsUvD+HXHpJkzJZ0MBA8K29lTH6g==",
+              "requires": {
+                "event-target-shim": "^6.0.2"
+              }
+            },
+            "@deephaven/react-hooks": {
+              "version": "0.86.0",
+              "resolved": "https://registry.npmjs.org/@deephaven/react-hooks/-/react-hooks-0.86.0.tgz",
+              "integrity": "sha512-wm3GRJvf6k2+6Uf3fVotf2BeD0DGW0rwIz7etPtlyi1AxTvJcFN6mKLz0iV27Z36i0GG5QkiCPpiou5meML0Rg==",
+              "requires": {
+                "@adobe/react-spectrum": "3.35.1",
+                "@deephaven/log": "^0.86.0",
+                "@deephaven/utils": "^0.86.0",
+                "lodash.debounce": "^4.0.8",
+                "lodash.throttle": "^4.1.1",
+                "nanoid": "^5.0.7"
+              }
+            },
+            "@deephaven/utils": {
+              "version": "0.86.0",
+              "resolved": "https://registry.npmjs.org/@deephaven/utils/-/utils-0.86.0.tgz",
+              "integrity": "sha512-zZdxoHxhuSSxQpCZWlJFo1jEoNThIyyGosMUvFyaMiwgsQbvR+4LxBFXXkXBfqNrUPqYWXhgcSIOcdr/+pL1Gg=="
+            }
           }
         },
         "@deephaven/filters": {
-          "version": "0.58.0"
-        },
-        "@deephaven/golden-layout": {
-          "version": "0.58.0",
-          "requires": {
-            "@deephaven/components": "^0.58.0",
-            "jquery": "^3.6.0"
-          }
-        },
-        "@deephaven/grid": {
-          "version": "0.58.0",
-          "requires": {
-            "@deephaven/utils": "^0.58.0",
-            "classnames": "^2.3.1",
-            "color-convert": "^2.0.1",
-            "event-target-shim": "^6.0.2",
-            "linkifyjs": "^4.1.0",
-            "lodash.clamp": "^4.0.3",
-            "memoize-one": "^5.1.1",
-            "memoizee": "^0.4.15",
-            "prop-types": "^15.7.2"
-          }
+          "version": "0.86.0",
+          "resolved": "https://registry.npmjs.org/@deephaven/filters/-/filters-0.86.0.tgz",
+          "integrity": "sha512-iAjO1hcuE9m73YyzWnZJLSyDJfgcOluFljMDLop6IRI3ie7bFwCoLnnPEeJdP3wkDNVGH3sUtfrkFE3uLfxiUw=="
         },
         "@deephaven/icons": {
-          "version": "0.58.0",
+          "version": "0.87.0",
+          "resolved": "https://registry.npmjs.org/@deephaven/icons/-/icons-0.87.0.tgz",
+          "integrity": "sha512-2q+HUkW9pByPG81LLqRo/reem6EcZhgC/NKISOR9roeL2rASq8E+Xq4Yg2gW2zlXy6fSGi8e5q887Ynby4TGgQ==",
           "requires": {
             "@fortawesome/fontawesome-common-types": "^6.1.1"
           }
         },
-        "@deephaven/iris-grid": {
-          "version": "0.58.0",
-          "requires": {
-            "@deephaven/components": "^0.58.0",
-            "@deephaven/console": "^0.58.0",
-            "@deephaven/filters": "^0.58.0",
-            "@deephaven/grid": "^0.58.0",
-            "@deephaven/icons": "^0.58.0",
-            "@deephaven/jsapi-types": "^0.58.0",
-            "@deephaven/jsapi-utils": "^0.58.0",
-            "@deephaven/log": "^0.58.0",
-            "@deephaven/react-hooks": "^0.58.0",
-            "@deephaven/storage": "^0.58.0",
-            "@deephaven/utils": "^0.58.0",
-            "@dnd-kit/core": "^6.0.5",
-            "@dnd-kit/sortable": "^7.0.0",
-            "@dnd-kit/utilities": "^3.2.0",
-            "@fortawesome/react-fontawesome": "^0.2.0",
-            "classnames": "^2.3.1",
-            "deep-equal": "^2.0.5",
-            "lodash.clamp": "^4.0.3",
-            "lodash.debounce": "^4.0.8",
-            "lodash.throttle": "^4.1.1",
-            "memoize-one": "^5.1.1",
-            "memoizee": "^0.4.15",
-            "monaco-editor": "^0.41.0",
-            "prop-types": "^15.7.2",
-            "react-beautiful-dnd": "^13.1.0",
-            "react-transition-group": "^4.4.2",
-            "shortid": "^2.2.16"
-          }
-        },
         "@deephaven/jsapi-bootstrap": {
-          "version": "0.58.0",
+          "version": "0.87.0",
+          "resolved": "https://registry.npmjs.org/@deephaven/jsapi-bootstrap/-/jsapi-bootstrap-0.87.0.tgz",
+          "integrity": "sha512-rsrrPe5JzMlOZV3JmeDGv0V12NkEVtmggzRauA28brBatiEd+TRE0iBbjcmavinhtXB/4NAQ5Xcl6FcvX67Pfg==",
           "requires": {
-            "@deephaven/components": "^0.58.0",
-            "@deephaven/jsapi-types": "^0.58.0",
-            "@deephaven/log": "^0.58.0",
-            "@deephaven/react-hooks": "^0.58.0"
+            "@deephaven/components": "^0.87.0",
+            "@deephaven/jsapi-types": "^1.0.0-dev0.34.0",
+            "@deephaven/log": "^0.87.0",
+            "@deephaven/react-hooks": "^0.87.0",
+            "@deephaven/utils": "^0.87.0"
+          },
+          "dependencies": {
+            "@deephaven/react-hooks": {
+              "version": "0.87.0",
+              "resolved": "https://registry.npmjs.org/@deephaven/react-hooks/-/react-hooks-0.87.0.tgz",
+              "integrity": "sha512-5PMDsHAAGawF53Th4vEqsyImJdioqIbw0+1o2X0pnQSOfhIda/OqCoq1a16cCHxwcpjWaMvI5BvTRe45HMZHIw==",
+              "requires": {
+                "@adobe/react-spectrum": "3.35.1",
+                "@deephaven/log": "^0.87.0",
+                "@deephaven/utils": "^0.87.0",
+                "lodash.debounce": "^4.0.8",
+                "lodash.throttle": "^4.1.1",
+                "nanoid": "^5.0.7"
+              }
+            }
           }
         },
         "@deephaven/jsapi-types": {
-          "version": "0.58.0"
+          "version": "1.0.0-dev0.35.2",
+          "resolved": "https://registry.npmjs.org/@deephaven/jsapi-types/-/jsapi-types-1.0.0-dev0.35.2.tgz",
+          "integrity": "sha512-VM1WAps/+KEXdxIiaEGutcjgaf5p1LNf6AA+Hv7sTIaENYYJpndZqD6bGFcuuiUVTYDlnFF0hohN4l6lOsjcQw=="
         },
         "@deephaven/jsapi-utils": {
-          "version": "0.58.0",
+          "version": "0.86.0",
+          "resolved": "https://registry.npmjs.org/@deephaven/jsapi-utils/-/jsapi-utils-0.86.0.tgz",
+          "integrity": "sha512-HnKAEWLwZuF7KRt5sU6CIdS2P+NSIj9UfV2SLRoFB+eN70dLm6+E+Rsw2Q1msPRC9SYa4sdtoF6qKp7Djf/7iw==",
           "requires": {
-            "@deephaven/filters": "^0.58.0",
-            "@deephaven/jsapi-types": "^0.58.0",
-            "@deephaven/log": "^0.58.0",
-            "@deephaven/utils": "^0.58.0",
+            "@deephaven/filters": "^0.86.0",
+            "@deephaven/jsapi-types": "^1.0.0-dev0.34.0",
+            "@deephaven/log": "^0.86.0",
+            "@deephaven/utils": "^0.86.0",
             "lodash.clamp": "^4.0.3",
-            "shortid": "^2.2.16"
+            "nanoid": "^5.0.7"
+          },
+          "dependencies": {
+            "@deephaven/log": {
+              "version": "0.86.0",
+              "resolved": "https://registry.npmjs.org/@deephaven/log/-/log-0.86.0.tgz",
+              "integrity": "sha512-VgldfD7weCUhtsSFy2KLBRGcgfmIVepZ0rSkyCVVwNLxtu+7BwsJ68uKxOtsUvD+HXHpJkzJZ0MBA8K29lTH6g==",
+              "requires": {
+                "event-target-shim": "^6.0.2"
+              }
+            },
+            "@deephaven/utils": {
+              "version": "0.86.0",
+              "resolved": "https://registry.npmjs.org/@deephaven/utils/-/utils-0.86.0.tgz",
+              "integrity": "sha512-zZdxoHxhuSSxQpCZWlJFo1jEoNThIyyGosMUvFyaMiwgsQbvR+4LxBFXXkXBfqNrUPqYWXhgcSIOcdr/+pL1Gg=="
+            }
           }
         },
         "@deephaven/log": {
-          "version": "0.58.0",
+          "version": "0.87.0",
+          "resolved": "https://registry.npmjs.org/@deephaven/log/-/log-0.87.0.tgz",
+          "integrity": "sha512-hq2szL3DRBVPuv5OrIfEiFIg4MYHwICiALWFNCPNkX7isESOv/6LBxpFXOgnUAtzFsL7X1Cv3bbUtMacxw9uvA==",
           "requires": {
             "event-target-shim": "^6.0.2"
           }
         },
         "@deephaven/plugin": {
-          "version": "0.58.0",
+          "version": "0.86.0",
+          "resolved": "https://registry.npmjs.org/@deephaven/plugin/-/plugin-0.86.0.tgz",
+          "integrity": "sha512-oXwidAEE3QMycEjzxturHnG00i0zEli7d4AlDKZ/Yu14vBNcN/uB00Duyrw2AvEXTKspFrtRSKKIGXUJUpWqxA==",
           "requires": {
-            "@deephaven/components": "^0.58.0",
-            "@deephaven/golden-layout": "^0.58.0",
-            "@deephaven/icons": "^0.58.0",
-            "@deephaven/iris-grid": "^0.58.0",
-            "@deephaven/jsapi-types": "^0.58.0",
-            "@deephaven/log": "^0.58.0",
-            "@deephaven/react-hooks": "^0.58.0",
+            "@deephaven/components": "^0.86.0",
+            "@deephaven/golden-layout": "^0.86.0",
+            "@deephaven/icons": "^0.86.0",
+            "@deephaven/iris-grid": "^0.86.0",
+            "@deephaven/jsapi-types": "^1.0.0-dev0.34.0",
+            "@deephaven/log": "^0.86.0",
+            "@deephaven/react-hooks": "^0.86.0",
             "@fortawesome/fontawesome-common-types": "^6.1.1",
             "@fortawesome/react-fontawesome": "^0.2.0"
-          }
-        },
-        "@deephaven/react-hooks": {
-          "version": "0.58.0",
-          "requires": {
-            "@adobe/react-spectrum": "^3.29.0",
-            "@deephaven/log": "^0.58.0",
-            "@deephaven/utils": "^0.58.0",
-            "lodash.debounce": "^4.0.8",
-            "shortid": "^2.2.16"
+          },
+          "dependencies": {
+            "@deephaven/components": {
+              "version": "0.86.0",
+              "resolved": "https://registry.npmjs.org/@deephaven/components/-/components-0.86.0.tgz",
+              "integrity": "sha512-DZslAyK5SDI8bV/u8eIrIcILY7rX53lkAIBepRgbbONV/e9uJYvEcB3m81ggmHB0j5hlGioomY9SmTSpwMwlmQ==",
+              "requires": {
+                "@adobe/react-spectrum": "3.35.1",
+                "@deephaven/icons": "^0.86.0",
+                "@deephaven/log": "^0.86.0",
+                "@deephaven/react-hooks": "^0.86.0",
+                "@deephaven/utils": "^0.86.0",
+                "@fortawesome/fontawesome-svg-core": "^6.2.1",
+                "@fortawesome/react-fontawesome": "^0.2.0",
+                "@react-spectrum/theme-default": "^3.5.1",
+                "@react-spectrum/utils": "^3.11.5",
+                "@react-types/radio": "^3.8.1",
+                "@react-types/shared": "^3.22.1",
+                "@react-types/textfield": "^3.9.1",
+                "bootstrap": "4.6.2",
+                "classnames": "^2.3.1",
+                "event-target-shim": "^6.0.2",
+                "lodash.clamp": "^4.0.3",
+                "lodash.debounce": "^4.0.8",
+                "lodash.flatten": "^4.4.0",
+                "memoizee": "^0.4.15",
+                "nanoid": "^5.0.7",
+                "popper.js": "^1.16.1",
+                "prop-types": "^15.7.2",
+                "react-beautiful-dnd": "^13.1.0",
+                "react-transition-group": "^4.4.2",
+                "react-virtualized-auto-sizer": "1.0.6",
+                "react-window": "^1.8.6"
+              }
+            },
+            "@deephaven/golden-layout": {
+              "version": "0.86.0",
+              "resolved": "https://registry.npmjs.org/@deephaven/golden-layout/-/golden-layout-0.86.0.tgz",
+              "integrity": "sha512-S9lckwF482Is3E8+HGx98rvvV9GuOblWNW09UI7kuNNkynnOUIcTW8bVdDWfVGIvXMawkKso2uCtJAXzDiRK2w==",
+              "requires": {
+                "@deephaven/components": "^0.86.0",
+                "jquery": "^3.6.0",
+                "nanoid": "^5.0.7"
+              }
+            },
+            "@deephaven/icons": {
+              "version": "0.86.0",
+              "resolved": "https://registry.npmjs.org/@deephaven/icons/-/icons-0.86.0.tgz",
+              "integrity": "sha512-/sMhQ4eW1J6K/8mppoGkBBV64g9jNINWZAIgu5yl1zBXqdKNysYgvBz+YYjpP752P/fCZhZVpmVbEBwpQvHYwg==",
+              "requires": {
+                "@fortawesome/fontawesome-common-types": "^6.1.1"
+              }
+            },
+            "@deephaven/iris-grid": {
+              "version": "0.86.0",
+              "resolved": "https://registry.npmjs.org/@deephaven/iris-grid/-/iris-grid-0.86.0.tgz",
+              "integrity": "sha512-g5M5YoWZGe6MCr8ltnTDEtK7QvlHnd1d5cXwZkpLOfEYsFOf6mcmJVK/p7XmjcyElsdLe9dT93YQiTfVzNnQrQ==",
+              "requires": {
+                "@deephaven/components": "^0.86.0",
+                "@deephaven/console": "^0.86.0",
+                "@deephaven/filters": "^0.86.0",
+                "@deephaven/grid": "^0.86.0",
+                "@deephaven/icons": "^0.86.0",
+                "@deephaven/jsapi-components": "^0.86.0",
+                "@deephaven/jsapi-types": "^1.0.0-dev0.34.0",
+                "@deephaven/jsapi-utils": "^0.86.0",
+                "@deephaven/log": "^0.86.0",
+                "@deephaven/react-hooks": "^0.86.0",
+                "@deephaven/storage": "^0.86.0",
+                "@deephaven/utils": "^0.86.0",
+                "@dnd-kit/core": "^6.1.0",
+                "@dnd-kit/sortable": "^7.0.2",
+                "@dnd-kit/utilities": "^3.2.2",
+                "@fortawesome/react-fontawesome": "^0.2.0",
+                "classnames": "^2.3.1",
+                "fast-deep-equal": "^3.1.3",
+                "lodash.clamp": "^4.0.3",
+                "lodash.debounce": "^4.0.8",
+                "lodash.throttle": "^4.1.1",
+                "memoize-one": "^5.1.1",
+                "memoizee": "^0.4.15",
+                "monaco-editor": "^0.41.0",
+                "nanoid": "^5.0.7",
+                "prop-types": "^15.7.2",
+                "react-beautiful-dnd": "^13.1.0",
+                "react-transition-group": "^4.4.2"
+              },
+              "dependencies": {
+                "@deephaven/console": {
+                  "version": "0.86.0",
+                  "resolved": "https://registry.npmjs.org/@deephaven/console/-/console-0.86.0.tgz",
+                  "integrity": "sha512-BLCi1o9oNXAY/cdHnXQURASnCznXwFQUScQwe0wUpXt/9MYrqJkblP96Iv1Egs+TW3O8XHsO3e5/g6dw9juTBQ==",
+                  "requires": {
+                    "@deephaven/chart": "^0.86.0",
+                    "@deephaven/components": "^0.86.0",
+                    "@deephaven/icons": "^0.86.0",
+                    "@deephaven/jsapi-bootstrap": "^0.86.0",
+                    "@deephaven/jsapi-types": "^1.0.0-dev0.34.0",
+                    "@deephaven/log": "^0.86.0",
+                    "@deephaven/react-hooks": "^0.86.0",
+                    "@deephaven/storage": "^0.86.0",
+                    "@deephaven/utils": "^0.86.0",
+                    "@fortawesome/react-fontawesome": "^0.2.0",
+                    "classnames": "^2.3.1",
+                    "linkifyjs": "^4.1.0",
+                    "lodash.debounce": "^4.0.8",
+                    "lodash.throttle": "^4.1.1",
+                    "memoize-one": "^5.1.1",
+                    "memoizee": "^0.4.15",
+                    "monaco-editor": "^0.41.0",
+                    "nanoid": "^5.0.7",
+                    "papaparse": "5.3.2",
+                    "popper.js": "^1.16.1",
+                    "prop-types": "^15.7.2",
+                    "shell-quote": "^1.7.2"
+                  },
+                  "dependencies": {
+                    "@deephaven/chart": {
+                      "version": "0.86.0",
+                      "resolved": "https://registry.npmjs.org/@deephaven/chart/-/chart-0.86.0.tgz",
+                      "integrity": "sha512-e9Fk2KCsKjGiNlNPJbBUilhdVCp61wTNkWCC4JA7o3zSO1DFO75e9fWvfNQTr4AVCIDTLSbqv2AoRLXnmvD86w==",
+                      "requires": {
+                        "@deephaven/components": "^0.86.0",
+                        "@deephaven/icons": "^0.86.0",
+                        "@deephaven/jsapi-types": "^1.0.0-dev0.34.0",
+                        "@deephaven/jsapi-utils": "^0.86.0",
+                        "@deephaven/log": "^0.86.0",
+                        "@deephaven/react-hooks": "^0.86.0",
+                        "@deephaven/utils": "^0.86.0",
+                        "buffer": "^6.0.3",
+                        "fast-deep-equal": "^3.1.3",
+                        "lodash.debounce": "^4.0.8",
+                        "lodash.set": "^4.3.2",
+                        "memoize-one": "^5.1.1",
+                        "memoizee": "^0.4.15",
+                        "plotly.js": "^2.29.1",
+                        "prop-types": "^15.7.2",
+                        "react-plotly.js": "^2.6.0"
+                      }
+                    },
+                    "@deephaven/jsapi-bootstrap": {
+                      "version": "0.86.0",
+                      "resolved": "https://registry.npmjs.org/@deephaven/jsapi-bootstrap/-/jsapi-bootstrap-0.86.0.tgz",
+                      "integrity": "sha512-pVlPxcEsIwAv7rvBlAhmVeqFdWRwfXpoAbJC6AgdFM8v/CNbTnlBOyocaifE99dnQTGtJTrjheCNrEpJgm372g==",
+                      "requires": {
+                        "@deephaven/components": "^0.86.0",
+                        "@deephaven/jsapi-types": "^1.0.0-dev0.34.0",
+                        "@deephaven/log": "^0.86.0",
+                        "@deephaven/react-hooks": "^0.86.0",
+                        "@deephaven/utils": "^0.86.0"
+                      }
+                    }
+                  }
+                },
+                "@deephaven/grid": {
+                  "version": "0.86.0",
+                  "resolved": "https://registry.npmjs.org/@deephaven/grid/-/grid-0.86.0.tgz",
+                  "integrity": "sha512-lRCn4Cjd05jU58vfeZN8QTm9MRwWtUBdXfpGrkIBBHJytG/I9D8+abNyG3TQ1z4NPTzqf+51IGnr/E8Fgim8Ew==",
+                  "requires": {
+                    "@deephaven/utils": "^0.86.0",
+                    "classnames": "^2.3.1",
+                    "color-convert": "^2.0.1",
+                    "event-target-shim": "^6.0.2",
+                    "linkifyjs": "^4.1.0",
+                    "lodash.clamp": "^4.0.3",
+                    "memoize-one": "^5.1.1",
+                    "memoizee": "^0.4.15",
+                    "prop-types": "^15.7.2"
+                  }
+                },
+                "@deephaven/jsapi-components": {
+                  "version": "0.86.0",
+                  "resolved": "https://registry.npmjs.org/@deephaven/jsapi-components/-/jsapi-components-0.86.0.tgz",
+                  "integrity": "sha512-hWRk6JFC3MxSG8UP9FdCt5OK8Q9lPbIVGB/bDMChS9w/qQcrD87ry+KmGJqnggyKouUoMj2ljdL99xhwhurF8g==",
+                  "requires": {
+                    "@deephaven/components": "^0.86.0",
+                    "@deephaven/jsapi-bootstrap": "^0.86.0",
+                    "@deephaven/jsapi-types": "^1.0.0-dev0.34.0",
+                    "@deephaven/jsapi-utils": "^0.86.0",
+                    "@deephaven/log": "^0.86.0",
+                    "@deephaven/react-hooks": "^0.86.0",
+                    "@deephaven/utils": "^0.86.0",
+                    "@types/js-cookie": "^3.0.3",
+                    "classnames": "^2.3.2",
+                    "js-cookie": "^3.0.5",
+                    "lodash.debounce": "^4.0.8",
+                    "prop-types": "^15.8.1"
+                  },
+                  "dependencies": {
+                    "@deephaven/jsapi-bootstrap": {
+                      "version": "0.86.0",
+                      "resolved": "https://registry.npmjs.org/@deephaven/jsapi-bootstrap/-/jsapi-bootstrap-0.86.0.tgz",
+                      "integrity": "sha512-pVlPxcEsIwAv7rvBlAhmVeqFdWRwfXpoAbJC6AgdFM8v/CNbTnlBOyocaifE99dnQTGtJTrjheCNrEpJgm372g==",
+                      "requires": {
+                        "@deephaven/components": "^0.86.0",
+                        "@deephaven/jsapi-types": "^1.0.0-dev0.34.0",
+                        "@deephaven/log": "^0.86.0",
+                        "@deephaven/react-hooks": "^0.86.0",
+                        "@deephaven/utils": "^0.86.0"
+                      }
+                    }
+                  }
+                },
+                "@deephaven/storage": {
+                  "version": "0.86.0",
+                  "resolved": "https://registry.npmjs.org/@deephaven/storage/-/storage-0.86.0.tgz",
+                  "integrity": "sha512-YN1q47KVVgyY8UXmZgF9nIZYBVZZLHv01VyRWMViwVMT7obEw0HInYq6JTg4DbzFcJOiTtwy7hQq9V7kreIPNQ==",
+                  "requires": {
+                    "@deephaven/filters": "^0.86.0",
+                    "@deephaven/log": "^0.86.0",
+                    "lodash.throttle": "^4.1.1"
+                  }
+                }
+              }
+            },
+            "@deephaven/log": {
+              "version": "0.86.0",
+              "resolved": "https://registry.npmjs.org/@deephaven/log/-/log-0.86.0.tgz",
+              "integrity": "sha512-VgldfD7weCUhtsSFy2KLBRGcgfmIVepZ0rSkyCVVwNLxtu+7BwsJ68uKxOtsUvD+HXHpJkzJZ0MBA8K29lTH6g==",
+              "requires": {
+                "event-target-shim": "^6.0.2"
+              }
+            },
+            "@deephaven/react-hooks": {
+              "version": "0.86.0",
+              "resolved": "https://registry.npmjs.org/@deephaven/react-hooks/-/react-hooks-0.86.0.tgz",
+              "integrity": "sha512-wm3GRJvf6k2+6Uf3fVotf2BeD0DGW0rwIz7etPtlyi1AxTvJcFN6mKLz0iV27Z36i0GG5QkiCPpiou5meML0Rg==",
+              "requires": {
+                "@adobe/react-spectrum": "3.35.1",
+                "@deephaven/log": "^0.86.0",
+                "@deephaven/utils": "^0.86.0",
+                "lodash.debounce": "^4.0.8",
+                "lodash.throttle": "^4.1.1",
+                "nanoid": "^5.0.7"
+              }
+            },
+            "@deephaven/utils": {
+              "version": "0.86.0",
+              "resolved": "https://registry.npmjs.org/@deephaven/utils/-/utils-0.86.0.tgz",
+              "integrity": "sha512-zZdxoHxhuSSxQpCZWlJFo1jEoNThIyyGosMUvFyaMiwgsQbvR+4LxBFXXkXBfqNrUPqYWXhgcSIOcdr/+pL1Gg=="
+            }
           }
         },
         "@deephaven/redux": {
-          "version": "0.58.0",
+          "version": "0.86.0",
+          "resolved": "https://registry.npmjs.org/@deephaven/redux/-/redux-0.86.0.tgz",
+          "integrity": "sha512-3EcgwYyXzkzQTmWa5DB57b4wfVfWO4tZefXf2VdQnfyJEhiD25/QJ9kAS6SHdR4vEjmK5MZA+hxLa9/2so47Mw==",
           "requires": {
-            "@deephaven/jsapi-types": "^0.58.0",
-            "@deephaven/jsapi-utils": "^0.58.0",
-            "@deephaven/log": "^0.58.0",
-            "@deephaven/plugin": "^0.58.0",
-            "deep-equal": "^2.0.5",
+            "@deephaven/jsapi-types": "^1.0.0-dev0.34.0",
+            "@deephaven/jsapi-utils": "^0.86.0",
+            "@deephaven/log": "^0.86.0",
+            "@deephaven/plugin": "^0.86.0",
+            "fast-deep-equal": "^3.1.3",
+            "proxy-memoize": "^3.0.0",
             "redux-thunk": "2.4.1"
-          }
-        },
-        "@deephaven/storage": {
-          "version": "0.58.0",
-          "requires": {
-            "@deephaven/filters": "^0.58.0",
-            "@deephaven/log": "^0.58.0",
-            "lodash.throttle": "^4.1.1"
+          },
+          "dependencies": {
+            "@deephaven/log": {
+              "version": "0.86.0",
+              "resolved": "https://registry.npmjs.org/@deephaven/log/-/log-0.86.0.tgz",
+              "integrity": "sha512-VgldfD7weCUhtsSFy2KLBRGcgfmIVepZ0rSkyCVVwNLxtu+7BwsJ68uKxOtsUvD+HXHpJkzJZ0MBA8K29lTH6g==",
+              "requires": {
+                "event-target-shim": "^6.0.2"
+              }
+            }
           }
         },
         "@deephaven/utils": {
-          "version": "0.58.0"
+          "version": "0.87.0",
+          "resolved": "https://registry.npmjs.org/@deephaven/utils/-/utils-0.87.0.tgz",
+          "integrity": "sha512-hgvOZQfOMznKX4YeyfBJFjck0IbzAOcPhr9uQO5EDgPvuFQF3b0XKqurqs8plWmSHDv+wDYaubu83dW++EYRcw=="
         },
-        "redux-thunk": {
-          "version": "2.4.1",
-          "requires": {}
+        "buffer": {
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+          "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+          "requires": {
+            "base64-js": "^1.3.1",
+            "ieee754": "^1.2.1"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "event-target-shim": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-6.0.2.tgz",
+          "integrity": "sha512-8q3LsZjRezbFZ2PN+uP+Q7pnHUMmAOziU2vA2OwoFaKIXxlxl38IylhSSgUorWu/rf4er67w0ikBqjBFk/pomA=="
         },
         "typescript": {
           "version": "4.9.5",
@@ -36151,10 +36817,6 @@
         },
         "event-target-shim": {
           "version": "6.0.2"
-        },
-        "redux-thunk": {
-          "version": "2.4.1",
-          "requires": {}
         },
         "typescript": {
           "version": "4.9.5",
@@ -36631,12 +37293,6 @@
         "event-target-shim": {
           "version": "6.0.2"
         },
-        "redux-thunk": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.4.1.tgz",
-          "integrity": "sha512-OOYGNY5Jy2TWvTL1KgAlVy6dcx3siPJ1wTq741EPyUKfn6W6nChdICjZwCd0p8AZBs5kWpZlbkXW2nE/zjUa+Q==",
-          "requires": {}
-        },
         "typescript": {
           "version": "4.9.5",
           "dev": true
@@ -36950,12 +37606,6 @@
         "@deephaven/log": "^0.40.0",
         "deep-equal": "^2.0.5",
         "redux-thunk": "2.4.1"
-      },
-      "dependencies": {
-        "redux-thunk": {
-          "version": "2.4.1",
-          "requires": {}
-        }
       }
     },
     "@deephaven/storage": {
@@ -43281,6 +43931,7 @@
     },
     "color-convert": {
       "version": "1.9.3",
+      "dev": true,
       "requires": {
         "color-name": "1.1.3"
       }
@@ -44827,7 +45478,8 @@
       }
     },
     "event-target-shim": {
-      "version": "5.0.1"
+      "version": "5.0.1",
+      "dev": true
     },
     "eventemitter3": {
       "version": "4.0.7",
@@ -51897,6 +52549,12 @@
       "requires": {
         "@babel/runtime": "^7.9.2"
       }
+    },
+    "redux-thunk": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.4.1.tgz",
+      "integrity": "sha512-OOYGNY5Jy2TWvTL1KgAlVy6dcx3siPJ1wTq741EPyUKfn6W6nChdICjZwCd0p8AZBs5kWpZlbkXW2nE/zjUa+Q==",
+      "requires": {}
     },
     "reflect.getprototypeof": {
       "version": "1.0.4",

--- a/plugins/matplotlib/src/js/package.json
+++ b/plugins/matplotlib/src/js/package.json
@@ -30,20 +30,23 @@
     "@vitejs/plugin-react-swc": "^3.0.0",
     "@types/react-dom": "^17.0.2",
     "react": "^17.0.2",
+    "react-dom": "^17.0.2",
     "typescript": "^4.5.4",
     "vite": "~4.1.4"
   },
   "peerDependencies": {
-    "react": "^17.0.2"
+    "react": "^17.0.2",
+    "react-dom": "^17.0.2"
   },
   "dependencies": {
-    "@deephaven/components": "^0.58.0",
-    "@deephaven/dashboard": "^0.58.0",
-    "@deephaven/icons": "^0.58.0",
-    "@deephaven/jsapi-bootstrap": "^0.58.0",
-    "@deephaven/jsapi-types": "^0.58.0",
-    "@deephaven/log": "^0.58.0",
-    "@deephaven/plugin": "^0.58.0"
+    "@deephaven/components": "^0.87.0",
+    "@deephaven/dashboard": "^0.86.0",
+    "@deephaven/icons": "^0.87.0",
+    "@deephaven/jsapi-bootstrap": "^0.87.0",
+    "@deephaven/jsapi-types": "1.0.0-dev0.35.2",
+    "@deephaven/log": "^0.87.0",
+    "@deephaven/plugin": "^0.86.0",
+    "nanoid": "^5.0.7"
   },
   "publishConfig": {
     "access": "public"

--- a/plugins/matplotlib/src/js/src/DashboardPlugin.tsx
+++ b/plugins/matplotlib/src/js/src/DashboardPlugin.tsx
@@ -1,0 +1,78 @@
+import React, { useCallback, useEffect } from 'react';
+import { nanoid } from 'nanoid';
+import {
+  DashboardPluginComponentProps,
+  LayoutUtils,
+  useListener,
+} from '@deephaven/dashboard';
+import type { dh } from '@deephaven/jsapi-types';
+import Log from '@deephaven/log';
+import MatplotlibPanel from './MatplotlibPanel';
+
+const VARIABLE_TYPE = 'matplotlib.figure.Figure';
+
+const log = Log.module('@deephaven/js-plugin-matplotlib.DashboardPlugin');
+
+export function DashboardPlugin({
+  id,
+  layout,
+  registerComponent,
+}: DashboardPluginComponentProps): React.ReactNode {
+  const handlePanelOpen = useCallback(
+    ({
+      dragEvent,
+      fetch,
+      metadata = {},
+      panelId = nanoid(),
+      widget,
+    }: {
+      dragEvent?: DragEvent;
+      fetch: () => Promise<dh.Widget>;
+      metadata?: Record<string, unknown>;
+      panelId?: string;
+      widget: dh.ide.VariableDescriptor;
+    }) => {
+      const { name, type } = widget;
+      if (type !== VARIABLE_TYPE) {
+        // Only want to listen for matplotlib panels
+        return;
+      }
+      log.info('Panel opened of type', type);
+      const config = {
+        type: 'react-component' as const,
+        component: MatplotlibPanel.COMPONENT,
+        props: {
+          localDashboardId: id,
+          id: panelId,
+          metadata: {
+            ...metadata,
+            ...widget,
+          },
+          fetch,
+        },
+        title: name ?? undefined,
+        id: panelId,
+      };
+
+      const { root } = layout;
+      LayoutUtils.openComponent({ root, config, dragEvent });
+    },
+    [id, layout]
+  );
+
+  useEffect(() => {
+    const cleanups = [
+      registerComponent(MatplotlibPanel.COMPONENT, MatplotlibPanel),
+    ];
+
+    return () => {
+      cleanups.forEach(cleanup => cleanup());
+    };
+  }, [registerComponent]);
+
+  useListener(layout.eventHub, 'PanelEvent.OPEN', handlePanelOpen);
+
+  return null;
+}
+
+export default DashboardPlugin;

--- a/plugins/matplotlib/src/js/src/MatplotlibPanel.tsx
+++ b/plugins/matplotlib/src/js/src/MatplotlibPanel.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { type dh } from '@deephaven/jsapi-types';
+import { type WidgetPanelProps } from '@deephaven/plugin';
+import MatplotlibView from './MatplotlibView';
+
+/**
+ * This is just a wrapper panel around the MatplotlibView to make TS happy.
+ * This can be removed when the DashboardPlugin legacy plugin is removed.
+ */
+function MatplotlibPanel(props: WidgetPanelProps<dh.Widget>): JSX.Element {
+  // eslint-disable-next-line react/jsx-props-no-spreading
+  return <MatplotlibView {...props} />;
+}
+
+MatplotlibPanel.COMPONENT = 'MatPlotLibPanel';
+
+export default MatplotlibPanel;

--- a/plugins/matplotlib/src/js/src/MatplotlibPlugin.ts
+++ b/plugins/matplotlib/src/js/src/MatplotlibPlugin.ts
@@ -1,9 +1,11 @@
 import { type WidgetPlugin, PluginType } from '@deephaven/plugin';
+import { type dh } from '@deephaven/jsapi-types';
 import { vsGraph } from '@deephaven/icons';
 import { MatplotlibView } from './MatplotlibView';
 
-export const MatplotlibPlugin: WidgetPlugin = {
+export const MatplotlibPlugin: WidgetPlugin<dh.Widget> = {
   name: '@deephaven/js-plugin-matplotlib',
+  title: 'Matplotlib Figure',
   type: PluginType.WIDGET_PLUGIN,
   supportedTypes: 'matplotlib.figure.Figure',
   component: MatplotlibView,

--- a/plugins/matplotlib/src/js/src/MatplotlibView.tsx
+++ b/plugins/matplotlib/src/js/src/MatplotlibView.tsx
@@ -1,6 +1,6 @@
 import React, { CSSProperties, useEffect, useState } from 'react';
 import { useApi } from '@deephaven/jsapi-bootstrap';
-import type { Table, ViewportData } from '@deephaven/jsapi-types';
+import type { dh } from '@deephaven/jsapi-types';
 import Log from '@deephaven/log';
 import { WidgetComponentProps } from '@deephaven/plugin';
 
@@ -30,17 +30,19 @@ export const MatplotlibViewImageStyle: CSSProperties = {
 /**
  * Displays a rendered matplotlib from the server
  */
-export function MatplotlibView(props: WidgetComponentProps): JSX.Element {
+export function MatplotlibView(
+  props: WidgetComponentProps<dh.Widget>
+): JSX.Element {
   const { fetch } = props;
   const [imageSrc, setImageSrc] = useState<string>();
-  const [inputTable, setInputTable] = useState<Table>();
+  const [inputTable, setInputTable] = useState<dh.Table>();
   // Set revision to 0 until we're listening to the revision table
   const [revision, setRevision] = useState<number>(0);
   const dh = useApi();
 
   useEffect(
     function initInputTable() {
-      if (!inputTable) {
+      if (inputTable == null) {
         return;
       }
 
@@ -55,7 +57,7 @@ export function MatplotlibView(props: WidgetComponentProps): JSX.Element {
         ]);
         table.addEventListener(
           dh.Table.EVENT_UPDATED,
-          ({ detail: data }: CustomEvent<ViewportData>) => {
+          ({ detail: data }: CustomEvent<dh.ViewportData>) => {
             const newRevision = data.rows[0].get(valueColumn);
             log.debug('New revision', newRevision);
             setRevision(newRevision);
@@ -83,7 +85,7 @@ export function MatplotlibView(props: WidgetComponentProps): JSX.Element {
           log.debug('Getting new input table');
           // We haven't connected to the input table yet, do that
           const newInputTable =
-            (await widget.exportedObjects[0].fetch()) as Table;
+            (await widget.exportedObjects[0].fetch()) as dh.Table;
           setInputTable(newInputTable);
         }
       }

--- a/plugins/matplotlib/src/js/src/index.ts
+++ b/plugins/matplotlib/src/js/src/index.ts
@@ -1,3 +1,6 @@
 import { MatplotlibPlugin } from './MatplotlibPlugin';
 
+// Export legacy dashboard plugin as named export for backwards compatibility
+export * from './DashboardPlugin';
+
 export default MatplotlibPlugin;

--- a/plugins/matplotlib/src/js/vite.config.ts
+++ b/plugins/matplotlib/src/js/vite.config.ts
@@ -1,3 +1,4 @@
+/* eslint-disable import/no-extraneous-dependencies */
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react-swc';
 


### PR DESCRIPTION
Tested on dev-grizzly w/ a Core+ worker using this snippet. Also imported the all types dashboard from DH-16263 and that loaded on dev-grizzly properly.

```py
import matplotlib.pyplot as plt
import deephaven.ui as ui

mpl_fig = plt.figure()
ax = mpl_fig.subplots()  # Create a figure containing a single axes.
ax.plot([1, 2, 3, 4], [4, 2, 6, 7])  # Plot some data on the axes.

@ui.component
def test():
    mpl_fig = plt.figure()
    ax = mpl_fig.subplots()  # Create a figure containing a single axes.
    ax.plot([1, 2, 3, 4], [4, 2, 6, 7])  # Plot some data on the axes.

    return mpl_fig

mpl_dhui = test()
```