### PR TITLE
feat: Add watch mode to `plugin_builder.py`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
-# when adding new files here, consider adding them to tools/plugin_builder.py as well
-# if they could trigger an infinite loop
+# When adding new files here, consider adding them to `tools/plugin_builder.py` as well.
+# particularly for large build directories with lots of files or directories that may cause infinite loops
+# because they are built by the plugin builder.
 
 node_modules
 .vscode/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# when adding new files here, consider adding them to tools/plugin_builder.py as well
+# if they could trigger an infinite loop
+
 node_modules
 .vscode/
 tsconfig.tsbuildinfo

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,8 @@ repos:
             matplotlib,
             deephaven-plugin-utilities,
             sphinx,
-            click
+            click,
+            watchdog,
           ]
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.2.2

--- a/README.md
+++ b/README.md
@@ -268,17 +268,15 @@ python tools/plugin_builder.py --js -r -s ui
 ````
 
 Enable `watch` mode with the `--watch` flag. This will watch the project for changes and rerun the script with the same arguments.  
-This example reinstalls the `ui` plugin with js, starts the server, and watches for changes.  
-Every time a change is made to the plugin, the plugin will be rebuilt and the server will be restarted.
 Note that when using `--watch`, the script will not exit until stopped manually.
-```shell
-python tools/plugin_builder.py -jrsw ui
-```
-
-The `watch` option also works with `--docs`. 
 For example, to watch the `plotly-express` plugin for changes and rebuild the docs when changes are made:
 ```shell
 python tools/plugin_builder.py --docs --watch plotly-express
+```
+
+This example reinstalls the `ui` plugin with js, starts the server, and watches for changes.
+```shell
+python tools/plugin_builder.py -jrsw ui
 ```
 
 ## Release Management

--- a/README.md
+++ b/README.md
@@ -208,12 +208,12 @@ services:
 ### Using plugin_builder.py
 
 The `tools/plugin_builder.py` script is a utility script that makes common plugin development cases easier.
-The tool uses `click` for command line argument parsing, so install it if you haven't already:
+The tool uses `click` for command line argument parsing and `watchdog` for file watching.  
 Skip the venv setup if you already have one
 ```shell
 python -m venv .venv
 source .venv/bin/activate
-pip install click
+pip install click watchdog
 ```
 
 The script can then be used to help set up your venv.
@@ -265,6 +265,20 @@ The js plugins can be built with the `--js` flag. This will build all js plugins
 This example reinstalls the `ui` plugin with js, and starts the server with shorthand flags.
 ```shell
 python tools/plugin_builder.py --js -r -s ui
+````
+
+Enable `watch` mode with the `--watch` flag. This will watch the project for changes and rerun the script with the same arguments.  
+This example reinstalls the `ui` plugin with js, starts the server, and watches for changes.  
+Every time a change is made to the plugin, the plugin will be rebuilt and the server will be restarted.
+Note that when using `--watch`, the script will not exit until stopped manually.
+```shell
+python tools/plugin_builder.py -jrsw ui
+```
+
+The `watch` option also works with `--docs`. 
+For example, to watch the `plotly-express` plugin for changes and rebuild the docs when changes are made:
+```shell
+python tools/plugin_builder.py --docs --watch plotly-express
 ```
 
 ## Release Management

--- a/README.md
+++ b/README.md
@@ -238,8 +238,8 @@ python tools/plugin_builder.py plotly-express ui
 ```
 This targeting works for all commands that target the plugins directly, such as `--docs` or `--install`.
 
-To build docs, pass the `--docs` flag.
-First install the necessary dependencies (if setup with `--configure=full` this is already done)
+To build docs, pass the `--docs` flag.  
+First install the necessary dependencies (if setup with `--configure=full` this is already done)  
 ```shell
 pip install -r sphinx_ext/sphinx-requirements.txt
 ```
