### PR TITLE
fix: text_area on_key_down throws errors

### DIFF
--- a/plugins/ui/src/js/src/elements/TextArea.tsx
+++ b/plugins/ui/src/js/src/elements/TextArea.tsx
@@ -1,36 +1,15 @@
 import React from 'react';
-import {
-  TextArea as DHCTextArea,
-  TextAreaProps as DHCTextAreaProps,
-} from '@deephaven/components';
-import { EMPTY_FUNCTION } from '@deephaven/utils';
-import useDebouncedOnChange from './hooks/useDebouncedOnChange';
+import { TextArea as DHCTextArea, TextAreaProps } from '@deephaven/components';
+import useTextAreaProps from './hooks/useTextAreaProps';
+import { SerializedTextAreaEventProps } from './model';
 
-interface TextAreaProps extends DHCTextAreaProps {
-  onChange?: (value: string) => Promise<void>;
-}
+export function TextArea(
+  props: SerializedTextAreaEventProps<TextAreaProps>
+): JSX.Element {
+  const textAreaProps = useTextAreaProps(props);
 
-export function TextArea(props: TextAreaProps): JSX.Element {
-  const {
-    defaultValue = '',
-    value: propValue,
-    onChange: propOnChange = EMPTY_FUNCTION,
-    ...otherProps
-  } = props;
-
-  const [value, onChange] = useDebouncedOnChange(
-    propValue ?? defaultValue,
-    propOnChange
-  );
-
-  return (
-    <DHCTextArea
-      value={value}
-      onChange={onChange}
-      // eslint-disable-next-line react/jsx-props-no-spreading
-      {...otherProps}
-    />
-  );
+  // eslint-disable-next-line react/jsx-props-no-spreading
+  return <DHCTextArea {...textAreaProps} />;
 }
 
 TextArea.displayName = 'TextArea';

--- a/plugins/ui/src/js/src/elements/hooks/useDebouncedOnChange.ts
+++ b/plugins/ui/src/js/src/elements/hooks/useDebouncedOnChange.ts
@@ -6,8 +6,8 @@ const VALUE_CHANGE_DEBOUNCE = 250;
 
 function useDebouncedOnChange<T>(
   propValue: T,
-  propOnChange: (() => void) | ((newValue: T) => Promise<void>)
-): [T, (newValue: T) => void] {
+  propOnChange: (() => void) | ((newValue: T) => Promise<void>) | undefined
+): [T, ((newValue: T) => void) | undefined] {
   const [value, setValue] = useState<T>(propValue);
   const [pending, setPending] = useState(false);
   const prevPropValue = usePrevious(propValue);
@@ -26,7 +26,7 @@ function useDebouncedOnChange<T>(
   const propDebouncedOnChange = useCallback(
     async (newValue: T) => {
       try {
-        await propOnChange(newValue);
+        await propOnChange?.(newValue);
       } catch (e) {
         log.warn('Error returned from onChange', e);
       }
@@ -50,7 +50,7 @@ function useDebouncedOnChange<T>(
     [debouncedOnChange]
   );
 
-  return [value, onChange] as const;
+  return [value, propOnChange != null ? onChange : undefined] as const;
 }
 
 export default useDebouncedOnChange;

--- a/plugins/ui/src/js/src/elements/hooks/useFocusEventCallback.ts
+++ b/plugins/ui/src/js/src/elements/hooks/useFocusEventCallback.ts
@@ -26,9 +26,7 @@ export type SerializedFocusEventCallback = (
   event: SerializedFocusEvent
 ) => void;
 
-export type DeserializedFocusEventCallback =
-  | ((e: FocusEvent) => void)
-  | undefined;
+export type DeserializedFocusEventCallback = (e: FocusEvent) => void;
 
 /**
  * Get a callback function to be passed into spectrum components
@@ -37,7 +35,7 @@ export type DeserializedFocusEventCallback =
  */
 export function useFocusEventCallback(
   callback?: SerializedFocusEventCallback
-): DeserializedFocusEventCallback {
+): DeserializedFocusEventCallback | undefined {
   const focusCallBack = useCallback(
     (e: FocusEvent) => {
       callback?.(serializeFocusEvent(e));

--- a/plugins/ui/src/js/src/elements/hooks/useFocusEventCallback.ts
+++ b/plugins/ui/src/js/src/elements/hooks/useFocusEventCallback.ts
@@ -26,7 +26,9 @@ export type SerializedFocusEventCallback = (
   event: SerializedFocusEvent
 ) => void;
 
-export type DeserializedFocusEventCallback = (e: FocusEvent) => void;
+export type DeserializedFocusEventCallback =
+  | ((e: FocusEvent) => void)
+  | undefined;
 
 /**
  * Get a callback function to be passed into spectrum components
@@ -36,10 +38,11 @@ export type DeserializedFocusEventCallback = (e: FocusEvent) => void;
 export function useFocusEventCallback(
   callback?: SerializedFocusEventCallback
 ): DeserializedFocusEventCallback {
-  return useCallback(
+  const focusCallBack = useCallback(
     (e: FocusEvent) => {
       callback?.(serializeFocusEvent(e));
     },
     [callback]
   );
+  return callback != null ? focusCallBack : undefined;
 }

--- a/plugins/ui/src/js/src/elements/hooks/useKeyboardEventCallback.ts
+++ b/plugins/ui/src/js/src/elements/hooks/useKeyboardEventCallback.ts
@@ -26,7 +26,9 @@ export type SerializedKeyboardEventCallback = (
   event: SerializedKeyboardEvent
 ) => void;
 
-export type DeserializedKeyboardEventCallback = (e: KeyboardEvent) => void;
+export type DeserializedKeyboardEventCallback =
+  | ((e: KeyboardEvent) => void)
+  | undefined;
 
 /**
  * Get a callback function to be passed into spectrum components
@@ -36,10 +38,11 @@ export type DeserializedKeyboardEventCallback = (e: KeyboardEvent) => void;
 export function useKeyboardEventCallback(
   callback?: SerializedKeyboardEventCallback
 ): DeserializedKeyboardEventCallback {
-  return useCallback(
+  const keyboardCallback = useCallback(
     (e: KeyboardEvent) => {
       callback?.(serializeKeyboardEvent(e));
     },
     [callback]
   );
+  return callback != null ? keyboardCallback : undefined;
 }

--- a/plugins/ui/src/js/src/elements/hooks/useKeyboardEventCallback.ts
+++ b/plugins/ui/src/js/src/elements/hooks/useKeyboardEventCallback.ts
@@ -26,9 +26,7 @@ export type SerializedKeyboardEventCallback = (
   event: SerializedKeyboardEvent
 ) => void;
 
-export type DeserializedKeyboardEventCallback =
-  | ((e: KeyboardEvent) => void)
-  | undefined;
+export type DeserializedKeyboardEventCallback = (e: KeyboardEvent) => void;
 
 /**
  * Get a callback function to be passed into spectrum components
@@ -37,7 +35,7 @@ export type DeserializedKeyboardEventCallback =
  */
 export function useKeyboardEventCallback(
   callback?: SerializedKeyboardEventCallback
-): DeserializedKeyboardEventCallback {
+): DeserializedKeyboardEventCallback | undefined {
   const keyboardCallback = useCallback(
     (e: KeyboardEvent) => {
       callback?.(serializeKeyboardEvent(e));

--- a/plugins/ui/src/js/src/elements/hooks/usePressEventCallback.ts
+++ b/plugins/ui/src/js/src/elements/hooks/usePressEventCallback.ts
@@ -36,11 +36,12 @@ export type SerializedPressEventCallback = (
  */
 export function usePressEventCallback(
   callback?: SerializedPressEventCallback
-): (e: PressEvent) => void {
-  return useCallback(
+): ((e: PressEvent) => void) | undefined {
+  const pressCallback = useCallback(
     (e: PressEvent) => {
       callback?.(serializePressEvent(e));
     },
     [callback]
   );
+  return callback != null ? pressCallback : undefined;
 }

--- a/plugins/ui/src/js/src/elements/hooks/useTextAreaProps.ts
+++ b/plugins/ui/src/js/src/elements/hooks/useTextAreaProps.ts
@@ -1,0 +1,43 @@
+import { EMPTY_FUNCTION } from '@deephaven/utils';
+import { useFocusEventCallback } from './useFocusEventCallback';
+import { useKeyboardEventCallback } from './useKeyboardEventCallback';
+import { SerializedTextAreaEventProps } from '../model/SerializedPropTypes';
+import { wrapTextChildren } from '../utils';
+import useDebouncedOnChange from './useDebouncedOnChange';
+
+// returns SpectrumButtonProps
+export function useTextAreaProps<T>(props: SerializedTextAreaEventProps<T>): T {
+  const {
+    defaultValue = '',
+    value: propValue,
+    onChange: propOnChange = EMPTY_FUNCTION,
+    onFocus: propOnFocus,
+    onBlur: propOnBlur,
+    onKeyDown: propOnKeyDown,
+    onKeyUp: propOnKeyUp,
+    children,
+    ...otherProps
+  } = props;
+  const onFocus = useFocusEventCallback(propOnFocus);
+  const onBlur = useFocusEventCallback(propOnBlur);
+  const onKeyDown = useKeyboardEventCallback(propOnKeyDown);
+  const onKeyUp = useKeyboardEventCallback(propOnKeyUp);
+  const [value, onChange] = useDebouncedOnChange(
+    propValue ?? defaultValue,
+    propOnChange
+  );
+
+  return {
+    defaultValue,
+    value,
+    onChange,
+    onFocus,
+    onBlur,
+    onKeyDown,
+    onKeyUp,
+    children: wrapTextChildren(children),
+    ...otherProps,
+  } as T;
+}
+
+export default useTextAreaProps;

--- a/plugins/ui/src/js/src/elements/hooks/useTextAreaProps.ts
+++ b/plugins/ui/src/js/src/elements/hooks/useTextAreaProps.ts
@@ -5,7 +5,7 @@ import { SerializedTextAreaEventProps } from '../model/SerializedPropTypes';
 import { wrapTextChildren } from '../utils';
 import useDebouncedOnChange from './useDebouncedOnChange';
 
-// returns SpectrumButtonProps
+// returns SpectrumTextAreaProps
 export function useTextAreaProps<T>(props: SerializedTextAreaEventProps<T>): T {
   const {
     defaultValue = '',

--- a/plugins/ui/src/js/src/elements/hooks/useTextAreaProps.ts
+++ b/plugins/ui/src/js/src/elements/hooks/useTextAreaProps.ts
@@ -1,4 +1,3 @@
-import { EMPTY_FUNCTION } from '@deephaven/utils';
 import { useFocusEventCallback } from './useFocusEventCallback';
 import { useKeyboardEventCallback } from './useKeyboardEventCallback';
 import { SerializedTextAreaEventProps } from '../model/SerializedPropTypes';
@@ -10,7 +9,7 @@ export function useTextAreaProps<T>(props: SerializedTextAreaEventProps<T>): T {
   const {
     defaultValue = '',
     value: propValue,
-    onChange: propOnChange = EMPTY_FUNCTION,
+    onChange: propOnChange,
     onFocus: propOnFocus,
     onBlur: propOnBlur,
     onKeyDown: propOnKeyDown,

--- a/plugins/ui/src/js/src/elements/model/SerializedPropTypes.ts
+++ b/plugins/ui/src/js/src/elements/model/SerializedPropTypes.ts
@@ -44,6 +44,24 @@ export type SerializedPressEventProps<T> = Omit<
   onPressUp?: SerializedPressEventCallback;
 };
 
+export type SerializedInputElementProps<T> = Omit<
+  T,
+  'defaultValue' | 'value' | 'onChange'
+> & {
+  /** The default value of the input */
+  defaultValue?: string;
+
+  /** The value of the input */
+  value?: string;
+
+  /** Handler that is called when the input value changes */
+  onChange?: (value: string) => Promise<void>;
+};
+
 export type SerializedButtonEventProps<T> = SerializedFocusEventProps<
   SerializedKeyboardEventProps<SerializedPressEventProps<T>>
+> & { children: React.ReactNode };
+
+export type SerializedTextAreaEventProps<T> = SerializedFocusEventProps<
+  SerializedKeyboardEventProps<SerializedInputElementProps<T>>
 > & { children: React.ReactNode };


### PR DESCRIPTION
- Fixes #790 
- Switch to `useKeyboardEventCallback` for `text_area` keyboard events
- Add new serialized props for input elements, which contains `defaultValue`, `value`, and `onChange`