### PR TITLE
fix: Remove `replay_lock` in `use_table_listener`

### DIFF
--- a/plugins/ui/src/deephaven/ui/hooks/use_table_listener.py
+++ b/plugins/ui/src/deephaven/ui/hooks/use_table_listener.py
@@ -93,7 +93,7 @@ def use_table_listener(
         Returns:
             A function that can be called to stop the listener by the use_effect hook.
         """
-        if table is None or (not table.is_refreshing and not do_replay):
+        if table is None or not table.is_refreshing:
             return lambda: None
 
         handle = listen(

--- a/plugins/ui/src/deephaven/ui/hooks/use_table_listener.py
+++ b/plugins/ui/src/deephaven/ui/hooks/use_table_listener.py
@@ -70,7 +70,6 @@ def use_table_listener(
     dependencies: Dependencies,
     description: str | None = None,
     do_replay: bool = False,
-    replay_lock: LockType = "shared",
 ) -> None:
     """
     Listen to a table and call a listener when the table updates.
@@ -85,7 +84,6 @@ def use_table_listener(
         description: An optional description for the UpdatePerformanceTracker to append to the listener’s
           entry description, default is None.
         do_replay: Whether to replay the initial snapshot of the table, default is False.
-        replay_lock: The lock type used during replay, default is ‘shared’, can also be ‘exclusive’.
     """
 
     def start_listener() -> Callable[[], None]:
@@ -103,12 +101,11 @@ def use_table_listener(
             wrap_listener(listener),
             description=description,  # type: ignore # missing Optional type
             do_replay=do_replay,
-            replay_lock=replay_lock,
         )
 
         return lambda: handle.stop()
 
     use_effect(
         start_listener,
-        [table, listener, description, do_replay, replay_lock] + list(dependencies),
+        [table, listener, description, do_replay] + list(dependencies),
     )

--- a/plugins/ui/test/deephaven/ui/test_hooks.py
+++ b/plugins/ui/test/deephaven/ui/test_hooks.py
@@ -248,8 +248,6 @@ class HooksTest(BaseTestCase):
             ]
         )
 
-        self.verify_table_replayed(static_table)
-
     def test_table_data(self):
         from deephaven.ui.hooks import use_table_data
         from deephaven import new_table

--- a/plugins/ui/test/deephaven/ui/test_hooks.py
+++ b/plugins/ui/test/deephaven/ui/test_hooks.py
@@ -231,8 +231,7 @@ class HooksTest(BaseTestCase):
             assert False, "listener was not called"
 
     def test_table_listener(self):
-        from deephaven import DynamicTableWriter, new_table
-        from deephaven.column import int_col
+        from deephaven import DynamicTableWriter
         import deephaven.dtypes as dht
 
         column_definitions = {"Numbers": dht.int32, "Words": dht.string}
@@ -241,12 +240,6 @@ class HooksTest(BaseTestCase):
         table = table_writer.table
 
         self.verify_table_updated(table_writer, table, (1, "Testing"))
-
-        static_table = new_table(
-            [
-                int_col("Numbers", [1]),
-            ]
-        )
 
     def test_table_data(self):
         from deephaven.ui.hooks import use_table_data


### PR DESCRIPTION
Removes `replay_lock` due to  https://github.com/deephaven/deephaven-core/pull/5672