### PR TITLE
fix: Can't pass both x and y to violin, box and strip

### DIFF
--- a/plugins/plotly-express/src/deephaven/plot/express/plots/PartitionManager.py
+++ b/plugins/plotly-express/src/deephaven/plot/express/plots/PartitionManager.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-import sys
 from collections.abc import Generator, Callable
+from copy import copy
 from typing import Any, cast, Tuple, Dict
 
 import plotly.express as px
@@ -161,7 +161,9 @@ class PartitionManager:
         self.marg_color = None
 
         self.args = args
-        self.groups = groups if groups else set()
+        # in some cases, such as violin plots, the default groups are a static object that is shared and should
+        # be copied to not modify the original
+        self.groups = copy(groups) if groups else set()
         self.preprocessor = None
         self.set_long_mode_variables()
         self.convert_table_to_long_mode()

--- a/plugins/plotly-express/src/deephaven/plot/express/plots/distribution.py
+++ b/plugins/plotly-express/src/deephaven/plot/express/plots/distribution.py
@@ -1,21 +1,16 @@
 from __future__ import annotations
 
-from functools import partial
 from typing import Callable
-
-from plotly import express as px
 
 from deephaven.table import Table
 
 from ._private_utils import (
-    validate_common_args,
     shared_violin,
     shared_box,
     shared_strip,
     shared_histogram,
 )
 from ..deephaven_figure import DeephavenFigure
