### PR TITLE
fix: Make regex strings raw

### DIFF
--- a/templates/widget/{{ cookiecutter.python_project_name }}/plugin_builder.py
+++ b/templates/widget/{{ cookiecutter.python_project_name }}/plugin_builder.py
@@ -17,22 +17,22 @@ current_dir = os.path.dirname(os.path.abspath(__file__))
 # these are the patterns to watch for changes in this directory
 # if in editable mode, the builder will rerun when these files change
 REBUILD_REGEXES = [
-    ".*\.py$",
-    ".*\.js$",
-    ".*\.ts$",
-    ".*\.tsx$",
-    ".*\.scss$",
+    r".*\.py$",
+    r".*\.js$",
+    r".*\.ts$",
+    r".*\.tsx$",
+    r".*\.scss$",
 ]
 
 # ignore these patterns in particular
 # prevents infinite loops when the builder is rerun
 IGNORE_REGEXES = [
-    ".*/dist/.*",
-    ".*/build/.*",
-    ".*/node_modules/.*",
-    ".*/_js/.*",
+    r".*/dist/.*",
+    r".*/build/.*",
+    r".*/node_modules/.*",
+    r".*/_js/.*",
     # ignore hidden files and directories
-    ".*/\..*/.*",
+    r".*/\..*/.*",
 ]
 
 # the path where the python files are located relative to this script

--- a/tools/plugin_builder.py
+++ b/tools/plugin_builder.py
@@ -20,24 +20,24 @@ project_path = os.path.split(current_dir)[0]
 # these are the patterns to watch for changes in the plugins directory
 # if in editable mode, the builder will rerun when these files change
 REBUILD_REGEXES = [
-    ".*\.py$",
-    ".*\.js$",
-    ".*\.md$",
-    ".*\.svg$",
-    ".*\.ts$",
-    ".*\.tsx$",
-    ".*\.scss$",
+    r".*\.py$",
+    r".*\.js$",
+    r".*\.md$",
+    r".*\.svg$",
+    r".*\.ts$",
+    r".*\.tsx$",
+    r".*\.scss$",
 ]
 
 # ignore these patterns in particular
 # prevents infinite loops when the builder is rerun
 IGNORE_REGEXES = [
-    ".*/dist/.*",
-    ".*/build/.*",
-    ".*/node_modules/.*",
-    ".*/_js/.*",
+    r".*/dist/.*",
+    r".*/build/.*",
+    r".*/node_modules/.*",
+    r".*/_js/.*",
     # ignore hidden files and directories
-    ".*/\..*/.*",
+    r".*/\..*/.*",
 ]
 
 


### PR DESCRIPTION
Regex strings should generally be raw as in "normal" strings, "\" signifies an escape.