### PR TITLE
fix: Revert clearing the build/dist directories

### DIFF
--- a/plugins/ui/setup.py
+++ b/plugins/ui/setup.py
@@ -6,13 +6,6 @@ from deephaven.plugin.packaging import package_js
 js_dir = "src/js/"
 dest_dir = os.path.join("src/deephaven/ui/_js")
 
-# remove the build/dist directory to ensure that the package is built from the latest js files
-try:
-    shutil.rmtree("build")
-    shutil.rmtree("dist")
-except FileNotFoundError:
-    pass
-
 package_js(js_dir, dest_dir)
 
 setup(package_data={"deephaven.ui._js": ["**"]})


### PR DESCRIPTION
We recently merged #599 which works fine locally but appears to remove the `whl` file in our gh actions.
There are other solutions we can investigate, but this is just to get ui docs built so any better solution is beyond the scope of this.
It's worth noting that `plugin_builder.py` also will clean the directories up automatically and might be the better path forward for development cases.