### PR TITLE
fix: Newlines within type description not parsed correctly in docs

### DIFF
--- a/sphinx_ext/deephaven_autodoc.py
+++ b/sphinx_ext/deephaven_autodoc.py
@@ -104,7 +104,7 @@ def extract_list_item(node: docutils.nodes.list_item) -> ParamData:
     Returns:
         The param data
     """
-    field = node.astext().replace("\n", "<br />")
+    field = node.astext().replace("\n", " ")
     try:
         match = re.match(r"(.+?) \((.*?)\) -- (.+)", field, re.DOTALL)
         if match is None:


### PR DESCRIPTION
Goes back to stripping newlines for type descriptions specifically (changed in #805) as those don't parse properly now