### PR TITLE
fix: set necessity_indicator default to None

### DIFF
--- a/plugins/ui/src/deephaven/ui/components/combo_box.py
+++ b/plugins/ui/src/deephaven/ui/components/combo_box.py
@@ -72,7 +72,7 @@ def combo_box(
     validation_state: ValidationState | None = None,
     label_position: LabelPosition = "top",
     label_align: Alignment | None = None,
-    necessity_indicator: NecessityIndicator | None = "icon",
+    necessity_indicator: NecessityIndicator | None = None,
     contextual_help: Element | None = None,
     on_open_change: Callable[[bool, MenuTriggerAction], None] | None = None,
     on_selection_change: Callable[[Key], None] | None = None,

--- a/plugins/ui/src/deephaven/ui/components/form.py
+++ b/plugins/ui/src/deephaven/ui/components/form.py
@@ -40,7 +40,7 @@ def form(
     auto_capitalize: AutoCapitalizeModes | None = None,
     label_position: LabelPosition = "top",
     label_align: Alignment | None = None,
-    necessity_indicator: NecessityIndicator = "icon",
+    necessity_indicator: NecessityIndicator | None = None,
     on_submit: Callable[[dict[str, str]], None] | None = None,
     on_reset: Callable[[dict[str, str]], None] | None = None,
     on_invalid: Callable[[dict[str, str]], None] | None = None,

--- a/plugins/ui/src/deephaven/ui/components/number_field.py
+++ b/plugins/ui/src/deephaven/ui/components/number_field.py
@@ -44,7 +44,7 @@ def number_field(
     name: str | None = None,
     label_position: LabelPosition = "top",
     label_align: Alignment | None = None,
-    necessity_indicator: NecessityIndicator = "icon",
+    necessity_indicator: NecessityIndicator | None = None,
     contextual_help: Any | None = None,
     on_focus: FocusEventCallable | None = None,
     on_blur: FocusEventCallable | None = None,

--- a/plugins/ui/src/deephaven/ui/components/picker.py
+++ b/plugins/ui/src/deephaven/ui/components/picker.py
@@ -63,7 +63,7 @@ def picker(
     is_loading: bool | None = None,
     label_position: LabelPosition = "top",
     label_align: Alignment | None = None,
-    necessity_indicator: NecessityIndicator = "icon",
+    necessity_indicator: NecessityIndicator | None = None,
     contextual_help: Element | None = None,
     on_open_change: Callable[[bool], None] | None = None,
     on_focus: FocusEventCallable | None = None,

--- a/plugins/ui/src/deephaven/ui/components/radio_group.py
+++ b/plugins/ui/src/deephaven/ui/components/radio_group.py
@@ -40,7 +40,7 @@ def radio_group(
     error_message: Any | None = None,
     label_position: LabelPosition = "top",
     label_align: Alignment | None = None,
-    necessity_indicator: NecessityIndicator = "icon",
+    necessity_indicator: NecessityIndicator | None = None,
     contextual_help: Any | None = None,
     show_error_icon: bool | None = None,
     on_focus: FocusEventCallable | None = None,

--- a/plugins/ui/src/deephaven/ui/components/text_area.py
+++ b/plugins/ui/src/deephaven/ui/components/text_area.py
@@ -49,7 +49,7 @@ def text_area(
     validation_state: TextFieldValidationState | None = None,
     label_position: LabelPosition = "top",
     label_align: Alignment | None = None,
-    necessity_indicator: NecessityIndicator = "icon",
+    necessity_indicator: NecessityIndicator | None = None,
     contextual_help: Any | None = None,
     on_focus: FocusEventCallable | None = None,
     on_blur: FocusEventCallable | None = None,

--- a/plugins/ui/src/deephaven/ui/components/text_field.py
+++ b/plugins/ui/src/deephaven/ui/components/text_field.py
@@ -48,7 +48,7 @@ def text_field(
     validation_state: TextFieldValidationState | None = None,
     label_position: LabelPosition = "top",
     label_align: Alignment | None = None,
-    necessity_indicator: NecessityIndicator = "icon",
+    necessity_indicator: NecessityIndicator | None = None,
     contextual_help: Any | None = None,
     on_focus: FocusEventCallable | None = None,
     on_blur: FocusEventCallable | None = None,


### PR DESCRIPTION
- Fixes #924 
- Set default of `necessity_indicator` to `None` so the prop can inherit from parents if necessary