-from ..preprocess import preprocess_ecdf
 
 from ..shared import (
     VIOLIN_DEFAULTS,
@@ -23,7 +18,6 @@ from ..shared import (
     STRIP_DEFAULTS,
     HISTOGRAM_DEFAULTS,
     default_callback,
-    unsafe_figure_update_wrapper,
 )
 
 
@@ -53,12 +47,12 @@ def violin(
 
     Args:
       table: A table to pull data from.
-      x: A column name or list of columns that contain x-axis values.
-        Only one of x or y can be specified. If x is specified,
-        the violins are drawn horizontally.
-      y: A column name or list of columns that contain y-axis values.
-        Only one of x or y can be specified. If y is specified, the
-        violins are drawn vertically.
+      x: A column or list of columns that contain x-axis values.
+        If both x and y are specified, one should be numerical and the other categorical.
+        If x is numerical, the violins are drawn horizontally.
+      y: A column or list of columns that contain y-axis values.
+        If both x and y are specified, one should be numerical and the other categorical.
+        If y is numerical, the violins are drawn vertically.
       by: A column or list of columns that contain values to plot the figure traces by.
         All values or combination of values map to a unique design. The variable
         by_vars specifies which design elements are used.
@@ -103,9 +97,6 @@ def violin(
       DeephavenFigure: A DeephavenFigure that contains the violin chart
 
     """
-    if x and y:
-        raise ValueError("Cannot specify both x and y")
-
     args = locals()
 
     return shared_violin(is_marginal=False, **args)
@@ -137,12 +128,12 @@ def box(
 
     Args:
       table: A table to pull data from.
-      x: A column name or list of columns that contain x-axis values.
-        Only one of x or y can be specified. If x is specified,
-        the boxes are drawn horizontally.
-      y: A column name or list of columns that contain y-axis values.
-        Only one of x or y can be specified. If y is specified, the
-        boxes are drawn vertically.
+      x: A column or list of columns that contain x-axis values.
+        If both x and y are specified, one should be numerical and the other categorical.
+        If x is numerical, the violins are drawn horizontally.
+      y: A column or list of columns that contain y-axis values.
+        If both x and y are specified, one should be numerical and the other categorical.
+        If y is numerical, the violins are drawn vertically.
       by: A column or list of columns that contain values to plot the figure traces by.
         All values or combination of values map to a unique design. The variable
         by_vars specifies which design elements are used.
@@ -187,9 +178,6 @@ def box(
       A DeephavenFigure that contains the box chart
 
     """
-    if x and y:
-        raise ValueError("Cannot specify both x and y")
-
     args = locals()
 
     return shared_box(is_marginal=False, **args)
@@ -219,12 +207,12 @@ def strip(
 
     Args:
       table: A table to pull data from.
-      x: A column name or list of columns that contain x-axis values.
-        Only one of x or y can be specified. If x is specified,
-        the strips are drawn horizontally.
-      y: A column name or list of columns that contain y-axis values.
-        Only one of x or y can be specified. If y is specified, the
-        strips are drawn vertically.
+      x: A column or list of columns that contain x-axis values.
+        If both x and y are specified, one should be numerical and the other categorical.
+        If x is numerical, the violins are drawn horizontally.
+      y: A column or list of columns that contain y-axis values.
+        If both x and y are specified, one should be numerical and the other categorical.
+        If y is numerical, the violins are drawn vertically.
       by: A column or list of columns that contain values to plot the figure traces by.
         All values or combination of values map to a unique design. The variable
         by_vars specifies which design elements are used.
@@ -265,9 +253,6 @@ def strip(
       A DeephavenFigure that contains the strip chart
 
     """
-    if x and y:
-        raise ValueError("Cannot specify both x and y")
-
     args = locals()
 
     return shared_strip(is_marginal=False, **args)

--- a/plugins/plotly-express/test/deephaven/plot/express/plots/test_distribution.py
+++ b/plugins/plotly-express/test/deephaven/plot/express/plots/test_distribution.py
@@ -977,7 +977,7 @@ class DistributionTestCase(BaseTestCase):
         import src.deephaven.plot.express as dx
         from deephaven.constants import NULL_INT
 
-        chart = dx.violin(self.source, y="Y", by="category_str").to_dict(self.exporter)
+        chart = dx.violin(self.source, y="Y", by="category").to_dict(self.exporter)
         plotly, deephaven = chart["plotly"], chart["deephaven"]
 
         # pop template as we currently do not modify it
@@ -1240,7 +1240,7 @@ class DistributionTestCase(BaseTestCase):
             {
                 "alignmentgroup": "True",
                 "box": {"visible": False},
-                "hovertemplate": "category=1<br>Y=%{y}<extra></extra>",
+                "hovertemplate": "category=1<br>value=%{y}<extra></extra>",
                 "legendgroup": "1",
                 "marker": {"color": "#636EFA"},
                 "name": "1",
@@ -1259,7 +1259,7 @@ class DistributionTestCase(BaseTestCase):
             {
                 "alignmentgroup": "True",
                 "box": {"visible": False},
-                "hovertemplate": "category=2<br>Y=%{y}<extra></extra>",
+                "hovertemplate": "category=2<br>value=%{y}<extra></extra>",
                 "legendgroup": "2",
                 "marker": {"color": "#EF553B"},
                 "name": "2",
@@ -1288,15 +1288,15 @@ class DistributionTestCase(BaseTestCase):
                 "anchor": "x",
                 "domain": [0.0, 1.0],
                 "side": "left",
-                "title": {"text": "Y"},
+                "title": {"text": "value"},
             },
         }
 
         self.assertEqual(plotly["layout"], expected_layout)
 
         expected_mappings = [
-            {"data_columns": {"Y": ["/plotly/data/0/y"]}, "table": 0},
-            {"data_columns": {"Y": ["/plotly/data/1/y"]}, "table": 0},
+            {"data_columns": {"value": ["/plotly/data/0/y"]}, "table": 0},
+            {"data_columns": {"value": ["/plotly/data/1/y"]}, "table": 0},
         ]
 
         self.assertEqual(deephaven["mappings"], expected_mappings)

--- a/plugins/plotly-express/test/deephaven/plot/express/plots/test_distribution.py
+++ b/plugins/plotly-express/test/deephaven/plot/express/plots/test_distribution.py
@@ -481,6 +481,1026 @@ class DistributionTestCase(BaseTestCase):
         self.assertEqual(deephaven["is_user_set_template"], False)
         self.assertEqual(deephaven["is_user_set_color"], False)
 
+    def test_basic_violin_x_y(self):
+        import src.deephaven.plot.express as dx
+        from deephaven.constants import NULL_INT
+
+        chart = dx.violin(self.source, x="X", y="Y").to_dict(self.exporter)
+        plotly, deephaven = chart["plotly"], chart["deephaven"]
+
+        # pop template as we currently do not modify it
+        plotly["layout"].pop("template")
+
+        expected_data = [
+            {
+                "alignmentgroup": "True",
+                "box": {"visible": False},
+                "hovertemplate": "X=%{x}<br>Y=%{y}<extra></extra>",
+                "legendgroup": "",
+                "marker": {"color": "#636efa"},
+                "name": "",
+                "offsetgroup": "",
+                "orientation": "v",
+                "points": "outliers",
+                "scalegroup": "True",
+                "showlegend": False,
+                "type": "violin",
+                "x": [NULL_INT],
+                "x0": " ",
+                "xaxis": "x",
+                "y": [NULL_INT],
+                "y0": " ",
+                "yaxis": "y",
+            }
+        ]
+
+        self.assertEqual(plotly["data"], expected_data)
+
+        expected_layout = {
+            "legend": {"tracegroupgap": 0},
+            "margin": {"t": 60},
+            "showlegend": False,
+            "violinmode": "group",
+            "xaxis": {
+                "anchor": "y",
+                "domain": [0.0, 1.0],
+                "side": "bottom",
+                "title": {"text": "X"},
+            },
+            "yaxis": {
+                "anchor": "x",
+                "domain": [0.0, 1.0],
+                "side": "left",
+                "title": {"text": "Y"},
+            },
+        }
+
+        self.assertEqual(plotly["layout"], expected_layout)
+
+        expected_mappings = [
+            {
+                "data_columns": {"X": ["/plotly/data/0/x"], "Y": ["/plotly/data/0/y"]},
+                "table": 0,
+            }
+        ]
+
+        self.assertEqual(deephaven["mappings"], expected_mappings)
+
+        self.assertEqual(deephaven["is_user_set_template"], False)
+        self.assertEqual(deephaven["is_user_set_color"], False)
+
+    def test_list_violin_x(self):
+        import src.deephaven.plot.express as dx
+        from deephaven.constants import NULL_INT
+
+        chart = dx.violin(self.source, x=["X", "Y"]).to_dict(self.exporter)
+        plotly, deephaven = chart["plotly"], chart["deephaven"]
+
+        # pop template as we currently do not modify it
+        plotly["layout"].pop("template")
+
+        expected_data = [
+            {
+                "alignmentgroup": "True",
+                "box": {"visible": False},
+                "hovertemplate": "variable=X<br>value=%{x}<extra></extra>",
+                "legendgroup": "X",
+                "marker": {"color": "#636EFA"},
+                "name": "X",
+                "offsetgroup": "variable0",
+                "orientation": "h",
+                "points": "outliers",
+                "scalegroup": "True",
+                "showlegend": True,
+                "type": "violin",
+                "x": [NULL_INT],
+                "x0": " ",
+                "xaxis": "x",
+                "y0": " ",
+                "yaxis": "y",
+            },
+            {
+                "alignmentgroup": "True",
+                "box": {"visible": False},
+                "hovertemplate": "variable=Y<br>value=%{x}<extra></extra>",
+                "legendgroup": "Y",
+                "marker": {"color": "#EF553B"},
+                "name": "Y",
+                "offsetgroup": "variable1",
+                "orientation": "h",
+                "points": "outliers",
+                "scalegroup": "True",
+                "showlegend": True,
+                "type": "violin",
+                "x": [NULL_INT],
+                "x0": " ",
+                "xaxis": "x",
+                "y0": " ",
+                "yaxis": "y",
+            },
+        ]
+
+        self.assertEqual(plotly["data"], expected_data)
+
+        expected_layout = {
+            "legend": {"tracegroupgap": 0},
+            "margin": {"t": 60},
+            "violinmode": "group",
+            "xaxis": {
+                "anchor": "y",
+                "domain": [0.0, 1.0],
+                "side": "bottom",
+                "title": {"text": "value"},
+            },
+            "yaxis": {"anchor": "x", "domain": [0.0, 1.0], "side": "left"},
+        }
+
+        self.assertEqual(plotly["layout"], expected_layout)
+
+        expected_mappings = [
+            {"data_columns": {"value": ["/plotly/data/0/x"]}, "table": 0},
+            {"data_columns": {"value": ["/plotly/data/1/x"]}, "table": 0},
+        ]
+
+        self.assertEqual(deephaven["mappings"], expected_mappings)
+
+        self.assertEqual(deephaven["is_user_set_template"], False)
+        self.assertEqual(deephaven["is_user_set_color"], True)
+
+    def test_list_violin_y(self):
+        import src.deephaven.plot.express as dx
+        from deephaven.constants import NULL_INT
+
+        chart = dx.violin(self.source, y=["X", "Y"]).to_dict(self.exporter)
+        plotly, deephaven = chart["plotly"], chart["deephaven"]
+
+        # pop template as we currently do not modify it
+        plotly["layout"].pop("template")
+
+        expected_data = [
+            {
+                "alignmentgroup": "True",
+                "box": {"visible": False},
+                "hovertemplate": "variable=X<br>value=%{y}<extra></extra>",
+                "legendgroup": "X",
+                "marker": {"color": "#636EFA"},
+                "name": "X",
+                "offsetgroup": "variable0",
+                "orientation": "v",
+                "points": "outliers",
+                "scalegroup": "True",
+                "showlegend": True,
+                "type": "violin",
+                "x0": " ",
+                "xaxis": "x",
+                "y": [NULL_INT],
+                "y0": " ",
+                "yaxis": "y",
+            },
+            {
+                "alignmentgroup": "True",
+                "box": {"visible": False},
+                "hovertemplate": "variable=Y<br>value=%{y}<extra></extra>",
+                "legendgroup": "Y",
+                "marker": {"color": "#EF553B"},
+                "name": "Y",
+                "offsetgroup": "variable1",
+                "orientation": "v",
+                "points": "outliers",
+                "scalegroup": "True",
+                "showlegend": True,
+                "type": "violin",
+                "x0": " ",
+                "xaxis": "x",
+                "y": [NULL_INT],
+                "y0": " ",
+                "yaxis": "y",
+            },
+        ]
+
+        self.assertEqual(plotly["data"], expected_data)
+
+        expected_layout = {
+            "legend": {"tracegroupgap": 0},
+            "margin": {"t": 60},
+            "violinmode": "group",
+            "xaxis": {"anchor": "y", "domain": [0.0, 1.0], "side": "bottom"},
+            "yaxis": {
+                "anchor": "x",
+                "domain": [0.0, 1.0],
+                "side": "left",
+                "title": {"text": "value"},
+            },
+        }
+
+        self.assertEqual(plotly["layout"], expected_layout)
+
+        expected_mappings = [
+            {"data_columns": {"value": ["/plotly/data/0/y"]}, "table": 0},
+            {"data_columns": {"value": ["/plotly/data/1/y"]}, "table": 0},
+        ]
+
+        self.assertEqual(deephaven["mappings"], expected_mappings)
+
+        self.assertEqual(deephaven["is_user_set_template"], False)
+        self.assertEqual(deephaven["is_user_set_color"], True)
+
+    def test_list_violin_x_y(self):
+        import src.deephaven.plot.express as dx
+        from deephaven.constants import NULL_INT
+
+        chart = dx.violin(self.source, x=["X", "X2"], y="Y").to_dict(self.exporter)
+        plotly, deephaven = chart["plotly"], chart["deephaven"]
+
+        # pop template as we currently do not modify it
+        plotly["layout"].pop("template")
+
+        expected_data = [
+            {
+                "alignmentgroup": "True",
+                "box": {"visible": False},
+                "hovertemplate": "variable=X<br>value=%{x}<br>Y=%{y}<extra></extra>",
+                "legendgroup": "X",
+                "marker": {"color": "#636EFA"},
+                "name": "X",
+                "offsetgroup": "variable0",
+                "orientation": "v",
+                "points": "outliers",
+                "scalegroup": "True",
+                "showlegend": True,
+                "type": "violin",
+                "x": [NULL_INT],
+                "x0": " ",
+                "xaxis": "x",
+                "y": [NULL_INT],
+                "y0": " ",
+                "yaxis": "y",
+            },
+            {
+                "alignmentgroup": "True",
+                "box": {"visible": False},
+                "hovertemplate": "variable=X2<br>value=%{x}<br>Y=%{y}<extra></extra>",
+                "legendgroup": "X2",
+                "marker": {"color": "#EF553B"},
+                "name": "X2",
+                "offsetgroup": "variable1",
+                "orientation": "v",
+                "points": "outliers",
+                "scalegroup": "True",
+                "showlegend": True,
+                "type": "violin",
+                "x": [NULL_INT],
+                "x0": " ",
+                "xaxis": "x",
+                "y": [NULL_INT],
+                "y0": " ",
+                "yaxis": "y",
+            },
+        ]
+
+        self.assertEqual(plotly["data"], expected_data)
+
+        expected_layout = {
+            "legend": {"tracegroupgap": 0},
+            "margin": {"t": 60},
+            "violinmode": "group",
+            "xaxis": {
+                "anchor": "y",
+                "domain": [0.0, 1.0],
+                "side": "bottom",
+                "title": {"text": "value"},
+            },
+            "yaxis": {
+                "anchor": "x",
+                "domain": [0.0, 1.0],
+                "side": "left",
+                "title": {"text": "Y"},
+            },
+        }
+
+        self.assertEqual(plotly["layout"], expected_layout)
+
+        expected_mappings = [
+            {
+                "data_columns": {
+                    "Y": ["/plotly/data/0/y"],
+                    "value": ["/plotly/data/0/x"],
+                },
+                "table": 0,
+            },
+            {
+                "data_columns": {
+                    "Y": ["/plotly/data/1/y"],
+                    "value": ["/plotly/data/1/x"],
+                },
+                "table": 0,
+            },
+        ]
+
+        self.assertEqual(deephaven["mappings"], expected_mappings)
+
+        self.assertEqual(deephaven["is_user_set_template"], False)
+        self.assertEqual(deephaven["is_user_set_color"], True)
+
+        chart = dx.violin(self.source, x="X", y=["Y", "Y2"]).to_dict(self.exporter)
+        plotly, deephaven = chart["plotly"], chart["deephaven"]
+
+        # pop template as we currently do not modify it
+        plotly["layout"].pop("template")
+
+        expected_data = [
+            {
+                "alignmentgroup": "True",
+                "box": {"visible": False},
+                "hovertemplate": "variable=Y<br>X=%{x}<br>value=%{y}<extra></extra>",
+                "legendgroup": "Y",
+                "marker": {"color": "#636EFA"},
+                "name": "Y",
+                "offsetgroup": "variable0",
+                "orientation": "v",
+                "points": "outliers",
+                "scalegroup": "True",
+                "showlegend": True,
+                "type": "violin",
+                "x": [NULL_INT],
+                "x0": " ",
+                "xaxis": "x",
+                "y": [NULL_INT],
+                "y0": " ",
+                "yaxis": "y",
+            },
+            {
+                "alignmentgroup": "True",
+                "box": {"visible": False},
+                "hovertemplate": "variable=Y2<br>X=%{x}<br>value=%{y}<extra></extra>",
+                "legendgroup": "Y2",
+                "marker": {"color": "#EF553B"},
+                "name": "Y2",
+                "offsetgroup": "variable1",
+                "orientation": "v",
+                "points": "outliers",
+                "scalegroup": "True",
+                "showlegend": True,
+                "type": "violin",
+                "x": [NULL_INT],
+                "x0": " ",
+                "xaxis": "x",
+                "y": [NULL_INT],
+                "y0": " ",
+                "yaxis": "y",
+            },
+        ]
+
+        self.assertEqual(plotly["data"], expected_data)
+
+        expected_layout = {
+            "legend": {"tracegroupgap": 0},
+            "margin": {"t": 60},
+            "violinmode": "group",
+            "xaxis": {
+                "anchor": "y",
+                "domain": [0.0, 1.0],
+                "side": "bottom",
+                "title": {"text": "X"},
+            },
+            "yaxis": {
+                "anchor": "x",
+                "domain": [0.0, 1.0],
+                "side": "left",
+                "title": {"text": "value"},
+            },
+        }
+
+        self.assertEqual(plotly["layout"], expected_layout)
+
+        expected_mappings = [
+            {
+                "data_columns": {
+                    "X": ["/plotly/data/0/x"],
+                    "value": ["/plotly/data/0/y"],
+                },
+                "table": 0,
+            },
+            {
+                "data_columns": {
+                    "X": ["/plotly/data/1/x"],
+                    "value": ["/plotly/data/1/y"],
+                },
+                "table": 0,
+            },
+        ]
+
+        self.assertEqual(deephaven["mappings"], expected_mappings)
+
+        self.assertEqual(deephaven["is_user_set_template"], False)
+        self.assertEqual(deephaven["is_user_set_color"], True)
+
+    def test_by_violin_x(self):
+        import src.deephaven.plot.express as dx
+        from deephaven.constants import NULL_INT
+
+        chart = dx.violin(self.source, x="X", by="category").to_dict(self.exporter)
+        plotly, deephaven = chart["plotly"], chart["deephaven"]
+
+        # pop template as we currently do not modify it
+        plotly["layout"].pop("template")
+
+        expected_data = [
+            {
+                "alignmentgroup": "True",
+                "box": {"visible": False},
+                "hovertemplate": "category=1<br>X=%{x}<extra></extra>",
+                "legendgroup": "1",
+                "marker": {"color": "#636EFA"},
+                "name": "1",
+                "offsetgroup": "category0",
+                "orientation": "h",
+                "points": "outliers",
+                "scalegroup": "True",
+                "showlegend": True,
+                "type": "violin",
+                "x": [NULL_INT],
+                "x0": " ",
+                "xaxis": "x",
+                "y0": " ",
+                "yaxis": "y",
+            },
+            {
+                "alignmentgroup": "True",
+                "box": {"visible": False},
+                "hovertemplate": "category=2<br>X=%{x}<extra></extra>",
+                "legendgroup": "2",
+                "marker": {"color": "#EF553B"},
+                "name": "2",
+                "offsetgroup": "category1",
+                "orientation": "h",
+                "points": "outliers",
+                "scalegroup": "True",
+                "showlegend": True,
+                "type": "violin",
+                "x": [NULL_INT],
+                "x0": " ",
+                "xaxis": "x",
+                "y0": " ",
+                "yaxis": "y",
+            },
+        ]
+
+        self.assertEqual(plotly["data"], expected_data)
+
+        expected_layout = {
+            "legend": {"tracegroupgap": 0},
+            "margin": {"t": 60},
+            "violinmode": "group",
+            "xaxis": {
+                "anchor": "y",
+                "domain": [0.0, 1.0],
+                "side": "bottom",
+                "title": {"text": "X"},
+            },
+            "yaxis": {"anchor": "x", "domain": [0.0, 1.0], "side": "left"},
+        }
+
+        self.assertEqual(plotly["layout"], expected_layout)
+
+        expected_mappings = [
+            {"data_columns": {"X": ["/plotly/data/0/x"]}, "table": 0},
+            {"data_columns": {"X": ["/plotly/data/1/x"]}, "table": 0},
+        ]
+
+        self.assertEqual(deephaven["mappings"], expected_mappings)
+
+        self.assertEqual(deephaven["is_user_set_template"], False)
+        self.assertEqual(deephaven["is_user_set_color"], True)
+
+    def test_by_violin_y(self):
+        import src.deephaven.plot.express as dx
+        from deephaven.constants import NULL_INT
+
+        chart = dx.violin(self.source, y="Y", by="category_str").to_dict(self.exporter)
+        plotly, deephaven = chart["plotly"], chart["deephaven"]
+
+        # pop template as we currently do not modify it
+        plotly["layout"].pop("template")
+
+        expected_data = [
+            {
+                "alignmentgroup": "True",
+                "box": {"visible": False},
+                "hovertemplate": "category=1<br>Y=%{y}<extra></extra>",
+                "legendgroup": "1",
+                "marker": {"color": "#636EFA"},
+                "name": "1",
+                "offsetgroup": "category0",
+                "orientation": "v",
+                "points": "outliers",
+                "scalegroup": "True",
+                "showlegend": True,
+                "type": "violin",
+                "x0": " ",
+                "xaxis": "x",
+                "y": [NULL_INT],
+                "y0": " ",
+                "yaxis": "y",
+            },
+            {
+                "alignmentgroup": "True",
+                "box": {"visible": False},
+                "hovertemplate": "category=2<br>Y=%{y}<extra></extra>",
+                "legendgroup": "2",
+                "marker": {"color": "#EF553B"},
+                "name": "2",
+                "offsetgroup": "category1",
+                "orientation": "v",
+                "points": "outliers",
+                "scalegroup": "True",
+                "showlegend": True,
+                "type": "violin",
+                "x0": " ",
+                "xaxis": "x",
+                "y": [NULL_INT],
+                "y0": " ",
+                "yaxis": "y",
+            },
+        ]
+
+        self.assertEqual(plotly["data"], expected_data)
+
+        expected_layout = {
+            "legend": {"tracegroupgap": 0},
+            "margin": {"t": 60},
+            "violinmode": "group",
+            "xaxis": {"anchor": "y", "domain": [0.0, 1.0], "side": "bottom"},
+            "yaxis": {
+                "anchor": "x",
+                "domain": [0.0, 1.0],
+                "side": "left",
+                "title": {"text": "Y"},
+            },
+        }
+
+        self.assertEqual(plotly["layout"], expected_layout)
+
+        expected_mappings = [
+            {"data_columns": {"Y": ["/plotly/data/0/y"]}, "table": 0},
+            {"data_columns": {"Y": ["/plotly/data/1/y"]}, "table": 0},
+        ]
+
+        self.assertEqual(deephaven["mappings"], expected_mappings)
+
+        self.assertEqual(deephaven["is_user_set_template"], False)
+        self.assertEqual(deephaven["is_user_set_color"], True)
+
+    def test_by_violin_x_y(self):
+        import src.deephaven.plot.express as dx
+        from deephaven.constants import NULL_INT
+
+        chart = dx.violin(self.source, x="X", y="Y", by="category").to_dict(
+            self.exporter
+        )
+        plotly, deephaven = chart["plotly"], chart["deephaven"]
+
+        # pop template as we currently do not modify it
+        plotly["layout"].pop("template")
+
+        expected_data = [
+            {
+                "alignmentgroup": "True",
+                "box": {"visible": False},
+                "hovertemplate": "category=1<br>X=%{x}<br>Y=%{y}<extra></extra>",
+                "legendgroup": "1",
+                "marker": {"color": "#636EFA"},
+                "name": "1",
+                "offsetgroup": "category0",
+                "orientation": "v",
+                "points": "outliers",
+                "scalegroup": "True",
+                "showlegend": True,
+                "type": "violin",
+                "x": [NULL_INT],
+                "x0": " ",
+                "xaxis": "x",
+                "y": [NULL_INT],
+                "y0": " ",
+                "yaxis": "y",
+            },
+            {
+                "alignmentgroup": "True",
+                "box": {"visible": False},
+                "hovertemplate": "category=2<br>X=%{x}<br>Y=%{y}<extra></extra>",
+                "legendgroup": "2",
+                "marker": {"color": "#EF553B"},
+                "name": "2",
+                "offsetgroup": "category1",
+                "orientation": "v",
+                "points": "outliers",
+                "scalegroup": "True",
+                "showlegend": True,
+                "type": "violin",
+                "x": [NULL_INT],
+                "x0": " ",
+                "xaxis": "x",
+                "y": [NULL_INT],
+                "y0": " ",
+                "yaxis": "y",
+            },
+        ]
+
+        self.assertEqual(plotly["data"], expected_data)
+
+        expected_layout = {
+            "legend": {"tracegroupgap": 0},
+            "margin": {"t": 60},
+            "violinmode": "group",
+            "xaxis": {
+                "anchor": "y",
+                "domain": [0.0, 1.0],
+                "side": "bottom",
+                "title": {"text": "X"},
+            },
+            "yaxis": {
+                "anchor": "x",
+                "domain": [0.0, 1.0],
+                "side": "left",
+                "title": {"text": "Y"},
+            },
+        }
+
+        self.assertEqual(plotly["layout"], expected_layout)
+
+        expected_mappings = [
+            {
+                "data_columns": {"X": ["/plotly/data/0/x"], "Y": ["/plotly/data/0/y"]},
+                "table": 0,
+            },
+            {
+                "data_columns": {"X": ["/plotly/data/1/x"], "Y": ["/plotly/data/1/y"]},
+                "table": 0,
+            },
+        ]
+
+        self.assertEqual(deephaven["mappings"], expected_mappings)
+
+        self.assertEqual(deephaven["is_user_set_template"], False)
+        self.assertEqual(deephaven["is_user_set_color"], True)
+
+    def test_list_by_violin_x(self):
+        import src.deephaven.plot.express as dx
+        from deephaven.constants import NULL_INT
+
+        chart = dx.violin(self.source, x=["X", "X2"], by="category").to_dict(
+            self.exporter
+        )
+        plotly, deephaven = chart["plotly"], chart["deephaven"]
+
+        # pop template as we currently do not modify it
+        plotly["layout"].pop("template")
+
+        expected_data = [
+            {
+                "alignmentgroup": "True",
+                "box": {"visible": False},
+                "hovertemplate": "category=1<br>value=%{x}<extra></extra>",
+                "legendgroup": "1",
+                "marker": {"color": "#636EFA"},
+                "name": "1",
+                "offsetgroup": "category0",
+                "orientation": "h",
+                "points": "outliers",
+                "scalegroup": "True",
+                "showlegend": True,
+                "type": "violin",
+                "x": [NULL_INT],
+                "x0": " ",
+                "xaxis": "x",
+                "y0": " ",
+                "yaxis": "y",
+            },
+            {
+                "alignmentgroup": "True",
+                "box": {"visible": False},
+                "hovertemplate": "category=2<br>value=%{x}<extra></extra>",
+                "legendgroup": "2",
+                "marker": {"color": "#EF553B"},
+                "name": "2",
+                "offsetgroup": "category1",
+                "orientation": "h",
+                "points": "outliers",
+                "scalegroup": "True",
+                "showlegend": True,
+                "type": "violin",
+                "x": [NULL_INT],
+                "x0": " ",
+                "xaxis": "x",
+                "y0": " ",
+                "yaxis": "y",
+            },
+        ]
+
+        self.assertEqual(plotly["data"], expected_data)
+
+        expected_layout = {
+            "legend": {"tracegroupgap": 0},
+            "margin": {"t": 60},
+            "violinmode": "group",
+            "xaxis": {
+                "anchor": "y",
+                "domain": [0.0, 1.0],
+                "side": "bottom",
+                "title": {"text": "value"},
+            },
+            "yaxis": {"anchor": "x", "domain": [0.0, 1.0], "side": "left"},
+        }
+
+        self.assertEqual(plotly["layout"], expected_layout)
+
+        expected_mappings = [
+            {"data_columns": {"value": ["/plotly/data/0/x"]}, "table": 0},
+            {"data_columns": {"value": ["/plotly/data/1/x"]}, "table": 0},
+        ]
+
+        self.assertEqual(deephaven["mappings"], expected_mappings)
+
+        self.assertEqual(deephaven["is_user_set_template"], False)
+        self.assertEqual(deephaven["is_user_set_color"], True)
+
+    def test_list_by_violin_y(self):
+        import src.deephaven.plot.express as dx
+        from deephaven.constants import NULL_INT
+
+        chart = dx.violin(self.source, y=["Y", "Y2"], by="category").to_dict(
+            self.exporter
+        )
+        plotly, deephaven = chart["plotly"], chart["deephaven"]
+
+        # pop template as we currently do not modify it
+        plotly["layout"].pop("template")
+
+        expected_data = [
+            {
+                "alignmentgroup": "True",
+                "box": {"visible": False},
+                "hovertemplate": "category=1<br>Y=%{y}<extra></extra>",
+                "legendgroup": "1",
+                "marker": {"color": "#636EFA"},
+                "name": "1",
+                "offsetgroup": "category0",
+                "orientation": "v",
+                "points": "outliers",
+                "scalegroup": "True",
+                "showlegend": True,
+                "type": "violin",
+                "x0": " ",
+                "xaxis": "x",
+                "y": [NULL_INT],
+                "y0": " ",
+                "yaxis": "y",
+            },
+            {
+                "alignmentgroup": "True",
+                "box": {"visible": False},
+                "hovertemplate": "category=2<br>Y=%{y}<extra></extra>",
+                "legendgroup": "2",
+                "marker": {"color": "#EF553B"},
+                "name": "2",
+                "offsetgroup": "category1",
+                "orientation": "v",
+                "points": "outliers",
+                "scalegroup": "True",
+                "showlegend": True,
+                "type": "violin",
+                "x0": " ",
+                "xaxis": "x",
+                "y": [NULL_INT],
+                "y0": " ",
+                "yaxis": "y",
+            },
+        ]
+
+        self.assertEqual(plotly["data"], expected_data)
+
+        expected_layout = {
+            "legend": {"tracegroupgap": 0},
+            "margin": {"t": 60},
+            "violinmode": "group",
+            "xaxis": {"anchor": "y", "domain": [0.0, 1.0], "side": "bottom"},
+            "yaxis": {
+                "anchor": "x",
+                "domain": [0.0, 1.0],
+                "side": "left",
+                "title": {"text": "Y"},
+            },
+        }
+
+        self.assertEqual(plotly["layout"], expected_layout)
+
+        expected_mappings = [
+            {"data_columns": {"Y": ["/plotly/data/0/y"]}, "table": 0},
+            {"data_columns": {"Y": ["/plotly/data/1/y"]}, "table": 0},
+        ]
+
+        self.assertEqual(deephaven["mappings"], expected_mappings)
+
+        self.assertEqual(deephaven["is_user_set_template"], False)
+        self.assertEqual(deephaven["is_user_set_color"], True)
+
+    def test_list_by_violin_x_y(self):
+        import src.deephaven.plot.express as dx
+        from deephaven.constants import NULL_INT
+
+        chart = dx.violin(self.source, x=["X", "X2"], y="Y", by="category").to_dict(
+            self.exporter
+        )
+        plotly, deephaven = chart["plotly"], chart["deephaven"]
+
+        # pop template as we currently do not modify it
+        plotly["layout"].pop("template")
+
+        expected_data = [
+            {
+                "alignmentgroup": "True",
+                "box": {"visible": False},
+                "hovertemplate": "category=1<br>value=%{x}<br>Y=%{y}<extra></extra>",
+                "legendgroup": "1",
+                "marker": {"color": "#636EFA"},
+                "name": "1",
+                "offsetgroup": "category0",
+                "orientation": "v",
+                "points": "outliers",
+                "scalegroup": "True",
+                "showlegend": True,
+                "type": "violin",
+                "x": [NULL_INT],
+                "x0": " ",
+                "xaxis": "x",
+                "y": [NULL_INT],
+                "y0": " ",
+                "yaxis": "y",
+            },
+            {
+                "alignmentgroup": "True",
+                "box": {"visible": False},
+                "hovertemplate": "category=2<br>value=%{x}<br>Y=%{y}<extra></extra>",
+                "legendgroup": "2",
+                "marker": {"color": "#EF553B"},
+                "name": "2",
+                "offsetgroup": "category1",
+                "orientation": "v",
+                "points": "outliers",
+                "scalegroup": "True",
+                "showlegend": True,
+                "type": "violin",
+                "x": [NULL_INT],
+                "x0": " ",
+                "xaxis": "x",
+                "y": [NULL_INT],
+                "y0": " ",
+                "yaxis": "y",
+            },
+        ]
+
+        self.assertEqual(plotly["data"], expected_data)
+
+        expected_layout = {
+            "legend": {"tracegroupgap": 0},
+            "margin": {"t": 60},
+            "violinmode": "group",
+            "xaxis": {
+                "anchor": "y",
+                "domain": [0.0, 1.0],
+                "side": "bottom",
+                "title": {"text": "value"},
+            },
+            "yaxis": {
+                "anchor": "x",
+                "domain": [0.0, 1.0],
+                "side": "left",
+                "title": {"text": "Y"},
+            },
+        }
+
+        self.assertEqual(plotly["layout"], expected_layout)
+
+        expected_mappings = [
+            {
+                "data_columns": {
+                    "Y": ["/plotly/data/0/y"],
+                    "value": ["/plotly/data/0/x"],
+                },
+                "table": 0,
+            },
+            {
+                "data_columns": {
+                    "Y": ["/plotly/data/1/y"],
+                    "value": ["/plotly/data/1/x"],
+                },
+                "table": 0,
+            },
+        ]
+
+        self.assertEqual(deephaven["mappings"], expected_mappings)
+
+        self.assertEqual(deephaven["is_user_set_template"], False)
+        self.assertEqual(deephaven["is_user_set_color"], True)
+
+        import src.deephaven.plot.express as dx
+        from deephaven.constants import NULL_INT
+
+        chart = dx.violin(self.source, x="X", y=["Y", "Y2"], by="category").to_dict(
+            self.exporter
+        )
+        plotly, deephaven = chart["plotly"], chart["deephaven"]
+
+        # pop template as we currently do not modify it
+        plotly["layout"].pop("template")
+
+        expected_data = [
+            {
+                "alignmentgroup": "True",
+                "box": {"visible": False},
+                "hovertemplate": "category=1<br>X=%{x}<br>value=%{y}<extra></extra>",
+                "legendgroup": "1",
+                "marker": {"color": "#636EFA"},
+                "name": "1",
+                "offsetgroup": "category0",
+                "orientation": "v",
+                "points": "outliers",
+                "scalegroup": "True",
+                "showlegend": True,
+                "type": "violin",
+                "x": [NULL_INT],
+                "x0": " ",
+                "xaxis": "x",
+                "y": [NULL_INT],
+                "y0": " ",
+                "yaxis": "y",
+            },
+            {
+                "alignmentgroup": "True",
+                "box": {"visible": False},
+                "hovertemplate": "category=2<br>X=%{x}<br>value=%{y}<extra></extra>",
+                "legendgroup": "2",
+                "marker": {"color": "#EF553B"},
+                "name": "2",
+                "offsetgroup": "category1",
+                "orientation": "v",
+                "points": "outliers",
+                "scalegroup": "True",
+                "showlegend": True,
+                "type": "violin",
+                "x": [NULL_INT],
+                "x0": " ",
+                "xaxis": "x",
+                "y": [NULL_INT],
+                "y0": " ",
+                "yaxis": "y",
+            },
+        ]
+
+        self.assertEqual(plotly["data"], expected_data)
+
+        expected_layout = {
+            "legend": {"tracegroupgap": 0},
+            "margin": {"t": 60},
+            "violinmode": "group",
+            "xaxis": {
+                "anchor": "y",
+                "domain": [0.0, 1.0],
+                "side": "bottom",
+                "title": {"text": "X"},
+            },
+            "yaxis": {
+                "anchor": "x",
+                "domain": [0.0, 1.0],
+                "side": "left",
+                "title": {"text": "value"},
+            },
+        }
+
+        self.assertEqual(plotly["layout"], expected_layout)
+
+        expected_mappings = [
+            {
+                "data_columns": {
+                    "X": ["/plotly/data/0/x"],
+                    "value": ["/plotly/data/0/y"],
+                },
+                "table": 0,
+            },
+            {
+                "data_columns": {
+                    "X": ["/plotly/data/1/x"],
+                    "value": ["/plotly/data/1/y"],
+                },
+                "table": 0,
+            },
+        ]
+
+        self.assertEqual(deephaven["mappings"], expected_mappings)
+
+        self.assertEqual(deephaven["is_user_set_template"], False)
+        self.assertEqual(deephaven["is_user_set_color"], True)
+
     def test_basic_box_x(self):
         import src.deephaven.plot.express as dx
         from deephaven.constants import NULL_INT
@@ -592,6 +1612,999 @@ class DistributionTestCase(BaseTestCase):
 
         self.assertEqual(deephaven["is_user_set_template"], False)
         self.assertEqual(deephaven["is_user_set_color"], False)
+
+    def test_basic_box_x_y(self):
+        import src.deephaven.plot.express as dx
+        from deephaven.constants import NULL_INT
+
+        chart = dx.box(self.source, x="X", y="Y").to_dict(self.exporter)
+        plotly, deephaven = chart["plotly"], chart["deephaven"]
+
+        # pop template as we currently do not modify it
+        plotly["layout"].pop("template")
+
+        expected_data = [
+            {
+                "alignmentgroup": "True",
+                "boxpoints": "outliers",
+                "hovertemplate": "X=%{x}<br>Y=%{y}<extra></extra>",
+                "legendgroup": "",
+                "marker": {"color": "#636efa"},
+                "name": "",
+                "notched": False,
+                "offsetgroup": "",
+                "orientation": "v",
+                "showlegend": False,
+                "type": "box",
+                "x": [NULL_INT],
+                "x0": " ",
+                "xaxis": "x",
+                "y": [NULL_INT],
+                "y0": " ",
+                "yaxis": "y",
+            }
+        ]
+
+        self.assertEqual(plotly["data"], expected_data)
+
+        expected_layout = {
+            "boxmode": "group",
+            "legend": {"tracegroupgap": 0},
+            "margin": {"t": 60},
+            "showlegend": False,
+            "xaxis": {
+                "anchor": "y",
+                "domain": [0.0, 1.0],
+                "side": "bottom",
+                "title": {"text": "X"},
+            },
+            "yaxis": {
+                "anchor": "x",
+                "domain": [0.0, 1.0],
+                "side": "left",
+                "title": {"text": "Y"},
+            },
+        }
+
+        self.assertEqual(plotly["layout"], expected_layout)
+
+        expected_mappings = [
+            {
+                "data_columns": {"X": ["/plotly/data/0/x"], "Y": ["/plotly/data/0/y"]},
+                "table": 0,
+            }
+        ]
+
+        self.assertEqual(deephaven["mappings"], expected_mappings)
+
+        self.assertEqual(deephaven["is_user_set_template"], False)
+        self.assertEqual(deephaven["is_user_set_color"], False)
+
+    def test_list_box_x(self):
+        import src.deephaven.plot.express as dx
+        from deephaven.constants import NULL_INT
+
+        chart = dx.box(self.source, x=["X", "Y"]).to_dict(self.exporter)
+        plotly, deephaven = chart["plotly"], chart["deephaven"]
+
+        # pop template as we currently do not modify it
+        plotly["layout"].pop("template")
+
+        expected_data = [
+            {
+                "alignmentgroup": "True",
+                "boxpoints": "outliers",
+                "hovertemplate": "variable=X<br>value=%{x}<extra></extra>",
+                "legendgroup": "X",
+                "marker": {"color": "#636EFA"},
+                "name": "X",
+                "notched": False,
+                "offsetgroup": "variable0",
+                "orientation": "h",
+                "showlegend": True,
+                "type": "box",
+                "x": [NULL_INT],
+                "x0": " ",
+                "xaxis": "x",
+                "y0": " ",
+                "yaxis": "y",
+            },
+            {
+                "alignmentgroup": "True",
+                "boxpoints": "outliers",
+                "hovertemplate": "variable=Y<br>value=%{x}<extra></extra>",
+                "legendgroup": "Y",
+                "marker": {"color": "#EF553B"},
+                "name": "Y",
+                "notched": False,
+                "offsetgroup": "variable1",
+                "orientation": "h",
+                "showlegend": True,
+                "type": "box",
+                "x": [NULL_INT],
+                "x0": " ",
+                "xaxis": "x",
+                "y0": " ",
+                "yaxis": "y",
+            },
+        ]
+
+        self.assertEqual(plotly["data"], expected_data)
+
+        expected_layout = {
+            "boxmode": "group",
+            "legend": {"tracegroupgap": 0},
+            "margin": {"t": 60},
+            "xaxis": {
+                "anchor": "y",
+                "domain": [0.0, 1.0],
+                "side": "bottom",
+                "title": {"text": "value"},
+            },
+            "yaxis": {"anchor": "x", "domain": [0.0, 1.0], "side": "left"},
+        }
+
+        self.assertEqual(plotly["layout"], expected_layout)
+
+        expected_mappings = [
+            {"data_columns": {"value": ["/plotly/data/0/x"]}, "table": 0},
+            {"data_columns": {"value": ["/plotly/data/1/x"]}, "table": 0},
+        ]
+
+        self.assertEqual(deephaven["mappings"], expected_mappings)
+
+        self.assertEqual(deephaven["is_user_set_template"], False)
+        self.assertEqual(deephaven["is_user_set_color"], True)
+
+    def test_list_box_y(self):
+        import src.deephaven.plot.express as dx
+        from deephaven.constants import NULL_INT
+
+        chart = dx.box(self.source, y=["X", "Y"]).to_dict(self.exporter)
+        plotly, deephaven = chart["plotly"], chart["deephaven"]
+
+        # pop template as we currently do not modify it
+        plotly["layout"].pop("template")
+
+        expected_data = [
+            {
+                "alignmentgroup": "True",
+                "boxpoints": "outliers",
+                "hovertemplate": "variable=X<br>value=%{y}<extra></extra>",
+                "legendgroup": "X",
+                "marker": {"color": "#636EFA"},
+                "name": "X",
+                "notched": False,
+                "offsetgroup": "variable0",
+                "orientation": "v",
+                "showlegend": True,
+                "type": "box",
+                "x0": " ",
+                "xaxis": "x",
+                "y": [NULL_INT],
+                "y0": " ",
+                "yaxis": "y",
+            },
+            {
+                "alignmentgroup": "True",
+                "boxpoints": "outliers",
+                "hovertemplate": "variable=Y<br>value=%{y}<extra></extra>",
+                "legendgroup": "Y",
+                "marker": {"color": "#EF553B"},
+                "name": "Y",
+                "notched": False,
+                "offsetgroup": "variable1",
+                "orientation": "v",
+                "showlegend": True,
+                "type": "box",
+                "x0": " ",
+                "xaxis": "x",
+                "y": [NULL_INT],
+                "y0": " ",
+                "yaxis": "y",
+            },
+        ]
+
+        self.assertEqual(plotly["data"], expected_data)
+
+        expected_layout = {
+            "boxmode": "group",
+            "legend": {"tracegroupgap": 0},
+            "margin": {"t": 60},
+            "xaxis": {"anchor": "y", "domain": [0.0, 1.0], "side": "bottom"},
+            "yaxis": {
+                "anchor": "x",
+                "domain": [0.0, 1.0],
+                "side": "left",
+                "title": {"text": "value"},
+            },
+        }
+
+        self.assertEqual(plotly["layout"], expected_layout)
+
+        expected_mappings = [
+            {"data_columns": {"value": ["/plotly/data/0/y"]}, "table": 0},
+            {"data_columns": {"value": ["/plotly/data/1/y"]}, "table": 0},
+        ]
+
+        self.assertEqual(deephaven["mappings"], expected_mappings)
+
+        self.assertEqual(deephaven["is_user_set_template"], False)
+        self.assertEqual(deephaven["is_user_set_color"], True)
+
+    def test_list_box_x_y(self):
+        import src.deephaven.plot.express as dx
+        from deephaven.constants import NULL_INT
+
+        chart = dx.box(self.source, x=["X", "X2"], y="Y").to_dict(self.exporter)
+        plotly, deephaven = chart["plotly"], chart["deephaven"]
+
+        # pop template as we currently do not modify it
+        plotly["layout"].pop("template")
+
+        expected_data = [
+            {
+                "alignmentgroup": "True",
+                "boxpoints": "outliers",
+                "hovertemplate": "variable=X<br>value=%{x}<br>Y=%{y}<extra></extra>",
+                "legendgroup": "X",
+                "marker": {"color": "#636EFA"},
+                "name": "X",
+                "notched": False,
+                "offsetgroup": "variable0",
+                "orientation": "v",
+                "showlegend": True,
+                "type": "box",
+                "x": [NULL_INT],
+                "x0": " ",
+                "xaxis": "x",
+                "y": [NULL_INT],
+                "y0": " ",
+                "yaxis": "y",
+            },
+            {
+                "alignmentgroup": "True",
+                "boxpoints": "outliers",
+                "hovertemplate": "variable=X2<br>value=%{x}<br>Y=%{y}<extra></extra>",
+                "legendgroup": "X2",
+                "marker": {"color": "#EF553B"},
+                "name": "X2",
+                "notched": False,
+                "offsetgroup": "variable1",
+                "orientation": "v",
+                "showlegend": True,
+                "type": "box",
+                "x": [NULL_INT],
+                "x0": " ",
+                "xaxis": "x",
+                "y": [NULL_INT],
+                "y0": " ",
+                "yaxis": "y",
+            },
+        ]
+
+        self.assertEqual(plotly["data"], expected_data)
+
+        expected_layout = {
+            "boxmode": "group",
+            "legend": {"tracegroupgap": 0},
+            "margin": {"t": 60},
+            "xaxis": {
+                "anchor": "y",
+                "domain": [0.0, 1.0],
+                "side": "bottom",
+                "title": {"text": "value"},
+            },
+            "yaxis": {
+                "anchor": "x",
+                "domain": [0.0, 1.0],
+                "side": "left",
+                "title": {"text": "Y"},
+            },
+        }
+
+        self.assertEqual(plotly["layout"], expected_layout)
+
+        expected_mappings = [
+            {
+                "data_columns": {
+                    "Y": ["/plotly/data/0/y"],
+                    "value": ["/plotly/data/0/x"],
+                },
+                "table": 0,
+            },
+            {
+                "data_columns": {
+                    "Y": ["/plotly/data/1/y"],
+                    "value": ["/plotly/data/1/x"],
+                },
+                "table": 0,
+            },
+        ]
+
+        self.assertEqual(deephaven["mappings"], expected_mappings)
+
+        self.assertEqual(deephaven["is_user_set_template"], False)
+        self.assertEqual(deephaven["is_user_set_color"], True)
+
+        chart = dx.box(self.source, x="X", y=["Y", "Y2"]).to_dict(self.exporter)
+        plotly, deephaven = chart["plotly"], chart["deephaven"]
+
+        # pop template as we currently do not modify it
+        plotly["layout"].pop("template")
+
+        expected_data = [
+            {
+                "alignmentgroup": "True",
+                "boxpoints": "outliers",
+                "hovertemplate": "variable=Y<br>X=%{x}<br>value=%{y}<extra></extra>",
+                "legendgroup": "Y",
+                "marker": {"color": "#636EFA"},
+                "name": "Y",
+                "notched": False,
+                "offsetgroup": "variable0",
+                "orientation": "v",
+                "showlegend": True,
+                "type": "box",
+                "x": [NULL_INT],
+                "x0": " ",
+                "xaxis": "x",
+                "y": [NULL_INT],
+                "y0": " ",
+                "yaxis": "y",
+            },
+            {
+                "alignmentgroup": "True",
+                "boxpoints": "outliers",
+                "hovertemplate": "variable=Y2<br>X=%{x}<br>value=%{y}<extra></extra>",
+                "legendgroup": "Y2",
+                "marker": {"color": "#EF553B"},
+                "name": "Y2",
+                "notched": False,
+                "offsetgroup": "variable1",
+                "orientation": "v",
+                "showlegend": True,
+                "type": "box",
+                "x": [NULL_INT],
+                "x0": " ",
+                "xaxis": "x",
+                "y": [NULL_INT],
+                "y0": " ",
+                "yaxis": "y",
+            },
+        ]
+
+        self.assertEqual(plotly["data"], expected_data)
+
+        expected_layout = {
+            "boxmode": "group",
+            "legend": {"tracegroupgap": 0},
+            "margin": {"t": 60},
+            "xaxis": {
+                "anchor": "y",
+                "domain": [0.0, 1.0],
+                "side": "bottom",
+                "title": {"text": "X"},
+            },
+            "yaxis": {
+                "anchor": "x",
+                "domain": [0.0, 1.0],
+                "side": "left",
+                "title": {"text": "value"},
+            },
+        }
+
+        self.assertEqual(plotly["layout"], expected_layout)
+
+        expected_mappings = [
+            {
+                "data_columns": {
+                    "X": ["/plotly/data/0/x"],
+                    "value": ["/plotly/data/0/y"],
+                },
+                "table": 0,
+            },
+            {
+                "data_columns": {
+                    "X": ["/plotly/data/1/x"],
+                    "value": ["/plotly/data/1/y"],
+                },
+                "table": 0,
+            },
+        ]
+
+        self.assertEqual(deephaven["mappings"], expected_mappings)
+
+        self.assertEqual(deephaven["is_user_set_template"], False)
+        self.assertEqual(deephaven["is_user_set_color"], True)
+
+    def test_by_box_x(self):
+        import src.deephaven.plot.express as dx
+        from deephaven.constants import NULL_INT
+
+        chart = dx.box(self.source, x="X", by="category").to_dict(self.exporter)
+        plotly, deephaven = chart["plotly"], chart["deephaven"]
+
+        # pop template as we currently do not modify it
+        plotly["layout"].pop("template")
+
+        expected_data = [
+            {
+                "alignmentgroup": "True",
+                "boxpoints": "outliers",
+                "hovertemplate": "category=1<br>X=%{x}<extra></extra>",
+                "legendgroup": "1",
+                "marker": {"color": "#636EFA"},
+                "name": "1",
+                "notched": False,
+                "offsetgroup": "category0",
+                "orientation": "h",
+                "showlegend": True,
+                "type": "box",
+                "x": [NULL_INT],
+                "x0": " ",
+                "xaxis": "x",
+                "y0": " ",
+                "yaxis": "y",
+            },
+            {
+                "alignmentgroup": "True",
+                "boxpoints": "outliers",
+                "hovertemplate": "category=2<br>X=%{x}<extra></extra>",
+                "legendgroup": "2",
+                "marker": {"color": "#EF553B"},
+                "name": "2",
+                "notched": False,
+                "offsetgroup": "category1",
+                "orientation": "h",
+                "showlegend": True,
+                "type": "box",
+                "x": [NULL_INT],
+                "x0": " ",
+                "xaxis": "x",
+                "y0": " ",
+                "yaxis": "y",
+            },
+        ]
+
+        self.assertEqual(plotly["data"], expected_data)
+
+        expected_layout = {
+            "boxmode": "group",
+            "legend": {"tracegroupgap": 0},
+            "margin": {"t": 60},
+            "xaxis": {
+                "anchor": "y",
+                "domain": [0.0, 1.0],
+                "side": "bottom",
+                "title": {"text": "X"},
+            },
+            "yaxis": {"anchor": "x", "domain": [0.0, 1.0], "side": "left"},
+        }
+
+        self.assertEqual(plotly["layout"], expected_layout)
+
+        expected_mappings = [
+            {"data_columns": {"X": ["/plotly/data/0/x"]}, "table": 0},
+            {"data_columns": {"X": ["/plotly/data/1/x"]}, "table": 0},
+        ]
+
+        self.assertEqual(deephaven["mappings"], expected_mappings)
+
+        self.assertEqual(deephaven["is_user_set_template"], False)
+        self.assertEqual(deephaven["is_user_set_color"], True)
+
+    def test_by_box_y(self):
+        import src.deephaven.plot.express as dx
+        from deephaven.constants import NULL_INT
+
+        chart = dx.box(self.source, y="Y", by="category").to_dict(self.exporter)
+        plotly, deephaven = chart["plotly"], chart["deephaven"]
+
+        # pop template as we currently do not modify it
+        plotly["layout"].pop("template")
+
+        expected_data = [
+            {
+                "alignmentgroup": "True",
+                "boxpoints": "outliers",
+                "hovertemplate": "category=1<br>Y=%{y}<extra></extra>",
+                "legendgroup": "1",
+                "marker": {"color": "#636EFA"},
+                "name": "1",
+                "notched": False,
+                "offsetgroup": "category0",
+                "orientation": "v",
+                "showlegend": True,
+                "type": "box",
+                "x0": " ",
+                "xaxis": "x",
+                "y": [NULL_INT],
+                "y0": " ",
+                "yaxis": "y",
+            },
+            {
+                "alignmentgroup": "True",
+                "boxpoints": "outliers",
+                "hovertemplate": "category=2<br>Y=%{y}<extra></extra>",
+                "legendgroup": "2",
+                "marker": {"color": "#EF553B"},
+                "name": "2",
+                "notched": False,
+                "offsetgroup": "category1",
+                "orientation": "v",
+                "showlegend": True,
+                "type": "box",
+                "x0": " ",
+                "xaxis": "x",
+                "y": [NULL_INT],
+                "y0": " ",
+                "yaxis": "y",
+            },
+        ]
+
+        self.assertEqual(plotly["data"], expected_data)
+
+        expected_layout = {
+            "boxmode": "group",
+            "legend": {"tracegroupgap": 0},
+            "margin": {"t": 60},
+            "xaxis": {"anchor": "y", "domain": [0.0, 1.0], "side": "bottom"},
+            "yaxis": {
+                "anchor": "x",
+                "domain": [0.0, 1.0],
+                "side": "left",
+                "title": {"text": "Y"},
+            },
+        }
+
+        self.assertEqual(plotly["layout"], expected_layout)
+
+        expected_mappings = [
+            {"data_columns": {"Y": ["/plotly/data/0/y"]}, "table": 0},
+            {"data_columns": {"Y": ["/plotly/data/1/y"]}, "table": 0},
+        ]
+
+        self.assertEqual(deephaven["mappings"], expected_mappings)
+
+        self.assertEqual(deephaven["is_user_set_template"], False)
+        self.assertEqual(deephaven["is_user_set_color"], True)
+
+    def test_by_box_x_y(self):
+        import src.deephaven.plot.express as dx
+        from deephaven.constants import NULL_INT
+
+        chart = dx.box(self.source, x="X", y="Y", by="category").to_dict(self.exporter)
+        plotly, deephaven = chart["plotly"], chart["deephaven"]
+
+        # pop template as we currently do not modify it
+        plotly["layout"].pop("template")
+
+        expected_data = [
+            {
+                "alignmentgroup": "True",
+                "boxpoints": "outliers",
+                "hovertemplate": "category=1<br>X=%{x}<br>Y=%{y}<extra></extra>",
+                "legendgroup": "1",
+                "marker": {"color": "#636EFA"},
+                "name": "1",
+                "notched": False,
+                "offsetgroup": "category0",
+                "orientation": "v",
+                "showlegend": True,
+                "type": "box",
+                "x": [NULL_INT],
+                "x0": " ",
+                "xaxis": "x",
+                "y": [NULL_INT],
+                "y0": " ",
+                "yaxis": "y",
+            },
+            {
+                "alignmentgroup": "True",
+                "boxpoints": "outliers",
+                "hovertemplate": "category=2<br>X=%{x}<br>Y=%{y}<extra></extra>",
+                "legendgroup": "2",
+                "marker": {"color": "#EF553B"},
+                "name": "2",
+                "notched": False,
+                "offsetgroup": "category1",
+                "orientation": "v",
+                "showlegend": True,
+                "type": "box",
+                "x": [NULL_INT],
+                "x0": " ",
+                "xaxis": "x",
+                "y": [NULL_INT],
+                "y0": " ",
+                "yaxis": "y",
+            },
+        ]
+
+        self.assertEqual(plotly["data"], expected_data)
+
+        expected_layout = {
+            "boxmode": "group",
+            "legend": {"tracegroupgap": 0},
+            "margin": {"t": 60},
+            "xaxis": {
+                "anchor": "y",
+                "domain": [0.0, 1.0],
+                "side": "bottom",
+                "title": {"text": "X"},
+            },
+            "yaxis": {
+                "anchor": "x",
+                "domain": [0.0, 1.0],
+                "side": "left",
+                "title": {"text": "Y"},
+            },
+        }
+
+        self.assertEqual(plotly["layout"], expected_layout)
+
+        expected_mappings = [
+            {
+                "data_columns": {"X": ["/plotly/data/0/x"], "Y": ["/plotly/data/0/y"]},
+                "table": 0,
+            },
+            {
+                "data_columns": {"X": ["/plotly/data/1/x"], "Y": ["/plotly/data/1/y"]},
+                "table": 0,
+            },
+        ]
+
+        self.assertEqual(deephaven["mappings"], expected_mappings)
+
+        self.assertEqual(deephaven["is_user_set_template"], False)
+        self.assertEqual(deephaven["is_user_set_color"], True)
+
+    def test_list_by_box_x(self):
+        import src.deephaven.plot.express as dx
+        from deephaven.constants import NULL_INT
+
+        chart = dx.box(self.source, x=["X", "X2"], by="category").to_dict(self.exporter)
+        plotly, deephaven = chart["plotly"], chart["deephaven"]
+
+        # pop template as we currently do not modify it
+        plotly["layout"].pop("template")
+
+        expected_data = [
+            {
+                "alignmentgroup": "True",
+                "boxpoints": "outliers",
+                "hovertemplate": "category=1<br>value=%{x}<extra></extra>",
+                "legendgroup": "1",
+                "marker": {"color": "#636EFA"},
+                "name": "1",
+                "notched": False,
+                "offsetgroup": "category0",
+                "orientation": "h",
+                "showlegend": True,
+                "type": "box",
+                "x": [NULL_INT],
+                "x0": " ",
+                "xaxis": "x",
+                "y0": " ",
+                "yaxis": "y",
+            },
+            {
+                "alignmentgroup": "True",
+                "boxpoints": "outliers",
+                "hovertemplate": "category=2<br>value=%{x}<extra></extra>",
+                "legendgroup": "2",
+                "marker": {"color": "#EF553B"},
+                "name": "2",
+                "notched": False,
+                "offsetgroup": "category1",
+                "orientation": "h",
+                "showlegend": True,
+                "type": "box",
+                "x": [NULL_INT],
+                "x0": " ",
+                "xaxis": "x",
+                "y0": " ",
+                "yaxis": "y",
+            },
+        ]
+
+        self.assertEqual(plotly["data"], expected_data)
+
+        expected_layout = {
+            "boxmode": "group",
+            "legend": {"tracegroupgap": 0},
+            "margin": {"t": 60},
+            "xaxis": {
+                "anchor": "y",
+                "domain": [0.0, 1.0],
+                "side": "bottom",
+                "title": {"text": "value"},
+            },
+            "yaxis": {"anchor": "x", "domain": [0.0, 1.0], "side": "left"},
+        }
+
+        self.assertEqual(plotly["layout"], expected_layout)
+
+        expected_mappings = [
+            {"data_columns": {"value": ["/plotly/data/0/x"]}, "table": 0},
+            {"data_columns": {"value": ["/plotly/data/1/x"]}, "table": 0},
+        ]
+
+        self.assertEqual(deephaven["mappings"], expected_mappings)
+
+        self.assertEqual(deephaven["is_user_set_template"], False)
+        self.assertEqual(deephaven["is_user_set_color"], True)
+
+    def test_list_by_box_y(self):
+        import src.deephaven.plot.express as dx
+        from deephaven.constants import NULL_INT
+
+        chart = dx.box(self.source, y="Y", by="category").to_dict(self.exporter)
+        plotly, deephaven = chart["plotly"], chart["deephaven"]
+
+        # pop template as we currently do not modify it
+        plotly["layout"].pop("template")
+
+        expected_data = [
+            {
+                "alignmentgroup": "True",
+                "boxpoints": "outliers",
+                "hovertemplate": "category=1<br>Y=%{y}<extra></extra>",
+                "legendgroup": "1",
+                "marker": {"color": "#636EFA"},
+                "name": "1",
+                "notched": False,
+                "offsetgroup": "category0",
+                "orientation": "v",
+                "showlegend": True,
+                "type": "box",
+                "x0": " ",
+                "xaxis": "x",
+                "y": [NULL_INT],
+                "y0": " ",
+                "yaxis": "y",
+            },
+            {
+                "alignmentgroup": "True",
+                "boxpoints": "outliers",
+                "hovertemplate": "category=2<br>Y=%{y}<extra></extra>",
+                "legendgroup": "2",
+                "marker": {"color": "#EF553B"},
+                "name": "2",
+                "notched": False,
+                "offsetgroup": "category1",
+                "orientation": "v",
+                "showlegend": True,
+                "type": "box",
+                "x0": " ",
+                "xaxis": "x",
+                "y": [NULL_INT],
+                "y0": " ",
+                "yaxis": "y",
+            },
+        ]
+
+        self.assertEqual(plotly["data"], expected_data)
+
+        expected_layout = {
+            "boxmode": "group",
+            "legend": {"tracegroupgap": 0},
+            "margin": {"t": 60},
+            "xaxis": {"anchor": "y", "domain": [0.0, 1.0], "side": "bottom"},
+            "yaxis": {
+                "anchor": "x",
+                "domain": [0.0, 1.0],
+                "side": "left",
+                "title": {"text": "Y"},
+            },
+        }
+
+        self.assertEqual(plotly["layout"], expected_layout)
+
+        expected_mappings = [
+            {"data_columns": {"Y": ["/plotly/data/0/y"]}, "table": 0},
+            {"data_columns": {"Y": ["/plotly/data/1/y"]}, "table": 0},
+        ]
+
+        self.assertEqual(deephaven["mappings"], expected_mappings)
+
+        self.assertEqual(deephaven["is_user_set_template"], False)
+        self.assertEqual(deephaven["is_user_set_color"], True)
+
+    def test_list_by_box_x_y(self):
+        import src.deephaven.plot.express as dx
+        from deephaven.constants import NULL_INT
+
+        chart = dx.box(self.source, x=["X", "X2"], y="Y", by="category").to_dict(
+            self.exporter
+        )
+        plotly, deephaven = chart["plotly"], chart["deephaven"]
+
+        # pop template as we currently do not modify it
+        plotly["layout"].pop("template")
+
+        expected_data = [
+            {
+                "alignmentgroup": "True",
+                "boxpoints": "outliers",
+                "hovertemplate": "category=1<br>value=%{x}<br>Y=%{y}<extra></extra>",
+                "legendgroup": "1",
+                "marker": {"color": "#636EFA"},
+                "name": "1",
+                "notched": False,
+                "offsetgroup": "category0",
+                "orientation": "v",
+                "showlegend": True,
+                "type": "box",
+                "x": [NULL_INT],
+                "x0": " ",
+                "xaxis": "x",
+                "y": [NULL_INT],
+                "y0": " ",
+                "yaxis": "y",
+            },
+            {
+                "alignmentgroup": "True",
+                "boxpoints": "outliers",
+                "hovertemplate": "category=2<br>value=%{x}<br>Y=%{y}<extra></extra>",
+                "legendgroup": "2",
+                "marker": {"color": "#EF553B"},
+                "name": "2",
+                "notched": False,
+                "offsetgroup": "category1",
+                "orientation": "v",
+                "showlegend": True,
+                "type": "box",
+                "x": [NULL_INT],
+                "x0": " ",
+                "xaxis": "x",
+                "y": [NULL_INT],
+                "y0": " ",
+                "yaxis": "y",
+            },
+        ]
+
+        self.assertEqual(plotly["data"], expected_data)
+
+        expected_layout = {
+            "boxmode": "group",
+            "legend": {"tracegroupgap": 0},
+            "margin": {"t": 60},
+            "xaxis": {
+                "anchor": "y",
+                "domain": [0.0, 1.0],
+                "side": "bottom",
+                "title": {"text": "value"},
+            },
+            "yaxis": {
+                "anchor": "x",
+                "domain": [0.0, 1.0],
+                "side": "left",
+                "title": {"text": "Y"},
+            },
+        }
+
+        self.assertEqual(plotly["layout"], expected_layout)
+
+        expected_mappings = [
+            {
+                "data_columns": {
+                    "Y": ["/plotly/data/0/y"],
+                    "value": ["/plotly/data/0/x"],
+                },
+                "table": 0,
+            },
+            {
+                "data_columns": {
+                    "Y": ["/plotly/data/1/y"],
+                    "value": ["/plotly/data/1/x"],
+                },
+                "table": 0,
+            },
+        ]
+
+        self.assertEqual(deephaven["mappings"], expected_mappings)
+
+        self.assertEqual(deephaven["is_user_set_template"], False)
+        self.assertEqual(deephaven["is_user_set_color"], True)
+
+        import src.deephaven.plot.express as dx
+        from deephaven.constants import NULL_INT
+
+        chart = dx.violin(self.source, x="X", y=["Y", "Y2"], by="category").to_dict(
+            self.exporter
+        )
+        plotly, deephaven = chart["plotly"], chart["deephaven"]
+
+        # pop template as we currently do not modify it
+        plotly["layout"].pop("template")
+
+        expected_data = [
+            {
+                "alignmentgroup": "True",
+                "box": {"visible": False},
+                "hovertemplate": "category=1<br>X=%{x}<br>value=%{y}<extra></extra>",
+                "legendgroup": "1",
+                "marker": {"color": "#636EFA"},
+                "name": "1",
+                "offsetgroup": "category0",
+                "orientation": "v",
+                "points": "outliers",
+                "scalegroup": "True",
+                "showlegend": True,
+                "type": "violin",
+                "x": [NULL_INT],
+                "x0": " ",
+                "xaxis": "x",
+                "y": [NULL_INT],
+                "y0": " ",
+                "yaxis": "y",
+            },
+            {
+                "alignmentgroup": "True",
+                "box": {"visible": False},
+                "hovertemplate": "category=2<br>X=%{x}<br>value=%{y}<extra></extra>",
+                "legendgroup": "2",
+                "marker": {"color": "#EF553B"},
+                "name": "2",
+                "offsetgroup": "category1",
+                "orientation": "v",
+                "points": "outliers",
+                "scalegroup": "True",
+                "showlegend": True,
+                "type": "violin",
+                "x": [NULL_INT],
+                "x0": " ",
+                "xaxis": "x",
+                "y": [NULL_INT],
+                "y0": " ",
+                "yaxis": "y",
+            },
+        ]
+
+        self.assertEqual(plotly["data"], expected_data)
+
+        expected_layout = {
+            "legend": {"tracegroupgap": 0},
+            "margin": {"t": 60},
+            "violinmode": "group",
+            "xaxis": {
+                "anchor": "y",
+                "domain": [0.0, 1.0],
+                "side": "bottom",
+                "title": {"text": "X"},
+            },
+            "yaxis": {
+                "anchor": "x",
+                "domain": [0.0, 1.0],
+                "side": "left",
+                "title": {"text": "value"},
+            },
+        }
+
+        self.assertEqual(plotly["layout"], expected_layout)
+
+        expected_mappings = [
+            {
+                "data_columns": {
+                    "X": ["/plotly/data/0/x"],
+                    "value": ["/plotly/data/0/y"],
+                },
+                "table": 0,
+            },
+            {
+                "data_columns": {
+                    "X": ["/plotly/data/1/x"],
+                    "value": ["/plotly/data/1/y"],
+                },
+                "table": 0,
+            },
+        ]
+
+        self.assertEqual(deephaven["mappings"], expected_mappings)
+
+        self.assertEqual(deephaven["is_user_set_template"], False)
+        self.assertEqual(deephaven["is_user_set_color"], True)
 
     def test_basic_strip_x(self):
         import src.deephaven.plot.express as dx
@@ -707,6 +2720,1059 @@ class DistributionTestCase(BaseTestCase):
 
         self.assertEqual(deephaven["is_user_set_template"], False)
         self.assertEqual(deephaven["is_user_set_color"], False)
+
+    def test_basic_strip_x_y(self):
+        import src.deephaven.plot.express as dx
+        from deephaven.constants import NULL_INT
+
+        chart = dx.strip(self.source, x="X", y="Y").to_dict(self.exporter)
+        plotly, deephaven = chart["plotly"], chart["deephaven"]
+
+        # pop template as we currently do not modify it
+        plotly["layout"].pop("template")
+
+        expected_data = [
+            {
+                "alignmentgroup": "True",
+                "boxpoints": "all",
+                "fillcolor": "rgba(255,255,255,0)",
+                "hoveron": "points",
+                "hovertemplate": "X=%{x}<br>Y=%{y}<extra></extra>",
+                "legendgroup": "",
+                "line": {"color": "rgba(255,255,255,0)"},
+                "marker": {"color": "#636efa"},
+                "name": "",
+                "offsetgroup": "",
+                "orientation": "v",
+                "pointpos": 0,
+                "showlegend": False,
+                "type": "box",
+                "x": [NULL_INT],
+                "x0": " ",
+                "xaxis": "x",
+                "y": [NULL_INT],
+                "y0": " ",
+                "yaxis": "y",
+            }
+        ]
+
+        self.assertEqual(plotly["data"], expected_data)
+
+        expected_layout = {
+            "boxmode": "group",
+            "legend": {"tracegroupgap": 0},
+            "margin": {"t": 60},
+            "showlegend": False,
+            "xaxis": {
+                "anchor": "y",
+                "domain": [0.0, 1.0],
+                "side": "bottom",
+                "title": {"text": "X"},
+            },
+            "yaxis": {
+                "anchor": "x",
+                "domain": [0.0, 1.0],
+                "side": "left",
+                "title": {"text": "Y"},
+            },
+        }
+
+        self.assertEqual(plotly["layout"], expected_layout)
+
+        expected_mappings = [
+            {
+                "data_columns": {"X": ["/plotly/data/0/x"], "Y": ["/plotly/data/0/y"]},
+                "table": 0,
+            }
+        ]
+
+        self.assertEqual(deephaven["mappings"], expected_mappings)
+
+        self.assertEqual(deephaven["is_user_set_template"], False)
+        self.assertEqual(deephaven["is_user_set_color"], False)
+
+    def test_list_strip_x(self):
+        import src.deephaven.plot.express as dx
+        from deephaven.constants import NULL_INT
+
+        chart = dx.strip(self.source, x=["X", "Y"]).to_dict(self.exporter)
+        plotly, deephaven = chart["plotly"], chart["deephaven"]
+
+        # pop template as we currently do not modify it
+        plotly["layout"].pop("template")
+
+        expected_data = [
+            {
+                "alignmentgroup": "True",
+                "boxpoints": "all",
+                "fillcolor": "rgba(255,255,255,0)",
+                "hoveron": "points",
+                "hovertemplate": "variable=X<br>value=%{x}<extra></extra>",
+                "legendgroup": "X",
+                "line": {"color": "rgba(255,255,255,0)"},
+                "marker": {"color": "#636EFA"},
+                "name": "X",
+                "offsetgroup": "variable0",
+                "orientation": "h",
+                "pointpos": 0,
+                "showlegend": True,
+                "type": "box",
+                "x": [NULL_INT],
+                "x0": " ",
+                "xaxis": "x",
+                "y0": " ",
+                "yaxis": "y",
+            },
+            {
+                "alignmentgroup": "True",
+                "boxpoints": "all",
+                "fillcolor": "rgba(255,255,255,0)",
+                "hoveron": "points",
+                "hovertemplate": "variable=Y<br>value=%{x}<extra></extra>",
+                "legendgroup": "Y",
+                "line": {"color": "rgba(255,255,255,0)"},
+                "marker": {"color": "#EF553B"},
+                "name": "Y",
+                "offsetgroup": "variable1",
+                "orientation": "h",
+                "pointpos": 0,
+                "showlegend": True,
+                "type": "box",
+                "x": [NULL_INT],
+                "x0": " ",
+                "xaxis": "x",
+                "y0": " ",
+                "yaxis": "y",
+            },
+        ]
+
+        self.assertEqual(plotly["data"], expected_data)
+
+        expected_layout = {
+            "boxmode": "group",
+            "legend": {"tracegroupgap": 0},
+            "margin": {"t": 60},
+            "xaxis": {
+                "anchor": "y",
+                "domain": [0.0, 1.0],
+                "side": "bottom",
+                "title": {"text": "value"},
+            },
+            "yaxis": {"anchor": "x", "domain": [0.0, 1.0], "side": "left"},
+        }
+
+        self.assertEqual(plotly["layout"], expected_layout)
+
+        expected_mappings = [
+            {"data_columns": {"value": ["/plotly/data/0/x"]}, "table": 0},
+            {"data_columns": {"value": ["/plotly/data/1/x"]}, "table": 0},
+        ]
+
+        self.assertEqual(deephaven["mappings"], expected_mappings)
+
+        self.assertEqual(deephaven["is_user_set_template"], False)
+        self.assertEqual(deephaven["is_user_set_color"], True)
+
+    def test_list_strip_y(self):
+        import src.deephaven.plot.express as dx
+        from deephaven.constants import NULL_INT
+
+        chart = dx.strip(self.source, y=["X", "Y"]).to_dict(self.exporter)
+        plotly, deephaven = chart["plotly"], chart["deephaven"]
+
+        # pop template as we currently do not modify it
+        plotly["layout"].pop("template")
+
+        expected_data = [
+            {
+                "alignmentgroup": "True",
+                "boxpoints": "all",
+                "fillcolor": "rgba(255,255,255,0)",
+                "hoveron": "points",
+                "hovertemplate": "variable=X<br>value=%{y}<extra></extra>",
+                "legendgroup": "X",
+                "line": {"color": "rgba(255,255,255,0)"},
+                "marker": {"color": "#636EFA"},
+                "name": "X",
+                "offsetgroup": "variable0",
+                "orientation": "v",
+                "pointpos": 0,
+                "showlegend": True,
+                "type": "box",
+                "x0": " ",
+                "xaxis": "x",
+                "y": [NULL_INT],
+                "y0": " ",
+                "yaxis": "y",
+            },
+            {
+                "alignmentgroup": "True",
+                "boxpoints": "all",
+                "fillcolor": "rgba(255,255,255,0)",
+                "hoveron": "points",
+                "hovertemplate": "variable=Y<br>value=%{y}<extra></extra>",
+                "legendgroup": "Y",
+                "line": {"color": "rgba(255,255,255,0)"},
+                "marker": {"color": "#EF553B"},
+                "name": "Y",
+                "offsetgroup": "variable1",
+                "orientation": "v",
+                "pointpos": 0,
+                "showlegend": True,
+                "type": "box",
+                "x0": " ",
+                "xaxis": "x",
+                "y": [NULL_INT],
+                "y0": " ",
+                "yaxis": "y",
+            },
+        ]
+
+        self.assertEqual(plotly["data"], expected_data)
+
+        expected_layout = {
+            "boxmode": "group",
+            "legend": {"tracegroupgap": 0},
+            "margin": {"t": 60},
+            "xaxis": {"anchor": "y", "domain": [0.0, 1.0], "side": "bottom"},
+            "yaxis": {
+                "anchor": "x",
+                "domain": [0.0, 1.0],
+                "side": "left",
+                "title": {"text": "value"},
+            },
+        }
+
+        self.assertEqual(plotly["layout"], expected_layout)
+
+        expected_mappings = [
+            {"data_columns": {"value": ["/plotly/data/0/y"]}, "table": 0},
+            {"data_columns": {"value": ["/plotly/data/1/y"]}, "table": 0},
+        ]
+
+        self.assertEqual(deephaven["mappings"], expected_mappings)
+
+        self.assertEqual(deephaven["is_user_set_template"], False)
+        self.assertEqual(deephaven["is_user_set_color"], True)
+
+    def test_list_strip_x_y(self):
+        import src.deephaven.plot.express as dx
+        from deephaven.constants import NULL_INT
+
+        chart = dx.strip(self.source, x=["X", "X2"], y="Y").to_dict(self.exporter)
+        plotly, deephaven = chart["plotly"], chart["deephaven"]
+
+        # pop template as we currently do not modify it
+        plotly["layout"].pop("template")
+
+        expected_data = [
+            {
+                "alignmentgroup": "True",
+                "boxpoints": "all",
+                "fillcolor": "rgba(255,255,255,0)",
+                "hoveron": "points",
+                "hovertemplate": "variable=X<br>value=%{x}<br>Y=%{y}<extra></extra>",
+                "legendgroup": "X",
+                "line": {"color": "rgba(255,255,255,0)"},
+                "marker": {"color": "#636EFA"},
+                "name": "X",
+                "offsetgroup": "variable0",
+                "orientation": "v",
+                "pointpos": 0,
+                "showlegend": True,
+                "type": "box",
+                "x": [NULL_INT],
+                "x0": " ",
+                "xaxis": "x",
+                "y": [NULL_INT],
+                "y0": " ",
+                "yaxis": "y",
+            },
+            {
+                "alignmentgroup": "True",
+                "boxpoints": "all",
+                "fillcolor": "rgba(255,255,255,0)",
+                "hoveron": "points",
+                "hovertemplate": "variable=X2<br>value=%{x}<br>Y=%{y}<extra></extra>",
+                "legendgroup": "X2",
+                "line": {"color": "rgba(255,255,255,0)"},
+                "marker": {"color": "#EF553B"},
+                "name": "X2",
+                "offsetgroup": "variable1",
+                "orientation": "v",
+                "pointpos": 0,
+                "showlegend": True,
+                "type": "box",
+                "x": [NULL_INT],
+                "x0": " ",
+                "xaxis": "x",
+                "y": [NULL_INT],
+                "y0": " ",
+                "yaxis": "y",
+            },
+        ]
+
+        self.assertEqual(plotly["data"], expected_data)
+
+        expected_layout = {
+            "boxmode": "group",
+            "legend": {"tracegroupgap": 0},
+            "margin": {"t": 60},
+            "xaxis": {
+                "anchor": "y",
+                "domain": [0.0, 1.0],
+                "side": "bottom",
+                "title": {"text": "value"},
+            },
+            "yaxis": {
+                "anchor": "x",
+                "domain": [0.0, 1.0],
+                "side": "left",
+                "title": {"text": "Y"},
+            },
+        }
+
+        self.assertEqual(plotly["layout"], expected_layout)
+
+        expected_mappings = [
+            {
+                "data_columns": {
+                    "Y": ["/plotly/data/0/y"],
+                    "value": ["/plotly/data/0/x"],
+                },
+                "table": 0,
+            },
+            {
+                "data_columns": {
+                    "Y": ["/plotly/data/1/y"],
+                    "value": ["/plotly/data/1/x"],
+                },
+                "table": 0,
+            },
+        ]
+
+        self.assertEqual(deephaven["mappings"], expected_mappings)
+
+        self.assertEqual(deephaven["is_user_set_template"], False)
+        self.assertEqual(deephaven["is_user_set_color"], True)
+
+        chart = dx.violin(self.source, x="X", y=["Y", "Y2"]).to_dict(self.exporter)
+        plotly, deephaven = chart["plotly"], chart["deephaven"]
+
+        # pop template as we currently do not modify it
+        plotly["layout"].pop("template")
+
+        expected_data = [
+            {
+                "alignmentgroup": "True",
+                "box": {"visible": False},
+                "hovertemplate": "variable=Y<br>X=%{x}<br>value=%{y}<extra></extra>",
+                "legendgroup": "Y",
+                "marker": {"color": "#636EFA"},
+                "name": "Y",
+                "offsetgroup": "variable0",
+                "orientation": "v",
+                "points": "outliers",
+                "scalegroup": "True",
+                "showlegend": True,
+                "type": "violin",
+                "x": [NULL_INT],
+                "x0": " ",
+                "xaxis": "x",
+                "y": [NULL_INT],
+                "y0": " ",
+                "yaxis": "y",
+            },
+            {
+                "alignmentgroup": "True",
+                "box": {"visible": False},
+                "hovertemplate": "variable=Y2<br>X=%{x}<br>value=%{y}<extra></extra>",
+                "legendgroup": "Y2",
+                "marker": {"color": "#EF553B"},
+                "name": "Y2",
+                "offsetgroup": "variable1",
+                "orientation": "v",
+                "points": "outliers",
+                "scalegroup": "True",
+                "showlegend": True,
+                "type": "violin",
+                "x": [NULL_INT],
+                "x0": " ",
+                "xaxis": "x",
+                "y": [NULL_INT],
+                "y0": " ",
+                "yaxis": "y",
+            },
+        ]
+
+        self.assertEqual(plotly["data"], expected_data)
+
+        expected_layout = {
+            "legend": {"tracegroupgap": 0},
+            "margin": {"t": 60},
+            "violinmode": "group",
+            "xaxis": {
+                "anchor": "y",
+                "domain": [0.0, 1.0],
+                "side": "bottom",
+                "title": {"text": "X"},
+            },
+            "yaxis": {
+                "anchor": "x",
+                "domain": [0.0, 1.0],
+                "side": "left",
+                "title": {"text": "value"},
+            },
+        }
+
+        self.assertEqual(plotly["layout"], expected_layout)
+
+        expected_mappings = [
+            {
+                "data_columns": {
+                    "X": ["/plotly/data/0/x"],
+                    "value": ["/plotly/data/0/y"],
+                },
+                "table": 0,
+            },
+            {
+                "data_columns": {
+                    "X": ["/plotly/data/1/x"],
+                    "value": ["/plotly/data/1/y"],
+                },
+                "table": 0,
+            },
+        ]
+
+        self.assertEqual(deephaven["mappings"], expected_mappings)
+
+        self.assertEqual(deephaven["is_user_set_template"], False)
+        self.assertEqual(deephaven["is_user_set_color"], True)
+
+    def test_by_strip_x(self):
+        import src.deephaven.plot.express as dx
+        from deephaven.constants import NULL_INT
+
+        chart = dx.strip(self.source, x="X", by="category").to_dict(self.exporter)
+        plotly, deephaven = chart["plotly"], chart["deephaven"]
+
+        # pop template as we currently do not modify it
+        plotly["layout"].pop("template")
+
+        expected_data = [
+            {
+                "alignmentgroup": "True",
+                "boxpoints": "all",
+                "fillcolor": "rgba(255,255,255,0)",
+                "hoveron": "points",
+                "hovertemplate": "category=1<br>X=%{x}<extra></extra>",
+                "legendgroup": "1",
+                "line": {"color": "rgba(255,255,255,0)"},
+                "marker": {"color": "#636EFA"},
+                "name": "1",
+                "offsetgroup": "category0",
+                "orientation": "h",
+                "pointpos": 0,
+                "showlegend": True,
+                "type": "box",
+                "x": [NULL_INT],
+                "x0": " ",
+                "xaxis": "x",
+                "y0": " ",
+                "yaxis": "y",
+            },
+            {
+                "alignmentgroup": "True",
+                "boxpoints": "all",
+                "fillcolor": "rgba(255,255,255,0)",
+                "hoveron": "points",
+                "hovertemplate": "category=2<br>X=%{x}<extra></extra>",
+                "legendgroup": "2",
+                "line": {"color": "rgba(255,255,255,0)"},
+                "marker": {"color": "#EF553B"},
+                "name": "2",
+                "offsetgroup": "category1",
+                "orientation": "h",
+                "pointpos": 0,
+                "showlegend": True,
+                "type": "box",
+                "x": [NULL_INT],
+                "x0": " ",
+                "xaxis": "x",
+                "y0": " ",
+                "yaxis": "y",
+            },
+        ]
+
+        self.assertEqual(plotly["data"], expected_data)
+
+        expected_layout = {
+            "boxmode": "group",
+            "legend": {"tracegroupgap": 0},
+            "margin": {"t": 60},
+            "xaxis": {
+                "anchor": "y",
+                "domain": [0.0, 1.0],
+                "side": "bottom",
+                "title": {"text": "X"},
+            },
+            "yaxis": {"anchor": "x", "domain": [0.0, 1.0], "side": "left"},
+        }
+
+        self.assertEqual(plotly["layout"], expected_layout)
+
+        expected_mappings = [
+            {"data_columns": {"X": ["/plotly/data/0/x"]}, "table": 0},
+            {"data_columns": {"X": ["/plotly/data/1/x"]}, "table": 0},
+        ]
+
+        self.assertEqual(deephaven["mappings"], expected_mappings)
+
+        self.assertEqual(deephaven["is_user_set_template"], False)
+        self.assertEqual(deephaven["is_user_set_color"], True)
+
+    def test_by_strip_y(self):
+        import src.deephaven.plot.express as dx
+        from deephaven.constants import NULL_INT
+
+        chart = dx.strip(self.source, y="Y", by="category").to_dict(self.exporter)
+        plotly, deephaven = chart["plotly"], chart["deephaven"]
+
+        # pop template as we currently do not modify it
+        plotly["layout"].pop("template")
+
+        expected_data = [
+            {
+                "alignmentgroup": "True",
+                "boxpoints": "all",
+                "fillcolor": "rgba(255,255,255,0)",
+                "hoveron": "points",
+                "hovertemplate": "category=1<br>Y=%{y}<extra></extra>",
+                "legendgroup": "1",
+                "line": {"color": "rgba(255,255,255,0)"},
+                "marker": {"color": "#636EFA"},
+                "name": "1",
+                "offsetgroup": "category0",
+                "orientation": "v",
+                "pointpos": 0,
+                "showlegend": True,
+                "type": "box",
+                "x0": " ",
+                "xaxis": "x",
+                "y": [NULL_INT],
+                "y0": " ",
+                "yaxis": "y",
+            },
+            {
+                "alignmentgroup": "True",
+                "boxpoints": "all",
+                "fillcolor": "rgba(255,255,255,0)",
+                "hoveron": "points",
+                "hovertemplate": "category=2<br>Y=%{y}<extra></extra>",
+                "legendgroup": "2",
+                "line": {"color": "rgba(255,255,255,0)"},
+                "marker": {"color": "#EF553B"},
+                "name": "2",
+                "offsetgroup": "category1",
+                "orientation": "v",
+                "pointpos": 0,
+                "showlegend": True,
+                "type": "box",
+                "x0": " ",
+                "xaxis": "x",
+                "y": [NULL_INT],
+                "y0": " ",
+                "yaxis": "y",
+            },
+        ]
+
+        self.assertEqual(plotly["data"], expected_data)
+
+        expected_layout = {
+            "boxmode": "group",
+            "legend": {"tracegroupgap": 0},
+            "margin": {"t": 60},
+            "xaxis": {"anchor": "y", "domain": [0.0, 1.0], "side": "bottom"},
+            "yaxis": {
+                "anchor": "x",
+                "domain": [0.0, 1.0],
+                "side": "left",
+                "title": {"text": "Y"},
+            },
+        }
+
+        self.assertEqual(plotly["layout"], expected_layout)
+
+        expected_mappings = [
+            {"data_columns": {"Y": ["/plotly/data/0/y"]}, "table": 0},
+            {"data_columns": {"Y": ["/plotly/data/1/y"]}, "table": 0},
+        ]
+
+        self.assertEqual(deephaven["mappings"], expected_mappings)
+
+        self.assertEqual(deephaven["is_user_set_template"], False)
+        self.assertEqual(deephaven["is_user_set_color"], True)
+
+    def test_by_strip_x_y(self):
+        import src.deephaven.plot.express as dx
+        from deephaven.constants import NULL_INT
+
+        chart = dx.strip(self.source, x="X", y="Y", by="category").to_dict(
+            self.exporter
+        )
+        plotly, deephaven = chart["plotly"], chart["deephaven"]
+
+        # pop template as we currently do not modify it
+        plotly["layout"].pop("template")
+
+        expected_data = [
+            {
+                "alignmentgroup": "True",
+                "boxpoints": "all",
+                "fillcolor": "rgba(255,255,255,0)",
+                "hoveron": "points",
+                "hovertemplate": "category=1<br>X=%{x}<br>Y=%{y}<extra></extra>",
+                "legendgroup": "1",
+                "line": {"color": "rgba(255,255,255,0)"},
+                "marker": {"color": "#636EFA"},
+                "name": "1",
+                "offsetgroup": "category0",
+                "orientation": "v",
+                "pointpos": 0,
+                "showlegend": True,
+                "type": "box",
+                "x": [NULL_INT],
+                "x0": " ",
+                "xaxis": "x",
+                "y": [NULL_INT],
+                "y0": " ",
+                "yaxis": "y",
+            },
+            {
+                "alignmentgroup": "True",
+                "boxpoints": "all",
+                "fillcolor": "rgba(255,255,255,0)",
+                "hoveron": "points",
+                "hovertemplate": "category=2<br>X=%{x}<br>Y=%{y}<extra></extra>",
+                "legendgroup": "2",
+                "line": {"color": "rgba(255,255,255,0)"},
+                "marker": {"color": "#EF553B"},
+                "name": "2",
+                "offsetgroup": "category1",
+                "orientation": "v",
+                "pointpos": 0,
+                "showlegend": True,
+                "type": "box",
+                "x": [NULL_INT],
+                "x0": " ",
+                "xaxis": "x",
+                "y": [NULL_INT],
+                "y0": " ",
+                "yaxis": "y",
+            },
+        ]
+
+        self.assertEqual(plotly["data"], expected_data)
+
+        expected_layout = {
+            "boxmode": "group",
+            "legend": {"tracegroupgap": 0},
+            "margin": {"t": 60},
+            "xaxis": {
+                "anchor": "y",
+                "domain": [0.0, 1.0],
+                "side": "bottom",
+                "title": {"text": "X"},
+            },
+            "yaxis": {
+                "anchor": "x",
+                "domain": [0.0, 1.0],
+                "side": "left",
+                "title": {"text": "Y"},
+            },
+        }
+
+        self.assertEqual(plotly["layout"], expected_layout)
+
+        expected_mappings = [
+            {
+                "data_columns": {"X": ["/plotly/data/0/x"], "Y": ["/plotly/data/0/y"]},
+                "table": 0,
+            },
+            {
+                "data_columns": {"X": ["/plotly/data/1/x"], "Y": ["/plotly/data/1/y"]},
+                "table": 0,
+            },
+        ]
+
+        self.assertEqual(deephaven["mappings"], expected_mappings)
+
+        self.assertEqual(deephaven["is_user_set_template"], False)
+        self.assertEqual(deephaven["is_user_set_color"], True)
+
+    def test_list_by_strip_x(self):
+        import src.deephaven.plot.express as dx
+        from deephaven.constants import NULL_INT
+
+        chart = dx.strip(self.source, x=["X", "X2"], by="category").to_dict(
+            self.exporter
+        )
+        plotly, deephaven = chart["plotly"], chart["deephaven"]
+
+        # pop template as we currently do not modify it
+        plotly["layout"].pop("template")
+
+        expected_data = [
+            {
+                "alignmentgroup": "True",
+                "boxpoints": "all",
+                "fillcolor": "rgba(255,255,255,0)",
+                "hoveron": "points",
+                "hovertemplate": "category=1<br>value=%{x}<extra></extra>",
+                "legendgroup": "1",
+                "line": {"color": "rgba(255,255,255,0)"},
+                "marker": {"color": "#636EFA"},
+                "name": "1",
+                "offsetgroup": "category0",
+                "orientation": "h",
+                "pointpos": 0,
+                "showlegend": True,
+                "type": "box",
+                "x": [NULL_INT],
+                "x0": " ",
+                "xaxis": "x",
+                "y0": " ",
+                "yaxis": "y",
+            },
+            {
+                "alignmentgroup": "True",
+                "boxpoints": "all",
+                "fillcolor": "rgba(255,255,255,0)",
+                "hoveron": "points",
+                "hovertemplate": "category=2<br>value=%{x}<extra></extra>",
+                "legendgroup": "2",
+                "line": {"color": "rgba(255,255,255,0)"},
+                "marker": {"color": "#EF553B"},
+                "name": "2",
+                "offsetgroup": "category1",
+                "orientation": "h",
+                "pointpos": 0,
+                "showlegend": True,
+                "type": "box",
+                "x": [NULL_INT],
+                "x0": " ",
+                "xaxis": "x",
+                "y0": " ",
+                "yaxis": "y",
+            },
+        ]
+
+        self.assertEqual(plotly["data"], expected_data)
+
+        expected_layout = {
+            "boxmode": "group",
+            "legend": {"tracegroupgap": 0},
+            "margin": {"t": 60},
+            "xaxis": {
+                "anchor": "y",
+                "domain": [0.0, 1.0],
+                "side": "bottom",
+                "title": {"text": "value"},
+            },
+            "yaxis": {"anchor": "x", "domain": [0.0, 1.0], "side": "left"},
+        }
+
+        self.assertEqual(plotly["layout"], expected_layout)
+
+        expected_mappings = [
+            {"data_columns": {"value": ["/plotly/data/0/x"]}, "table": 0},
+            {"data_columns": {"value": ["/plotly/data/1/x"]}, "table": 0},
+        ]
+
+        self.assertEqual(deephaven["mappings"], expected_mappings)
+
+        self.assertEqual(deephaven["is_user_set_template"], False)
+        self.assertEqual(deephaven["is_user_set_color"], True)
+
+    def test_list_by_strip_y(self):
+        import src.deephaven.plot.express as dx
+        from deephaven.constants import NULL_INT
+
+        chart = dx.strip(self.source, y="Y", by="category").to_dict(self.exporter)
+        plotly, deephaven = chart["plotly"], chart["deephaven"]
+
+        # pop template as we currently do not modify it
+        plotly["layout"].pop("template")
+
+        expected_data = [
+            {
+                "alignmentgroup": "True",
+                "boxpoints": "all",
+                "fillcolor": "rgba(255,255,255,0)",
+                "hoveron": "points",
+                "hovertemplate": "category=1<br>Y=%{y}<extra></extra>",
+                "legendgroup": "1",
+                "line": {"color": "rgba(255,255,255,0)"},
+                "marker": {"color": "#636EFA"},
+                "name": "1",
+                "offsetgroup": "category0",
+                "orientation": "v",
+                "pointpos": 0,
+                "showlegend": True,
+                "type": "box",
+                "x0": " ",
+                "xaxis": "x",
+                "y": [NULL_INT],
+                "y0": " ",
+                "yaxis": "y",
+            },
+            {
+                "alignmentgroup": "True",
+                "boxpoints": "all",
+                "fillcolor": "rgba(255,255,255,0)",
+                "hoveron": "points",
+                "hovertemplate": "category=2<br>Y=%{y}<extra></extra>",
+                "legendgroup": "2",
+                "line": {"color": "rgba(255,255,255,0)"},
+                "marker": {"color": "#EF553B"},
+                "name": "2",
+                "offsetgroup": "category1",
+                "orientation": "v",
+                "pointpos": 0,
+                "showlegend": True,
+                "type": "box",
+                "x0": " ",
+                "xaxis": "x",
+                "y": [NULL_INT],
+                "y0": " ",
+                "yaxis": "y",
+            },
+        ]
+
+        self.assertEqual(plotly["data"], expected_data)
+
+        expected_layout = {
+            "boxmode": "group",
+            "legend": {"tracegroupgap": 0},
+            "margin": {"t": 60},
+            "xaxis": {"anchor": "y", "domain": [0.0, 1.0], "side": "bottom"},
+            "yaxis": {
+                "anchor": "x",
+                "domain": [0.0, 1.0],
+                "side": "left",
+                "title": {"text": "Y"},
+            },
+        }
+
+        self.assertEqual(plotly["layout"], expected_layout)
+
+        expected_mappings = [
+            {"data_columns": {"Y": ["/plotly/data/0/y"]}, "table": 0},
+            {"data_columns": {"Y": ["/plotly/data/1/y"]}, "table": 0},
+        ]
+
+        self.assertEqual(deephaven["mappings"], expected_mappings)
+
+        self.assertEqual(deephaven["is_user_set_template"], False)
+        self.assertEqual(deephaven["is_user_set_color"], True)
+
+    def test_list_by_strip_x_y(self):
+        import src.deephaven.plot.express as dx
+        from deephaven.constants import NULL_INT
+
+        chart = dx.strip(self.source, x=["X", "X2"], y="Y", by="category").to_dict(
+            self.exporter
+        )
+        plotly, deephaven = chart["plotly"], chart["deephaven"]
+
+        # pop template as we currently do not modify it
+        plotly["layout"].pop("template")
+
+        expected_data = [
+            {
+                "alignmentgroup": "True",
+                "boxpoints": "all",
+                "fillcolor": "rgba(255,255,255,0)",
+                "hoveron": "points",
+                "hovertemplate": "category=1<br>value=%{x}<br>Y=%{y}<extra></extra>",
+                "legendgroup": "1",
+                "line": {"color": "rgba(255,255,255,0)"},
+                "marker": {"color": "#636EFA"},
+                "name": "1",
+                "offsetgroup": "category0",
+                "orientation": "v",
+                "pointpos": 0,
+                "showlegend": True,
+                "type": "box",
+                "x": [NULL_INT],
+                "x0": " ",
+                "xaxis": "x",
+                "y": [NULL_INT],
+                "y0": " ",
+                "yaxis": "y",
+            },
+            {
+                "alignmentgroup": "True",
+                "boxpoints": "all",
+                "fillcolor": "rgba(255,255,255,0)",
+                "hoveron": "points",
+                "hovertemplate": "category=2<br>value=%{x}<br>Y=%{y}<extra></extra>",
+                "legendgroup": "2",
+                "line": {"color": "rgba(255,255,255,0)"},
+                "marker": {"color": "#EF553B"},
+                "name": "2",
+                "offsetgroup": "category1",
+                "orientation": "v",
+                "pointpos": 0,
+                "showlegend": True,
+                "type": "box",
+                "x": [NULL_INT],
+                "x0": " ",
+                "xaxis": "x",
+                "y": [NULL_INT],
+                "y0": " ",
+                "yaxis": "y",
+            },
+        ]
+
+        self.assertEqual(plotly["data"], expected_data)
+
+        expected_layout = {
+            "boxmode": "group",
+            "legend": {"tracegroupgap": 0},
+            "margin": {"t": 60},
+            "xaxis": {
+                "anchor": "y",
+                "domain": [0.0, 1.0],
+                "side": "bottom",
+                "title": {"text": "value"},
+            },
+            "yaxis": {
+                "anchor": "x",
+                "domain": [0.0, 1.0],
+                "side": "left",
+                "title": {"text": "Y"},
+            },
+        }
+
+        self.assertEqual(plotly["layout"], expected_layout)
+
+        expected_mappings = [
+            {
+                "data_columns": {
+                    "Y": ["/plotly/data/0/y"],
+                    "value": ["/plotly/data/0/x"],
+                },
+                "table": 0,
+            },
+            {
+                "data_columns": {
+                    "Y": ["/plotly/data/1/y"],
+                    "value": ["/plotly/data/1/x"],
+                },
+                "table": 0,
+            },
+        ]
+
+        self.assertEqual(deephaven["mappings"], expected_mappings)
+
+        self.assertEqual(deephaven["is_user_set_template"], False)
+        self.assertEqual(deephaven["is_user_set_color"], True)
+
+        chart = dx.violin(self.source, x="X", y=["Y", "Y2"], by="category").to_dict(
+            self.exporter
+        )
+        plotly, deephaven = chart["plotly"], chart["deephaven"]
+
+        # pop template as we currently do not modify it
+        plotly["layout"].pop("template")
+
+        expected_data = [
+            {
+                "alignmentgroup": "True",
+                "box": {"visible": False},
+                "hovertemplate": "category=1<br>X=%{x}<br>value=%{y}<extra></extra>",
+                "legendgroup": "1",
+                "marker": {"color": "#636EFA"},
+                "name": "1",
+                "offsetgroup": "category0",
+                "orientation": "v",
+                "points": "outliers",
+                "scalegroup": "True",
+                "showlegend": True,
+                "type": "violin",
+                "x": [NULL_INT],
+                "x0": " ",
+                "xaxis": "x",
+                "y": [NULL_INT],
+                "y0": " ",
+                "yaxis": "y",
+            },
+            {
+                "alignmentgroup": "True",
+                "box": {"visible": False},
+                "hovertemplate": "category=2<br>X=%{x}<br>value=%{y}<extra></extra>",
+                "legendgroup": "2",
+                "marker": {"color": "#EF553B"},
+                "name": "2",
+                "offsetgroup": "category1",
+                "orientation": "v",
+                "points": "outliers",
+                "scalegroup": "True",
+                "showlegend": True,
+                "type": "violin",
+                "x": [NULL_INT],
+                "x0": " ",
+                "xaxis": "x",
+                "y": [NULL_INT],
+                "y0": " ",
+                "yaxis": "y",
+            },
+        ]
+
+        self.assertEqual(plotly["data"], expected_data)
+
+        expected_layout = {
+            "legend": {"tracegroupgap": 0},
+            "margin": {"t": 60},
+            "violinmode": "group",
+            "xaxis": {
+                "anchor": "y",
+                "domain": [0.0, 1.0],
+                "side": "bottom",
+                "title": {"text": "X"},
+            },
+            "yaxis": {
+                "anchor": "x",
+                "domain": [0.0, 1.0],
+                "side": "left",
+                "title": {"text": "value"},
+            },
+        }
+
+        self.assertEqual(plotly["layout"], expected_layout)
+
+        expected_mappings = [
+            {
+                "data_columns": {
+                    "X": ["/plotly/data/0/x"],
+                    "value": ["/plotly/data/0/y"],
+                },
+                "table": 0,
+            },
+            {
+                "data_columns": {
+                    "X": ["/plotly/data/1/x"],
+                    "value": ["/plotly/data/1/y"],
+                },
+                "table": 0,
+            },
+        ]
+
+        self.assertEqual(deephaven["mappings"], expected_mappings)
+
+        self.assertEqual(deephaven["is_user_set_template"], False)
+        self.assertEqual(deephaven["is_user_set_color"], True)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #451 
This was already mostly supported, just needed to remove the exception and fix a small error.

Here is an example
```
import deephaven.plot.express as dx

iris = dx.data.iris()
violin_x = dx.violin(iris, x="PetalLength", y="Species")
```
