### PR TITLE
fix: Remove server startup from python tests

### DIFF
--- a/plugins/plotly-express/conf.py
+++ b/plugins/plotly-express/conf.py
@@ -41,5 +41,5 @@ always_use_bars_union = True
 
 from deephaven_server import Server
 
-s = Server(port=10075)
-s.start()
+# need a server instance to pull types from the autodocs
+Server(port=10075)

--- a/plugins/plotly-express/test/__init__.py
+++ b/plugins/plotly-express/test/__init__.py
@@ -1,0 +1,10 @@
+from deephaven_server.server import Server
+
+# Create a Server instance to initialize the JVM
+# Otherwise we get errors whenever we try to import anything or run tests
+# We don't even need to start the server, just create an instance.
+# https://github.com/deephaven/deephaven-core/blob/b5cae98c2f11b032cdd1b9c248dc5b4a0f95314a/py/embedded-server/deephaven_server/server.py#L152
+# Whenever you import anything from the deephaven namespace, it will check if the JVM is ready:
+# https://github.com/deephaven/deephaven-core/blob/b5cae98c2f11b032cdd1b9c248dc5b4a0f95314a/py/server/deephaven/__init__.py#L15
+if Server.instance is None:
+    Server(port=10000, jvm_args=["-Xmx4g"])

--- a/plugins/plotly-express/test/deephaven/plot/express/BaseTest.py
+++ b/plugins/plotly-express/test/deephaven/plot/express/BaseTest.py
@@ -24,15 +24,6 @@ def remap_types(
 class BaseTestCase(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        try:
-            cls.s = Server(port=10000, jvm_args=["-Xmx4g"])
-            cls.s.start()
-        except Exception as e:
-            # server is already running
-            pass
-
-        # these mocks need to be setup after the deephaven server is
-        # initialized because they access the deephaven namespace
         cls.setup_exporter_mock()
 
     @classmethod

--- a/plugins/ui/conf.py
+++ b/plugins/ui/conf.py
@@ -41,5 +41,5 @@ always_use_bars_union = True
 
 from deephaven_server import Server
 
+# need a server instance to pull types from the autodocs
 s = Server(port=10075)
-s.start()

--- a/plugins/ui/conf.py
+++ b/plugins/ui/conf.py
@@ -42,4 +42,4 @@ always_use_bars_union = True
 from deephaven_server import Server
 
 # need a server instance to pull types from the autodocs
-s = Server(port=10075)
+Server(port=10075)

--- a/templates/widget/{{ cookiecutter.python_project_name }}/test/__init__.py
+++ b/templates/widget/{{ cookiecutter.python_project_name }}/test/__init__.py
@@ -1,0 +1,10 @@
+from deephaven_server.server import Server
+
+# Create a Server instance to initialize the JVM
+# Otherwise we get errors whenever we try to import anything or run tests
+# We don't even need to start the server, just create an instance.
+# https://github.com/deephaven/deephaven-core/blob/b5cae98c2f11b032cdd1b9c248dc5b4a0f95314a/py/embedded-server/deephaven_server/server.py#L152
+# Whenever you import anything from the deephaven namespace, it will check if the JVM is ready:
+# https://github.com/deephaven/deephaven-core/blob/b5cae98c2f11b032cdd1b9c248dc5b4a0f95314a/py/server/deephaven/__init__.py#L15
+if Server.instance is None:
+    Server(port=11000, jvm_args=["-Xmx4g"])

--- a/templates/widget/{{ cookiecutter.python_project_name }}/test/{{ cookiecutter.python_project_name }}/BaseTest.py
+++ b/templates/widget/{{ cookiecutter.python_project_name }}/test/{{ cookiecutter.python_project_name }}/BaseTest.py
@@ -7,16 +7,6 @@ from deephaven_server import Server
 class BaseTestCase(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        try:
-            # Use port 11000 so it doesn't conflict with another server
-            cls.s = Server(port=11000, jvm_args=["-Xmx4g"])
-            cls.s.start()
-        except Exception as e:
-            # server is already running
-            pass
-
-        # these mocks need to be setup after the deephaven server is
-        # initialized because they access the deephaven namespace
         cls.setup_exporter_mock()
 
     @classmethod

--- a/templates/widget/{{ cookiecutter.python_project_name }}/test/{{ cookiecutter.python_project_name }}/test.py
+++ b/templates/widget/{{ cookiecutter.python_project_name }}/test/{{ cookiecutter.python_project_name }}/test.py
@@ -5,7 +5,7 @@ from .BaseTest import BaseTestCase
 class Test(BaseTestCase):
     def test(self):
         # since the tests use the embedded server, the import must happen after the tests start
-        from deephaven import Table
+        from deephaven.table import Table
 
         pass
 


### PR DESCRIPTION
Fixes #759 

Startup is not needed, only an instance, so removed the startup.