### PR TITLE
fix: Prevent pushing broken docs to main

### DIFF
--- a/.github/workflows/build-main-docs.yml
+++ b/.github/workflows/build-main-docs.yml
@@ -7,6 +7,10 @@ on:
         description: The plugin to publish the docs for
         required: true
         type: string
+      event_name:
+        description: The event name that triggered the workflow
+        required: true
+        type: string
 
 jobs:
   check-make-docs:

--- a/.github/workflows/build-main-docs.yml
+++ b/.github/workflows/build-main-docs.yml
@@ -37,3 +37,4 @@ jobs:
     with:
       package: ${{ inputs.package }}
       version: 'main'
+      event_name: ${{ inputs.event_name }}

--- a/.github/workflows/make-docs.yml
+++ b/.github/workflows/make-docs.yml
@@ -9,6 +9,10 @@ on:
       version:
         required: true
         type: string
+      event_name:
+        required: false
+        type: string
+        default: 'push'
 
 jobs:
   make-docs:
@@ -34,6 +38,8 @@ jobs:
         run: python plugins/${{ inputs.package }}/make_docs.py
 
       - name: Setup rclone
+        # pull requests should run the make_docs.py script, but not sync the docs
+        if: inputs.event_name == 'push'
         run: |
           sudo apt-get update
           sudo apt-get install -y rclone
@@ -53,4 +59,5 @@ jobs:
           EOF
 
       - name: Sync docs
+        if: inputs.event_name == 'push'
         run: rclone sync plugins/${{ inputs.package }}/docs/build/markdown/ plugindocs:website/deephaven/deephaven-plugins/${{ inputs.package }}/${{ inputs.version }}/

--- a/.github/workflows/modified-plugin.yml
+++ b/.github/workflows/modified-plugin.yml
@@ -105,7 +105,7 @@ jobs:
   build-main-docs:
     needs: changes
     # Only build main docs for push on main branch and PRs to main
-    if: ${{ needs.changes.outputs.packages != '[]' && needs.changes.outputs.packages != '' && (github.ref == 'refs/heads/main' || github.base_ref == 'main')}}
+    if: ${{ needs.changes.outputs.packages != '[]' && needs.changes.outputs.packages != '' && (github.ref == 'refs/heads/main' || github.base_ref == 'main') && (github.event_name == 'push' || github.event_name == 'pull_request')}}
     strategy:
       matrix:
         package: ${{ fromJSON(needs.changes.outputs.packages) }}

--- a/.github/workflows/modified-plugin.yml
+++ b/.github/workflows/modified-plugin.yml
@@ -104,7 +104,7 @@ jobs:
   # Main docs are built here, whereas release docs are built in release-python-package.yml
   build-main-docs:
     needs: changes