@@ -249,13 +249,22 @@ This example builds the docs for the `ui` plugin:
 python tools/plugin_builder.py --docs ui
 ```
 
-To run the server, pass the `--server` flag. 
-First install `deephaven-server` if it is not already installed (if setup with `--configure=full` this is already done):
+It is necessary to install the latest version of the plugin you're building docs for before building the docs themselves.  
+Run with `--install` or `--reinstall` to install the plugin (depending on if you're installing a new version or not) 
+before building the docs.
+```shell
+python tools/plugin_builder.py --docs --install ui
+```
+After the first time install, you can drop the `--install` flag and just run the script with `--docs` unless you have plugin changes.
+
+
+To run the server, pass the `--server` flag.  
+First install `deephaven-server` if it is not already installed (if setup with `--configure=full` this is already done):  
 ```shell
 pip install deephaven-server
 ```
 
-This example reinstalls the `plotly-express` plugin, then starts the server:
+This example reinstalls the `plotly-express` plugin, then starts the server:  
 ```shell
 python tools/plugin_builder.py --reinstall --server plotly-express
 ```

--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ The js plugins can be built with the `--js` flag. This will build all js plugins
 This example reinstalls the `ui` plugin with js, and starts the server with shorthand flags.
 ```shell
 python tools/plugin_builder.py --js -r -s ui
-````
+```
 
 Enable `watch` mode with the `--watch` flag. This will watch the project for changes and rerun the script with the same arguments.  
 Note that when using `--watch`, the script will not exit until stopped manually.

--- a/README.md
+++ b/README.md
@@ -270,6 +270,18 @@ python tools/plugin_builder.py --reinstall --server plotly-express
 ```
 Reinstall will force reinstall the plugins (but only the plugins, not the dependencies), which is useful if there are changes to the plugins but without a bumped version number.
 
