### PR TITLE
chore: Add precommit hook to prevent committing to protected branches

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,9 +25,14 @@ repos:
             matplotlib,
             deephaven-plugin-utilities,
             sphinx,
-            click
+            click,
           ]
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.2.2
     hooks:
-    - id: ruff
+      - id: ruff
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+      - id: no-commit-to-branch
+        args: [--branch, main, --pattern, release/.*]


### PR DESCRIPTION
Figured since we have pre-commit hooks, we could add one to prevent accidentally committing to main and release branches.

I tested this w/ main and it doesn't let me commit without bypassing the hook. Doesn't prevent anything if you don't have the hooks obviously, but at least useful for those of us w/ admin so we don't accidentally do it.

I don't know how this would affect the release process. We might need to add `SKIP=no-commit-to-branch` to the release process if it's run locally w/ git that follows the pre-commit hooks