### PR TITLE
fix: text_field events throw error

### DIFF
--- a/plugins/ui/src/js/src/elements/TextArea.tsx
+++ b/plugins/ui/src/js/src/elements/TextArea.tsx
@@ -1,12 +1,14 @@
-import React from 'react';
-import { TextArea as DHCTextArea, TextAreaProps } from '@deephaven/components';
-import useTextAreaProps from './hooks/useTextAreaProps';
-import { SerializedTextAreaEventProps } from './model';
+import {
+  TextArea as DHCTextArea,
+  TextAreaProps as DHCTextAreaProps,
+} from '@deephaven/components';
+import useTextInputProps from './hooks/useTextInputProps';
+import { SerializedTextInputEventProps } from './model';
 
 export function TextArea(
-  props: SerializedTextAreaEventProps<TextAreaProps>
+  props: SerializedTextInputEventProps<DHCTextAreaProps>
 ): JSX.Element {
-  const textAreaProps = useTextAreaProps(props);
+  const textAreaProps = useTextInputProps(props);
 
   // eslint-disable-next-line react/jsx-props-no-spreading
   return <DHCTextArea {...textAreaProps} />;

--- a/plugins/ui/src/js/src/elements/TextField.tsx
+++ b/plugins/ui/src/js/src/elements/TextField.tsx
@@ -1,37 +1,17 @@
-import React from 'react';
 import {
   TextField as DHCTextField,
   TextFieldProps as DHCTextFieldProps,
 } from '@deephaven/components';
-import useDebouncedOnChange from './hooks/useDebouncedOnChange';
+import useTextInputProps from './hooks/useTextInputProps';
+import { SerializedTextInputEventProps } from './model';
 
-const EMPTY_FUNCTION = () => undefined;
+export function TextField(
+  props: SerializedTextInputEventProps<DHCTextFieldProps>
+): JSX.Element {
+  const textFieldProps = useTextInputProps(props);
 
-interface TextFieldProps extends DHCTextFieldProps {
-  onChange?: (value: string) => Promise<void>;
-}
-
-export function TextField(props: TextFieldProps): JSX.Element {
-  const {
-    defaultValue = '',
-    value: propValue,
-    onChange: propOnChange = EMPTY_FUNCTION,
-    ...otherProps
-  } = props;
-
-  const [value, onChange] = useDebouncedOnChange<string>(
-    propValue ?? defaultValue,
-    propOnChange
-  );
-
-  return (
-    <DHCTextField
-      value={value}
-      onChange={onChange}
-      // eslint-disable-next-line react/jsx-props-no-spreading
-      {...otherProps}
-    />
-  );
+  // eslint-disable-next-line react/jsx-props-no-spreading
+  return <DHCTextField {...textFieldProps} />;
 }
 
 TextField.displayName = 'TextField';

--- a/plugins/ui/src/js/src/elements/hooks/useTextInputProps.ts
+++ b/plugins/ui/src/js/src/elements/hooks/useTextInputProps.ts
@@ -1,11 +1,12 @@
 import { useFocusEventCallback } from './useFocusEventCallback';
 import { useKeyboardEventCallback } from './useKeyboardEventCallback';
-import { SerializedTextAreaEventProps } from '../model/SerializedPropTypes';
-import { wrapTextChildren } from '../utils';
+import { SerializedTextInputEventProps } from '../model/SerializedPropTypes';
 import useDebouncedOnChange from './useDebouncedOnChange';
 
 // returns SpectrumTextAreaProps
-export function useTextAreaProps<T>(props: SerializedTextAreaEventProps<T>): T {
+export function useTextInputProps<T>(
+  props: SerializedTextInputEventProps<T>
+): T {
   const {
     defaultValue = '',
     value: propValue,
@@ -14,7 +15,6 @@ export function useTextAreaProps<T>(props: SerializedTextAreaEventProps<T>): T {
     onBlur: propOnBlur,
     onKeyDown: propOnKeyDown,
     onKeyUp: propOnKeyUp,
-    children,
     ...otherProps
   } = props;
   const onFocus = useFocusEventCallback(propOnFocus);
@@ -34,9 +34,8 @@ export function useTextAreaProps<T>(props: SerializedTextAreaEventProps<T>): T {
     onBlur,
     onKeyDown,
     onKeyUp,
-    children: wrapTextChildren(children),
     ...otherProps,
   } as T;
 }
 
-export default useTextAreaProps;
+export default useTextInputProps;

--- a/plugins/ui/src/js/src/elements/model/SerializedPropTypes.ts
+++ b/plugins/ui/src/js/src/elements/model/SerializedPropTypes.ts
@@ -62,6 +62,6 @@ export type SerializedButtonEventProps<T> = SerializedFocusEventProps<
   SerializedKeyboardEventProps<SerializedPressEventProps<T>>
 > & { children: React.ReactNode };
 
-export type SerializedTextAreaEventProps<T> = SerializedFocusEventProps<
+export type SerializedTextInputEventProps<T> = SerializedFocusEventProps<
   SerializedKeyboardEventProps<SerializedInputElementProps<T>>
-> & { children: React.ReactNode };
+>;


### PR DESCRIPTION
- Fixes #893 
  - Generalize the text area hook to be used for any text input, and make `text_field` use that