+To run the server with specific args, pass the `--server-arg` flag.  
+By default, the server is passed the `--no-browser` flag, which will prevent the server from opening a browser window.  
+This example will override that default and open the browser:
+```shell
+python tools/plugin_builder.py --server-arg --browser
+```
+Similar to other arguments, this argument can be shortened to `-sa`.  
+This example changes the port and psk and reinstalls the `ui` plugin before starting the server:  
+```shell
+python tools/plugin_builder.py -r -sa --port=9999 -sa --jvm-args="-Dauthentication.psk=mypsk" ui  
+```
+
 The js plugins can be built with the `--js` flag. This will build all js plugins or target specific ones if specified.
 This example reinstalls the `ui` plugin with js, and starts the server with shorthand flags.
 ```shell

--- a/tools/plugin_builder.py
+++ b/tools/plugin_builder.py
@@ -88,14 +88,6 @@ class PluginsChangedHandler(RegexMatchingEventHandler):
         Args:
             event: The event that occurred
         """
-        # if a file is .gitignored, do not rerun
-        # dump the output to /dev/null to prevent printing to the console
-        check_ignore = os.system(f"git check-ignore {event.src_path} > /dev/null")
-        if check_ignore != 256:
-            # git check-ignore returns 1 if the file is not ignored
-            # 256 is python's way of returning 1 from a system call
-            return
-
         if self.stop_event.is_set():
             # a rerun has already been scheduled on another thread
             print(f"File {event.src_path} changed, rerun has already been scheduled")

--- a/tools/plugin_builder.py
+++ b/tools/plugin_builder.py
@@ -483,8 +483,6 @@ def builder(
     try:
         while True:
             input()
-    except KeyboardInterrupt:
-        sys.exit(0)
     finally:
         observer.stop()
         observer.join()

--- a/tools/plugin_builder.py
+++ b/tools/plugin_builder.py
@@ -393,7 +393,7 @@ def handle_args(
 
     if server:
         click.echo("Running deephaven server")
-        process = subprocess.Popen("deephaven server", shell=True)
+        process = subprocess.Popen(["deephaven", "server"])
 
         # waiting on either the process to finish or the stop event to be set
         while not stop_event.wait(1):

--- a/tools/plugin_builder.py
+++ b/tools/plugin_builder.py
@@ -393,7 +393,7 @@ def handle_args(
 
     if server:
         click.echo("Running deephaven server")
-        process = subprocess.Popen(["deephaven", "server"])
+        process = subprocess.Popen(["deephaven", "server", "--no-browser"])
 
         # waiting on either the process to finish or the stop event to be set
         while not stop_event.wait(1):

--- a/tools/plugin_builder.py
+++ b/tools/plugin_builder.py
@@ -403,10 +403,12 @@ def handle_args(
                 os._exit(process.returncode)
 
         # stop event is set, so kill the process
+        process.terminate()
         try:
             process.wait(timeout=1)
         except subprocess.TimeoutExpired:
             process.kill()
+            process.wait()
 
 
 @click.command(

--- a/tools/plugin_builder.py
+++ b/tools/plugin_builder.py
@@ -80,7 +80,7 @@ class PluginsChangedHandler(RegexMatchingEventHandler):
             self.stop_event.clear()
             self.func()
 
-    def on_any_event(self, event: FileSystemEvent) -> None:
+    def event_handler(self, event: FileSystemEvent) -> None:
         """
         Handle any file system event
 
@@ -93,6 +93,45 @@ class PluginsChangedHandler(RegexMatchingEventHandler):
             return
         print(f"File {event.src_path} changed, new rerun scheduled")
         threading.Thread(target=self.attempt_rerun).start()
+
+    def on_created(self, event: FileSystemEvent) -> None:
+        """
+        Handle a file creation event
+
+        Args:
+            event: The event that occurred
+        """
+        self.event_handler(event)
+
+    def on_deleted(self, event: FileSystemEvent) -> None:
+        """
+        Handle a file deletion event
+
+        Args:
+            event: The event that occurred
+        """
+        self.event_handler(event)
+
+    def on_modified(self, event: FileSystemEvent) -> None:
+        """
+        Handle a file modification event
+
+        Args:
+            event: The event that occurred
+        """
+        self.event_handler(event)
+
+    def on_moved(self, event: FileSystemEvent) -> None:
+        """
+        Handle a file move event
+
+        Args:
+            event: The event that occurred
+
+        Returns:
+
+        """
+        self.event_handler(event)
 
 
 def clean_build_dist(plugin: str) -> None:

--- a/tools/plugin_builder.py
+++ b/tools/plugin_builder.py
@@ -39,6 +39,7 @@ IGNORE_REGEXES = [
     # ignore hidden files and directories
     ".*/\..*/.*",
 ]
+# njnhnuunnhunnuu
 
 
 class PluginsChangedHandler(RegexMatchingEventHandler):
@@ -87,6 +88,14 @@ class PluginsChangedHandler(RegexMatchingEventHandler):
         Args:
             event: The event that occurred
         """
+        # if a file is .gitignored, do not rerun
+        # dump the output to /dev/null to prevent printing to the console
+        check_ignore = os.system(f"git check-ignore {event.src_path} > /dev/null")
+        if check_ignore != 256:
+            # git check-ignore returns 1 if the file is not ignored
+            # 256 is python's way of returning 1 from a system call
+            return
+
         if self.stop_event.is_set():
             # a rerun has already been scheduled on another thread
             print(f"File {event.src_path} changed, rerun has already been scheduled")
@@ -481,7 +490,9 @@ def builder(
     observer.start()
     try:
         while True:
-            time.sleep(1)
+            input()
+    except KeyboardInterrupt:
+        sys.exit(0)
     finally:
         observer.stop()
         observer.join()

--- a/tools/plugin_builder.py
+++ b/tools/plugin_builder.py
@@ -3,12 +3,99 @@ from __future__ import annotations
 import click
 import os
 import sys
-from typing import Generator
+from typing import Generator, Callable
+import time
+import subprocess
+from watchdog.events import FileSystemEvent, PatternMatchingEventHandler
+from watchdog.observers import Observer
+import threading
+
+# these are the patterns to watch for changes in the plugins directory
+# if in editable mode, the builder will rerun when these files change
+REBUILD_PATTERNS = [
+    "**.py",
+    "**.js",
+    "**.md",
+    "**.svg",
+    "**.ts",
+    "**.tsx",
+    "**.scss",
+]
+
+# ignore these patterns in particular
+# prevents infinite loops when the builder is rerun
+IGNORE_PATTERNS = ["/dist/", "/build/", "/node_modules/", "/_js/", "/."]
+
+
+def start_function(
+    thread: threading.Thread | None, func: Callable, stop_event: threading.Event
+) -> threading.Thread:
+    """
+    Start a function in a new thread and stop the previous thread if it is still running.
+
+    Args:
+        thread: The previous thread to stop
+        func: The function to run
+        stop_event: The event to signal the function to stop
+
+    Returns:
+        The new thread
+    """
+    if thread and thread.is_alive():
+        # stop the previous thread before starting a new one
+        stop_event.set()
+        thread.join()
+    stop_event.clear()
+    thread = threading.Thread(target=func)
+    thread.start()
+    return thread
+
+
+class PluginsChangedHandler(PatternMatchingEventHandler):
+    """
+    A handler that watches for changes reruns the function when changes are detected
+
+    Args:
+        func: The function to run when changes are detected
+        stop_event: The event to signal the function to stop
+
+    Attributes:
+        func: The function to run when changes are detected
+        stop_event: The event to signal the function to stop
+        thread: The thread that the function is running in
+    """
+
+    def __init__(self, func: Callable, stop_event: threading.Event) -> None:
+        super().__init__(patterns=REBUILD_PATTERNS)
+
+        self.func = func
+
+        # A flag to indicate whether the function should continue running
+        self.stop_event = stop_event
+
+        self.thread = None
+
+        self.thread = start_function(self.thread, self.func, self.stop_event)
+
+    def on_any_event(self, event: FileSystemEvent) -> None:
+        """
+        Handle any file system event
+
+        Args:
+            event: The event that occurred
+        """
+        if any(pattern in event.src_path for pattern in IGNORE_PATTERNS):
+            return
+        print(f"File {event.src_path} has been changed, rerunning")
+        self.thread = start_function(self.thread, self.func, self.stop_event)
+
 
 # get the directory of the current file
 current_dir = os.path.dirname(os.path.abspath(__file__))
 # navigate out one directory to get to the plugins directory
 plugins_dir = os.path.join(current_dir, "../plugins")
+# navigate up one directory to get to the project directory
+project_path = os.path.split(current_dir)[0]
 
 
 def clean_build_dist(plugin: str) -> None:
@@ -51,6 +138,23 @@ def plugin_names(
 def run_command(command: str) -> None:
     """
     Run a command and exit if it fails.
+    This should only be used in a non-main thread.
+
+    Args:
+        command: The command to run.
+
+    Returns:
+        None
+    """
+    code = os.system(command)
+    if code != 0:
+        os._exit(1)
+
+
+def run_main_command(command: str) -> None:
+    """
+    Run a command and exit if it fails.
+    This should only be used in the main thread.
 
     Args:
         command: The command to run.
@@ -86,7 +190,7 @@ def run_build(
             run_command(f"python -m build --wheel {plugins_dir}/{plugin}")
         elif error_on_missing:
             click.echo(f"Error: setup.cfg not found in {plugin}")
-            sys.exit(1)
+            os._exit(1)
 
 
 def run_install(
@@ -138,7 +242,7 @@ def run_docs(
             run_command(f"python {plugins_dir}/{plugin}/make_docs.py")
         elif error_on_missing:
             click.echo(f"Error: make_docs.py not found in {plugin}")
-            sys.exit(1)
+            os._exit(1)
 
 
 def run_build_js(plugins: tuple[str]) -> None:
@@ -177,12 +281,88 @@ def run_configure(
         None
     """
     if configure in ["min", "full"]:
-        run_command("pip install -r requirements.txt")
-        run_command("pre-commit install")
-        run_command("npm install")
+        run_main_command("pip install -r requirements.txt")
+        run_main_command("pre-commit install")
+        run_main_command("npm install")
     if configure == "full":
         # currently deephaven-server is installed as part of the sphinx_ext requirements
-        run_command("pip install -r sphinx_ext/sphinx-requirements.txt")
+        run_main_command("pip install -r sphinx_ext/sphinx-requirements.txt")
+
+
+def handle_args(
+    build: bool,
+    install: bool,
+    reinstall: bool,
+    docs: bool,
+    server: bool,
+    js: bool,
+    configure: str | None,
+    plugins: tuple[str],
+    stop_event: threading.Event,
+) -> None:
+    """
+    Handle all arguments for the builder command
+
+    Args:
+        build: True to build the plugins
+        install: True to install the plugins
+        reinstall: True to reinstall the plugins
+        docs: True to generate the docs
+        server: True to run the deephaven server after building and installing the plugins
+        js: True to build the JS files for the plugins
+        configure: The configuration to use. 'min' will install the minimum requirements for development.
+            'full' will install some optional packages for development, such as sphinx and deephaven-server.
+        plugins: Plugins to build and install
+        stop_event: The event to signal the function to stop
+    """
+    # default is to install, but don't if just configuring
+    if not any([build, install, reinstall, docs, js, configure]):
+        js = True
+        install = True
+
+    # if this thread is signaled to stop, return after the current command
+    # instead of in the middle of a command that could leave the environment in a bad state
+    if stop_event.is_set():
+        return
+
+    if js:
+        run_build_js(plugins)
+
+    if stop_event.is_set():
+        return
+
+    if build or install or reinstall:
+        run_build(plugins, len(plugins) > 0)
+
+    if stop_event.is_set():
+        return
+
+    if install or reinstall:
+        run_install(plugins, reinstall)
+
+    if stop_event.is_set():
+        return
+
+    if docs:
+        run_docs(plugins, len(plugins) > 0)
+
+    if stop_event.is_set():
+        return
+
+    if server:
+        click.echo("Running deephaven server")
+        process = subprocess.Popen("deephaven server", shell=True)
+
+        # waiting on either the process to finish or the stop event to be set
+        while not stop_event.wait(1):
+            poll = process.poll()
+            if poll is not None:
+                os._exit(process.returncode)
+
+        try:
+            process.wait(timeout=1)
+        except subprocess.TimeoutExpired:
+            process.kill()
 
 
 @click.command(
@@ -229,8 +409,16 @@ def run_configure(
     "--configure",
     "-c",
     default=None,
-    help="Configure your venv for plugin development. 'min' will install the minimum requirements for development."
+    help="Configure your venv for plugin development. 'min' will install the minimum requirements for development. "
     "'full' will install some optional packages for development, such as sphinx and deephaven-server.",
+)
+@click.option(
+    "--watch",
+    "-w",
+    is_flag=True,
+    help="Run the other provided commands in an editable-like mode, watching for changes "
+    "This will rerun all other commands (except configure) when files are changed. "
+    "The top level directory of this project is watched.",
 )
 @click.argument("plugins", nargs=-1)
 def builder(
@@ -241,6 +429,7 @@ def builder(
     server: bool,
     js: bool,
     configure: str | None,
+    watch: bool,
     plugins: tuple[str],
 ) -> None:
     """
@@ -255,30 +444,41 @@ def builder(
         js: True to build the JS files for the plugins
         configure: The configuration to use. 'min' will install the minimum requirements for development.
             'full' will install some optional packages for development, such as sphinx and deephaven-server.
+        watch: True to rerun the other commands when files are changed
         plugins: Plugins to build and install
     """
+    # no matter what, only run the configure command once
     run_configure(configure)
 
-    # default is to install, but don't if just configuring
-    if not any([build, install, reinstall, docs, js, configure]):
-        js = True
-        install = True
+    stop_event = threading.Event()
 
-    if js:
-        run_build_js(plugins)
+    def run_handle_args():
+        handle_args(
+            build, install, reinstall, docs, server, js, configure, plugins, stop_event
+        )
 
-    if build or install or reinstall:
-        run_build(plugins, len(plugins) > 0)
+    if not watch:
+        # since editable is not specified, only run the handler once
+        # we call it from a thread to allow the usage of os._exit to exit the process
+        # rather than sys.exit because sys.exit will not exit the process when called from a thread
+        # and os._exit should be called from a thread
+        thread = threading.Thread(target=run_handle_args)
+        thread.start()
+        thread.join()
+        sys.exit(0)
 
-    if install or reinstall:
-        run_install(plugins, reinstall)
-
-    if docs:
-        run_docs(plugins, len(plugins) > 0)
-
-    if server:
-        click.echo("Running deephaven server")
-        os.system("deephaven server")
+    # editable is specified, so run the handler in a loop that watches for changes and
+    # reruns the handler when changes are detected
+    event_handler = PluginsChangedHandler(run_handle_args, stop_event)
+    observer = Observer()
+    observer.schedule(event_handler, project_path, recursive=True)
+    observer.start()
+    try:
+        while True:
+            time.sleep(1)
+    finally:
+        observer.stop()
+        observer.join()
 
 
 if __name__ == "__main__":

--- a/tools/plugin_builder.py
+++ b/tools/plugin_builder.py
@@ -39,7 +39,6 @@ IGNORE_REGEXES = [
     # ignore hidden files and directories
     ".*/\..*/.*",
 ]
-# njnhnuunnhunnuu
 
 
 class PluginsChangedHandler(RegexMatchingEventHandler):

--- a/tools/plugin_builder.py
+++ b/tools/plugin_builder.py
@@ -435,7 +435,9 @@ def handle_args(
     "--docs",
     "-d",
     is_flag=True,
-    help="Generate docs for all plugins that have a make_docs.py.",
+    help="Generate docs for all plugins that have a make_docs.py. "
+    "There must be an installed version of the plugin to generate the docs."
+    "Consider using the --reinstall or --install flags to update the plugin before generating the docs.",
 )
 @click.option(
     "--server",

--- a/tools/plugin_builder.py
+++ b/tools/plugin_builder.py
@@ -89,9 +89,11 @@ class PluginsChangedHandler(RegexMatchingEventHandler):
         """
         if self.stop_event.is_set():
             # a rerun has already been scheduled on another thread
-            print(f"File {event.src_path} changed, rerun has already been scheduled")
+            print(
+                f"File {event.src_path} {event.event_type}, rerun has already been scheduled"
+            )
             return
-        print(f"File {event.src_path} changed, new rerun scheduled")
+        print(f"File {event.src_path} {event.event_type}, new rerun scheduled")
         threading.Thread(target=self.attempt_rerun).start()
 
     def on_created(self, event: FileSystemEvent) -> None:


### PR DESCRIPTION
Fixes #632 
Adds a `--watch` mode to `plugin_builder.py`
This goes beyond just editable installs with the goal of automatically running any command that is reasonable to rerun (not config, for example). So this can also be used to rebuild `--docs` automatically, and could rerun tests once I add those in, etc. 
Some of the rerun detection is crude in that "any" file anywhere in the plugins repo will trigger a rerun, but since this is a development script I don't see that as a blocker. It's reasonable that we would run the script in a way that hones in on only building what we want.
Some examples are in the readme