-    if: ${{ needs.changes.outputs.packages != '[]' && needs.changes.outputs.packages != '' && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+    if: ${{ needs.changes.outputs.packages != '[]' && needs.changes.outputs.packages != '' && github.ref == 'refs/heads/main' }}
     strategy:
       matrix:
         package: ${{ fromJSON(needs.changes.outputs.packages) }}
@@ -112,3 +112,4 @@ jobs:
     secrets: inherit
     with:
       package: ${{ matrix.package }}
+      event_name: ${{ github.event_name }}

--- a/.github/workflows/modified-plugin.yml
+++ b/.github/workflows/modified-plugin.yml
@@ -104,7 +104,8 @@ jobs:
   # Main docs are built here, whereas release docs are built in release-python-package.yml
   build-main-docs:
     needs: changes
-    if: ${{ needs.changes.outputs.packages != '[]' && needs.changes.outputs.packages != '' && github.ref == 'refs/heads/main' }}
+    # Only build main docs for push on main branch and PRs to main
+    if: ${{ needs.changes.outputs.packages != '[]' && needs.changes.outputs.packages != '' && (github.ref == 'refs/heads/main' || github.base_ref == 'main')}}
     strategy:
       matrix:
         package: ${{ fromJSON(needs.changes.outputs.packages) }}

--- a/plugins/plotly-express/make_docs.py
+++ b/plugins/plotly-express/make_docs.py
@@ -12,4 +12,7 @@ sys.path.append(utilities_path)
 from make_docs_utilities import build_documents, pushd
 
 with pushd(__file__):
-    build_documents()
+    code = build_documents()
+
+if code != 0:
+    sys.exit(1)

--- a/plugins/ui/make_docs.py
+++ b/plugins/ui/make_docs.py
@@ -12,4 +12,7 @@ sys.path.append(utilities_path)
 from make_docs_utilities import build_documents, pushd
 
 with pushd(__file__):
-    build_documents()
+    code = build_documents()
+
+if code != 0:
+    sys.exit(1)

--- a/plugins/ui/src/deephaven/ui/components/text_area.py
+++ b/plugins/ui/src/deephaven/ui/components/text_area.py
@@ -124,6 +124,7 @@ def text_area(
         label: The label for the input
         auto_complete: Describes the type of autocomplete functionality the input should provide
         max_length: The maximum number of characters the input can accept
+        min_length: The minimum number of characters the input can accept
         input_mode: Hints at the tpye of data that might be entered by the user while editing the element or its contents
         name: The name of the input, used when submitting an HTML form
         validation_state: Whether the input should display its "valid" or "invalid" state
@@ -177,13 +178,17 @@ def text_area(
         exclude_from_tab_order: Whether the element should be excluded from the tab order.
         aria_active_descendant: Identifies the currently active element when DOM focus is on a composite widget, textbox, group, or application.
         aria_auto_complete: Indicates whether inputting text could trigger display of one or more predictions of the user's intended value for an input and specifies how predictions would be presented if they are made.
+        aria_haspopup: Indicates the availability and type of interactive popup element, such as menu or dialog, that can be triggered by an elemen
         aria_label: The label for the element.
-        aria_labelled_by: The id of the element that labels the current element.
-        aria_described_by: The id of the element that describes the current element.
+        aria_labelledby: The id of the element that labels the current element.
+        aria_describedby: The id of the element that describes the current element.
         aria_details: The id of the element that provides additional information about the current element.
         aria_errormessage: The id of the element that provides an error message for the current element.
         UNSAFE_class_name: A CSS class to apply to the element.
         UNSAFE_style: A CSS style to apply to the element.
+
+    Returns:
+        The element representing the text area
     """
 
     return component_element(

--- a/plugins/ui/src/deephaven/ui/components/text_area.py
+++ b/plugins/ui/src/deephaven/ui/components/text_area.py
@@ -178,7 +178,7 @@ def text_area(
         exclude_from_tab_order: Whether the element should be excluded from the tab order.
         aria_active_descendant: Identifies the currently active element when DOM focus is on a composite widget, textbox, group, or application.
         aria_auto_complete: Indicates whether inputting text could trigger display of one or more predictions of the user's intended value for an input and specifies how predictions would be presented if they are made.
-        aria_haspopup: Indicates the availability and type of interactive popup element, such as menu or dialog, that can be triggered by an elemen
+        aria_haspopup: Indicates the availability and type of interactive popup element, such as menu or dialog, that can be triggered by an element.
         aria_label: The label for the element.
         aria_labelledby: The id of the element that labels the current element.
         aria_describedby: The id of the element that describes the current element.

--- a/sphinx_ext/make_docs_utilities.py
+++ b/sphinx_ext/make_docs_utilities.py
@@ -17,7 +17,8 @@ def run_command(command: str, exit_on_fail: bool = True) -> int:
         exit_on_fail: Whether to exit if the command fails. Default is True. If False, the code is returned.
 
     Returns:
-        Returns the code if exit_on_fail is true, or 0 if success.
+        If exit_on_fail is True, exits with code 1 if the command failed or returns 0 if it succeeded.
+        If exit_on_fail is False, returns 0 if the command succeeded or the error code.
     """
     code = os.system(command)
     if code != 0 and exit_on_fail:

--- a/sphinx_ext/make_docs_utilities.py
+++ b/sphinx_ext/make_docs_utilities.py
@@ -17,30 +17,31 @@ def run_command(command: str, exit_on_fail: bool = True) -> int:
         exit_on_fail: Whether to exit if the command fails. Default is True. If False, the code is returned.
 
     Returns:
-        None
+        Returns the code if exit_on_fail is true, or 0 if success.
     """
     code = os.system(command)
     if code != 0 and exit_on_fail:
-        sys.exit(code)
+        sys.exit(1)
     return code
 
 
-def run_commands(commands: list[str], exit_on_fail: bool = False) -> int:
+def attempt_command_sequence(commands: list[str], exit_on_fail: bool = False) -> int:
     """
-    Run a list of commands and exit if any fail.
+    Run a list of commands and exit as soon as one fails.
 
     Args:
         commands: The list of commands to run.
-        exit_on_fail: Whether to exit if a command fails. Default is True. If False, the code is returned.
+        exit_on_fail: Whether to exit if a command fails. Default is True.
+            If False, the code is returned for the failing command and no subsequent commands are run.
 
     Returns:
-        None
+        Returns the code if exit_on_fail is true, or 0 if success.
     """
     for command in commands:
         code = run_command(command, exit_on_fail)
         if code != 0:
             print(f"Failed to run command: {command}")
-            return 1
+            return code
     return 0
 
 
@@ -121,6 +122,9 @@ def remove_paramtable_comment(
 def build_documents() -> int:
     """
     Make the markdown files and copy the assets in
+
+    Returns:
+        1 if the build failed, 0 if it succeeded
     """
     commands = [
         "make clean",
@@ -130,7 +134,7 @@ def build_documents() -> int:
         f"cp docs/sidebar.json {BUILT_DOCS}/sidebar.json",
     ]
 
-    code = run_commands(commands)
+    code = attempt_command_sequence(commands)
     if code != 0:
         return 1
 

--- a/tools/plugin_builder.py
+++ b/tools/plugin_builder.py
@@ -134,7 +134,7 @@ def run_docs(
     for plugin in plugin_names(plugins):
         if os.path.exists(f"{plugins_dir}/{plugin}/make_docs.py"):
             click.echo(f"Generating docs for {plugin}")
-            code = run_command(f"python {plugins_dir}/{plugin}/make_docs.py")
+            run_command(f"python {plugins_dir}/{plugin}/make_docs.py")
         elif error_on_missing:
             click.echo(f"Error: make_docs.py not found in {plugin}")
             sys.exit(1)

--- a/tools/plugin_builder.py
+++ b/tools/plugin_builder.py
@@ -21,10 +21,11 @@ def clean_build_dist(plugin: str) -> None:
     Returns:
         None
     """
+    # these folders may not exist, so ignore the errors
     if os.path.exists(f"{plugins_dir}/{plugin}/build"):
-        run_command(f"rm -rf {plugins_dir}/{plugin}/build")
+        os.system(f"rm -rf {plugins_dir}/{plugin}/build")
     if os.path.exists(f"{plugins_dir}/{plugin}/dist"):
-        run_command(f"rm -rf {plugins_dir}/{plugin}/dist")
+        os.system(f"rm -rf {plugins_dir}/{plugin}/dist")
 
 
 def plugin_names(

--- a/tools/plugin_builder.py
+++ b/tools/plugin_builder.py
@@ -22,9 +22,9 @@ def clean_build_dist(plugin: str) -> None:
         None
     """
     if os.path.exists(f"{plugins_dir}/{plugin}/build"):
-        os.system(f"rm -rf {plugins_dir}/{plugin}/build")
+        run_command(f"rm -rf {plugins_dir}/{plugin}/build")
     if os.path.exists(f"{plugins_dir}/{plugin}/dist"):
-        os.system(f"rm -rf {plugins_dir}/{plugin}/dist")
+        run_command(f"rm -rf {plugins_dir}/{plugin}/dist")
 
 
 def plugin_names(
@@ -134,7 +134,7 @@ def run_docs(
     for plugin in plugin_names(plugins):
         if os.path.exists(f"{plugins_dir}/{plugin}/make_docs.py"):
             click.echo(f"Generating docs for {plugin}")
-            run_command(f"python {plugins_dir}/{plugin}/make_docs.py")
+            code = run_command(f"python {plugins_dir}/{plugin}/make_docs.py")
         elif error_on_missing:
             click.echo(f"Error: make_docs.py not found in {plugin}")
             sys.exit(1)

--- a/tools/plugin_builder.py
+++ b/tools/plugin_builder.py
@@ -60,7 +60,7 @@ def run_command(command: str) -> None:
     """
     code = os.system(command)
     if code != 0:
-        sys.exit(code)
+        sys.exit(1)
 
 
 def run_build(


### PR DESCRIPTION
1. Plumbs through error codes so `make_docs.py` fails correctly
2. `make_docs.yml` now runs on pull request to main (without sync) so broken docs have to be cleaned up before merge
3. Fixed `text_area.py` so docs are able to build

Tested on my fork