### PR TITLE
fix: Set mime type correctly on google cloud md files

### DIFF
--- a/.github/workflows/build-main-docs.yml
+++ b/.github/workflows/build-main-docs.yml
@@ -23,6 +23,11 @@ on:
         options:
           - 'push'
           - 'test'
+      fix_mime_types:
+        description: 'Whether to fix the mime types of the markdown files in the docs bucket. Generally this should be false.'
+        required: false
+        type: boolean
+        default: false
   workflow_call:
     inputs:
       package:
@@ -37,6 +42,11 @@ on:
         description: The event name that triggered the workflow
         required: true
         type: string
+      fix_mime_types:
+        description: 'Whether to fix the mime types of the markdown files in the docs bucket. Generally this should be false.'
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   check-make-docs:
@@ -68,3 +78,5 @@ jobs:
       package: ${{ inputs.package }}
       version: ${{ inputs.version }}
       event_name: ${{ inputs.event_name }}
+      fix_mime_types: ${{ inputs.fix_mime_types }}
+

--- a/.github/workflows/make-docs.yml
+++ b/.github/workflows/make-docs.yml
@@ -61,7 +61,7 @@ jobs:
         if: inputs.event_name == 'push'
         run: rclone sync plugins/${{ inputs.package }}/docs/build/markdown/ plugindocs:${{ secrets.DOCS_GOOGLE_CLOUD_BUCKET }}/deephaven/deephaven-plugins/${{ inputs.package }}/${{ inputs.version }}/
 
-      - id: Setup gsutil auth
+      - name: Setup gsutil auth
         if: inputs.event_name == 'push'
         uses: 'google-github-actions/auth@v2'
         with:

--- a/.github/workflows/make-docs.yml
+++ b/.github/workflows/make-docs.yml
@@ -13,6 +13,10 @@ on:
         required: false
         type: string
         default: 'push'
+      fix_mime_types:
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   make-docs:
@@ -62,16 +66,16 @@ jobs:
         run: rclone sync plugins/${{ inputs.package }}/docs/build/markdown/ plugindocs:${{ secrets.DOCS_GOOGLE_CLOUD_BUCKET }}/deephaven/deephaven-plugins/${{ inputs.package }}/${{ inputs.version }}/
 
       - name: Setup gsutil auth
-        if: inputs.event_name == 'push'
+        if: inputs.fix_mime_types == true
         uses: 'google-github-actions/auth@v2'
         with:
           credentials_json: '${{ secrets.DOCS_GOOGLE_CLOUD_CREDENTIALS }}'
 
       - name: Setup gsutil CLI
-        if: inputs.event_name == 'push'
+        if: inputs.fix_mime_types == true
         uses: 'google-github-actions/setup-gcloud@v2'
 
       - name: Set gsutil markdown mime type
-        if: inputs.event_name == 'push'
+        if: inputs.fix_mime_types == true
         # some markdown files get set to octet-stream by default, so fix them
         run: gsutil -m setmeta -h "Content-Type:text/markdown; charset=utf-8" -r "gs://${{ secrets.DOCS_GOOGLE_CLOUD_BUCKET }}/deephaven/deephaven-plugins/${{ inputs.package }}/${{ inputs.version }}/**/*.md"

--- a/.github/workflows/make-docs.yml
+++ b/.github/workflows/make-docs.yml
@@ -74,4 +74,4 @@ jobs:
       - name: Set gsutil markdown mime type
         if: inputs.event_name == 'push'
         # some markdown files get set to octet-stream by default, so fix them
-        run: gsutil -m setmeta -h "Content-Type:text/markdown; charset=utf-8" -r "gs://${{ secrets.DOCS_GOOGLE_CLOUD_BUCKET }}/deephaven/deephaven-plugins/${{ inputs.package }}/${{ inputs.version }}/**.md"
+        run: gsutil -m setmeta -h "Content-Type:text/markdown; charset=utf-8" -r "gs://${{ secrets.DOCS_GOOGLE_CLOUD_BUCKET }}/deephaven/deephaven-plugins/${{ inputs.package }}/${{ inputs.version }}/**/*.md"

--- a/.github/workflows/make-docs.yml
+++ b/.github/workflows/make-docs.yml
@@ -60,3 +60,18 @@ jobs:
       - name: Sync docs
         if: inputs.event_name == 'push'
         run: rclone sync plugins/${{ inputs.package }}/docs/build/markdown/ plugindocs:${{ secrets.DOCS_GOOGLE_CLOUD_BUCKET }}/deephaven/deephaven-plugins/${{ inputs.package }}/${{ inputs.version }}/
+
+      - id: Setup gsutil auth
+        if: inputs.event_name == 'push'
+        uses: 'google-github-actions/auth@v2'
+        with:
+          credentials_json: '${{ secrets.DOCS_GOOGLE_CLOUD_CREDENTIALS }}'
+
+      - name: Setup gsutil CLI
+        if: inputs.event_name == 'push'
+        uses: 'google-github-actions/setup-gcloud@v2'
+
+      - name: Set gsutil markdown mime type
+        if: inputs.event_name == 'push'
+        # some markdown files get set to octet-stream by default, so fix them
+        run: gsutil -m setmeta -h "Content-Type:text/markdown; charset=utf-8" -r gs://${{ secrets.DOCS_GOOGLE_CLOUD_BUCKET }}/deephaven/deephaven-plugins/${{ inputs.package }}/${{ inputs.version }}/**.md

--- a/.github/workflows/make-docs.yml
+++ b/.github/workflows/make-docs.yml
@@ -74,4 +74,4 @@ jobs:
       - name: Set gsutil markdown mime type
         if: inputs.event_name == 'push'
         # some markdown files get set to octet-stream by default, so fix them
-        run: gsutil -m setmeta -h "Content-Type:text/markdown; charset=utf-8" -r gs://${{ secrets.DOCS_GOOGLE_CLOUD_BUCKET }}/deephaven/deephaven-plugins/${{ inputs.package }}/${{ inputs.version }}/**.md
+        run: gsutil -m setmeta -h "Content-Type:text/markdown; charset=utf-8" -r "gs://${{ secrets.DOCS_GOOGLE_CLOUD_BUCKET }}/deephaven/deephaven-plugins/${{ inputs.package }}/${{ inputs.version }}/**.md"


### PR DESCRIPTION
Fixes #806 

I've tested on my fork and it appears that all files are getting set to the proper mime type
<img width="593" alt="Screenshot 2024-09-09 at 3 48 57 PM" src="https://github.com/user-attachments/assets/06f3acbc-a9f8-4ef9-9611-1e2f934825ee">
