### PR TITLE
Mention Deephaven version where `server-ui` Docker image is mentioned

### DIFF
--- a/plugins/plotly-express/docs/README.md
+++ b/plugins/plotly-express/docs/README.md
@@ -97,10 +97,10 @@ This page contains a collection of links to examples demonstrating different plo
 
 ## Quickstart
 
-1. Install with Docker, use a Docker image with it already installed (`server-ui`), or pip install with:
+1. Install with Docker, use a Docker image with it already installed, or pip install with:
 
 ```bash
- pip install deephaven-plugin-plotly-express
+pip install deephaven-plugin-plotly-express
 ```
 
 2. To create a real-time plot using Deephaven Plotly Express, run the following example within Deephaven:

--- a/plugins/ui/docs/README.md
+++ b/plugins/ui/docs/README.md
@@ -15,10 +15,14 @@
 
 ## Getting Started
 
-You can run the example Docker container with the following command:
+You can run the example Docker container with either of the following commands, depending on your Deephaven version:
 
-```
-docker run --rm --name deephaven-ui -p 10000:10000 --pull=always ghcr.io/deephaven/server-ui:edge
+```bash
+# For Deephaven < 0.37.0
+docker run --rm --name deephaven-ui -p 10000:10000 --pull=always ghcr.io/deephaven/server-ui:latest
+
+# For Deephaven >= 0.37.0
+docker run --rm --name deephaven-ui -p 10000:10000 --pull=always ghcr.io/deephaven/server:latest
 ```
 
 You'll need to find the link to open the UI in the Docker logs:

--- a/plugins/ui/docs/installation.md
+++ b/plugins/ui/docs/installation.md
@@ -8,10 +8,14 @@ If you don't already have Deephaven installed, you can install via Docker or pip
 
 ### Install and run with Docker
 
-deephaven.ui can be run from a pre-built Docker image. Simply run the following to get the latest image:
+`deephaven.ui` can be run from pre-built Docker images. The image you use will depend on your version of Deephaven:
 
-```sh
+```bash
+# For Deephaven < 0.37.0
 docker run --name deephaven -p 10000:10000 ghcr.io/deephaven/server-ui:latest
+
+# For Deephaven >= 0.37.0
+docker run --name deephaven -p 10000:10000 ghcr.io/deephaven/server:latest
 ```
 
 See the [Deephaven Docker install documentation](https://deephaven.io/core/docs/getting-started/docker-install/) for more information.


### PR DESCRIPTION
In DH 0.37 onwards, the `server-ui` image will no longer be published. This PR addresses this upcoming change in the docs by giving both commands depending on the DH version.