### PR TITLE
docs: fix unclosed html tag in markdown

### DIFF
--- a/plugins/ui/docs/Plotting.md
+++ b/plugins/ui/docs/Plotting.md
@@ -1,10 +1,10 @@
-# Plotting and dh.ui
+# Plotting and deephaven.ui
 
-Creating dynamic plots that respond to user input is a common task in data analysis. The `dh.ui` module provides a simple interface for creating interactive plots using the `deephaven-express` library. This guide will show you how to create plots that updates based on user input.
+Creating dynamic plots that respond to user input is a common task in data analysis. The `deephaven.ui` module provides a simple interface for creating interactive plots using the `deephaven-express` library. This guide will show you how to create plots that updates based on user input.
 
 ## Plotting a filtered table
 
-This example demonstrates how to create a simple line plot that updates based on user input. The plot will display the price of a stock filtered based on the stock symbol entered by the user. Here we have used a `ui.text_field` to get the value, but it could be driven by any dh.ui input, including double clicking on a value from a `ui.table`. We've previously referred to this sort of behaviour as a "one-click" component in enterprise, as the plot updates as soon as the user enters a filter.
+This example demonstrates how to create a simple line plot that updates based on user input. The plot will display the price of a stock filtered based on the stock symbol entered by the user. Here we have used a `ui.text_field` to get the value, but it could be driven by any deephaven.ui input, including double clicking on a value from a `ui.table`. We've previously referred to this sort of behaviour as a "one-click" component in enterprise, as the plot updates as soon as the user enters a filter.
 
 ```python
 import deephaven.plot.express as dx

--- a/plugins/ui/docs/components/view.md
+++ b/plugins/ui/docs/components/view.md
@@ -25,7 +25,7 @@ view = ui.view(
 
 Recommendations for creating views:
 
-1. Views are analogous to HTML <div>'s, and can be used in a similar regard to ensure consistency in styling across components.
+1. Views are analogous to HTML `<div>`'s, and can be used in a similar regard to ensure consistency in styling across components.
 2. Views lose their value when overused. Use them sparingly to avoid creating unnecessary complexity.
 3. A view's height is flexible; it should accommodate the amount of content inside.
 4. Views should be used when a flexible layout container is needed that can handle various combinations of components (ie., `text_field`s, `text_area`s, or buttons).


### PR DESCRIPTION
Having an open div without a closing tag is Invalid markdown. We don't do any validation yet, but was preventing the page from rendering.

Also updated some dh.ui -> deephaven.ui wordings.