### PR TITLE
refactor: rename label_alignment to label_align

### DIFF
--- a/plugins/ui/src/deephaven/ui/components/form.py
+++ b/plugins/ui/src/deephaven/ui/components/form.py
@@ -39,7 +39,7 @@ def form(
     auto_complete: AutoCompleteModes | None = None,
     auto_capitalize: AutoCapitalizeModes | None = None,
     label_position: LabelPosition = "top",
-    label_alignment: Alignment = "start",
+    label_align: Alignment = "start",
     necessity_indicator: NecessityIndicator = "icon",
     on_submit: Callable[[dict[str, str]], None] | None = None,
     on_reset: Callable[[dict[str, str]], None] | None = None,
@@ -108,7 +108,7 @@ def form(
         auto_complete: Indicates whether input elements can by default have their values automatically completed by the browser.
         auto_capitalize: Controls whether inputted text is automatically capitalized and, if so, in what manner.
         label_position: The label's overall position relative to the element it is labeling.
-        label_alignment: The label's horizontal alignment relative to the element it is labeling.
+        label_align: The label's horizontal alignment relative to the element it is labeling.
         necessity_indicator: Whether the required state should be shown as an icon or text.
         on_submit: The function to call when the form is submitted.
         on_reset: The function to call when the form is reset.
@@ -175,7 +175,7 @@ def form(
         auto_complete=auto_complete,
         auto_capitalize=auto_capitalize,
         label_position=label_position,
-        label_alignment=label_alignment,
+        label_align=label_align,
         necessity_indicator=necessity_indicator,
         on_submit=on_submit,
         on_reset=on_reset,

--- a/plugins/ui/src/deephaven/ui/components/picker.py
+++ b/plugins/ui/src/deephaven/ui/components/picker.py
@@ -62,7 +62,7 @@ def picker(
     placeholder: str | None = None,
     is_loading: bool | None = None,
     label_position: LabelPosition = "top",
-    label_alignment: Alignment = "start",
+    label_align: Alignment = "start",
     necessity_indicator: NecessityIndicator = "icon",
     contextual_help: Element | None = None,
     on_open_change: Callable[[bool], None] | None = None,
@@ -162,7 +162,7 @@ def picker(
         placeholder: Placeholder text for the input.
         is_loading: Whether the Picker is in a loading state.
         label_position: The label's overall position relative to the element it is labeling.
-        label_alignment: The label's horizontal alignment relative to the element it is labeling.
+        label_align: The label's horizontal alignment relative to the element it is labeling.
         necessity_indicator: Whether the required state should be shown as an icon or text.
         contextual_help: A ContextualHelp element to place next to the label.
         on_open_change: Handler that is called when the open state changes.


### PR DESCRIPTION
- Fixes #717 
- Rename `label_alignment` to `label_align` for `form` and `picker`