### PR TITLE
ci: Specify deephaven-plugin-utilities version for pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
             plotly,
             json-rpc,
             matplotlib,
-            deephaven-plugin-utilities,
+            deephaven-plugin-utilities>=0.0.2,
             sphinx,
             click,
             watchdog,
@@ -31,4 +31,4 @@ repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.2.2
     hooks:
-    - id: ruff
+      - id: ruff


### PR DESCRIPTION
Looks like pre-commit uses its own venv if you specify dependencies, so this version needs to be explicit. Otherwise our local pre-commit hooks will have old dependencies and fail locally