### PR TITLE
fix: set label_align default to None

### DIFF
--- a/plugins/ui/src/deephaven/ui/components/combo_box.py
+++ b/plugins/ui/src/deephaven/ui/components/combo_box.py
@@ -71,7 +71,7 @@ def combo_box(
     name: str | None = None,
     validation_state: ValidationState | None = None,
     label_position: LabelPosition = "top",
-    label_align: Alignment = "start",
+    label_align: Alignment | None = None,
     necessity_indicator: NecessityIndicator | None = "icon",
     contextual_help: Element | None = None,
     on_open_change: Callable[[bool, MenuTriggerAction], None] | None = None,

--- a/plugins/ui/src/deephaven/ui/components/form.py
+++ b/plugins/ui/src/deephaven/ui/components/form.py
@@ -39,7 +39,7 @@ def form(
     auto_complete: AutoCompleteModes | None = None,
     auto_capitalize: AutoCapitalizeModes | None = None,
     label_position: LabelPosition = "top",
-    label_align: Alignment = "start",
+    label_align: Alignment | None = None,
     necessity_indicator: NecessityIndicator = "icon",
     on_submit: Callable[[dict[str, str]], None] | None = None,
     on_reset: Callable[[dict[str, str]], None] | None = None,

--- a/plugins/ui/src/deephaven/ui/components/number_field.py
+++ b/plugins/ui/src/deephaven/ui/components/number_field.py
@@ -15,7 +15,7 @@ from .types import (
     LayoutFlex,
     Position,
     LabelPosition,
-    Align,
+    Alignment,
 )
 from .basic import component_element
 from ..elements import Element
@@ -45,7 +45,7 @@ def number_field(
     validation_state: TextFieldValidationState | None = None,
     name: str | None = None,
     label_position: LabelPosition = "top",
-    label_align: Align = "start",
+    label_align: Alignment | None = None,
     necessity_indicator: NecessityIndicator = "icon",
     contextual_help: Any | None = None,
     on_focus: FocusEventCallable | None = None,

--- a/plugins/ui/src/deephaven/ui/components/picker.py
+++ b/plugins/ui/src/deephaven/ui/components/picker.py
@@ -62,7 +62,7 @@ def picker(
     placeholder: str | None = None,
     is_loading: bool | None = None,
     label_position: LabelPosition = "top",
-    label_align: Alignment = "start",
+    label_align: Alignment | None = None,
     necessity_indicator: NecessityIndicator = "icon",
     contextual_help: Element | None = None,
     on_open_change: Callable[[bool], None] | None = None,

--- a/plugins/ui/src/deephaven/ui/components/radio_group.py
+++ b/plugins/ui/src/deephaven/ui/components/radio_group.py
@@ -11,7 +11,7 @@ from .types import (
     LayoutFlex,
     Position,
     LabelPosition,
-    Align,
+    Alignment,
     # Validation
     NecessityIndicator,
     Orientation,
@@ -39,7 +39,7 @@ def radio_group(
     description: Any | None = None,
     error_message: Any | None = None,
     label_position: LabelPosition = "top",
-    label_align: Align = "start",
+    label_align: Alignment | None = None,
     necessity_indicator: NecessityIndicator = "icon",
     contextual_help: Any | None = None,
     show_error_icon: bool | None = None,

--- a/plugins/ui/src/deephaven/ui/components/text_area.py
+++ b/plugins/ui/src/deephaven/ui/components/text_area.py
@@ -15,7 +15,7 @@ from .types import (
     LayoutFlex,
     Position,
     LabelPosition,
-    Align,
+    Alignment,
     # Validation
     TextFieldInputMode,
     TextFieldValidationState,
@@ -48,7 +48,7 @@ def text_area(
     name: str | None = None,
     validation_state: TextFieldValidationState | None = None,
     label_position: LabelPosition = "top",
-    label_align: Align = "start",
+    label_align: Alignment | None = None,
     necessity_indicator: NecessityIndicator = "icon",
     contextual_help: Any | None = None,
     on_focus: FocusEventCallable | None = None,

--- a/plugins/ui/src/deephaven/ui/components/text_field.py
+++ b/plugins/ui/src/deephaven/ui/components/text_field.py
@@ -15,7 +15,7 @@ from .types import (
     LayoutFlex,
     Position,
     LabelPosition,
-    Align,
+    Alignment,
     # Validation
     TextFieldType,
     TextFieldInputMode,
@@ -47,7 +47,7 @@ def text_field(
     name: str | None = None,
     validation_state: TextFieldValidationState | None = None,
     label_position: LabelPosition = "top",
-    label_align: Align = "start",
+    label_align: Alignment | None = None,
     necessity_indicator: NecessityIndicator = "icon",
     contextual_help: Any | None = None,
     on_focus: FocusEventCallable | None = None,

--- a/plugins/ui/src/deephaven/ui/components/types/layout.py
+++ b/plugins/ui/src/deephaven/ui/components/types/layout.py
@@ -149,7 +149,6 @@ CSSProperties = Dict[str, Any]
 A dictionary of CSS properties.
 """
 LabelPosition = Literal["top", "side"]
-Align = Literal["start", "end"]
 
 GridFlow = Literal["row", "column", "row dense", "column dense"]
 BorderSize = Literal["none", "thin", "thick", "thicker", "thickest"]


### PR DESCRIPTION
- Fixes #801 
  - Set all `label_align` props to default to None
  - Deleted `Align` type - duplicate of `Alignment`