### PR TITLE
feat: Allow passing in a pandas dataframe to dx plots

### DIFF
--- a/plugins/plotly-express/docs/README.md
+++ b/plugins/plotly-express/docs/README.md
@@ -97,10 +97,10 @@ This page contains a collection of links to examples demonstrating different plo
 
 ## Quickstart
 
-1. Install with Docker, use a Docker image with it already installed (`server-ui`), or pip install with:
+1. Install with Docker, use a Docker image with it already installed, or pip install with:
 
 ```bash
- pip install deephaven-plugin-plotly-express
+pip install deephaven-plugin-plotly-express
 ```
 
 2. To create a real-time plot using Deephaven Plotly Express, run the following example within Deephaven:

--- a/plugins/plotly-express/docs/README.md
+++ b/plugins/plotly-express/docs/README.md
@@ -1,10 +1,10 @@
-# Deephaven Plotly Express
+# Deephaven Express
 
-[Deephaven Plotly Express](https://github.com/deephaven/deephaven-plugins) is a powerful plotting library built on top of [Plotly Express](https://plotly.com/python/plotly-express/) that enhances its capabilities by adding support for real-time Deephaven tables, automatic downsampling, and server-side data grouping and aggregation using the Deephaven query engine. This library seamlessly integrates real-time data from Deephaven with the interactive and expressive visualizations of Plotly Express, allowing you to easily plot or aggregate millions of data points.
+[Deephaven Express](https://github.com/deephaven/deephaven-plugins) is a powerful plotting library built on top of [Plotly Express](https://plotly.com/python/plotly-express/) that enhances its capabilities by adding support for real-time Deephaven tables, automatic downsampling, and server-side data grouping and aggregation using the Deephaven query engine. This library seamlessly integrates real-time data from Deephaven with the interactive and expressive visualizations of Plotly Express, allowing you to easily plot or aggregate millions of data points.
 
 ## Key Features
 
-- **Live Dataframe Support**: Direct integration with real-time Deephaven tables, allowing you to visualize and analyze data as it updates in real time.
+- **Live Dataframe Support**: Direct integration with real-time Deephaven tables, allowing you to visualize and analyze data as it updates in real time, in addition to Pandas DataFrames.
 - **Automatic Downsampling**: Pixel accurate automatic downsampling that reduces the number of data points displayed, ensuring smooth and responsive visualizations even with large datasets.
 - **Server-Side Data Grouping and Aggregation**: Uses server-side processing capabilities to perform data grouping and aggregation directly within Deephaven query engine, enabling efficient analysis of huge datasets without requiring data transfer.
 - **Plotly Express Compatibility**: Built on top of Plotly Express, the library inherits its comprehensive set of features, enabling you to create stunning and interactive visualizations effortlessly. In most cases you can directly swap `px` for `dx` for instant compatibility.
@@ -103,12 +103,12 @@ This page contains a collection of links to examples demonstrating different plo
 pip install deephaven-plugin-plotly-express
 ```
 
-2. To create a real-time plot using Deephaven Plotly Express, run the following example within Deephaven:
+2. To create a real-time plot using Deephaven Express, run the following example within Deephaven:
 
 ```python order=my_plot,my_table
 import deephaven.plot.express as dx
 
-# Deephaven plotly express includes a number of generated data sets for examples
+# Deephaven express includes a number of generated data sets for examples
 my_table = dx.data.stocks()
 
 # Create a line plot, and assign colors by distinct values in the `sym` column
@@ -136,12 +136,12 @@ The following terms define relationships between variables. They do not describe
 
 ## Contributing
 
-We welcome contributions to Deephaven Plotly Express! If you encounter any issues, have ideas for improvements, or would like to add new features, please open an issue or submit a pull request on the [GitHub repository](https://github.com/deephaven/deephaven-plugins).
+We welcome contributions to Deephaven Express! If you encounter any issues, have ideas for improvements, or would like to add new features, please open an issue or submit a pull request on the [GitHub repository](https://github.com/deephaven/deephaven-plugins).
 
 ## License
 
-Deephaven's Plotly Express plugin is licensed under the [Apache License 2.0](https://github.com/deephaven/deephaven-plugins/blob/main/plugins/plotly-express/LICENSE). You are free to use, modify, and distribute this library in compliance with the terms of the license.
+Deephaven's Express plugin is licensed under the [Apache License 2.0](https://github.com/deephaven/deephaven-plugins/blob/main/plugins/plotly-express/LICENSE). You are free to use, modify, and distribute this library in compliance with the terms of the license.
 
 ## Acknowledgments
 
-We would like to express our gratitude to the Plotly and the Plotly Express team for creating a remarkable plotting library and making it open-source. Their work forms the foundation of the Deephaven Plotly Express plugin.
+We would like to express our gratitude to the Plotly and the Plotly Express team for creating a remarkable plotting library and making it open-source. Their work forms the foundation of the Deephaven Express plugin.

--- a/plugins/plotly-express/docs/README.md
+++ b/plugins/plotly-express/docs/README.md
@@ -1,6 +1,6 @@
-# Deephaven Express
+# Deephaven Plotly Express
 
-[Deephaven Express](https://github.com/deephaven/deephaven-plugins) is a powerful plotting library built on top of [Plotly Express](https://plotly.com/python/plotly-express/) that enhances its capabilities by adding support for real-time Deephaven tables, automatic downsampling, and server-side data grouping and aggregation using the Deephaven query engine. This library seamlessly integrates real-time data from Deephaven with the interactive and expressive visualizations of Plotly Express, allowing you to easily plot or aggregate millions of data points.
+[Deephaven Plotly Express](https://github.com/deephaven/deephaven-plugins) is a powerful plotting library built on top of [Plotly Express](https://plotly.com/python/plotly-express/) that enhances its capabilities by adding support for real-time Deephaven tables, automatic downsampling, and server-side data grouping and aggregation using the Deephaven query engine. This library seamlessly integrates real-time data from Deephaven with the interactive and expressive visualizations of Plotly Express, allowing you to easily plot or aggregate millions of data points.
 
 ## Key Features
 
@@ -97,18 +97,18 @@ This page contains a collection of links to examples demonstrating different plo
 
 ## Quickstart
 
-1. Install with Docker, use a Docker image with it already installed, or pip install with:
+1. Install with Docker, use a Docker image with it already installed (`server-ui`), or pip install with:
 
 ```bash
-pip install deephaven-plugin-plotly-express
+ pip install deephaven-plugin-plotly-express
 ```
 
-2. To create a real-time plot using Deephaven Express, run the following example within Deephaven:
+2. To create a real-time plot using Deephaven Plotly Express, run the following example within Deephaven:
 
 ```python order=my_plot,my_table
 import deephaven.plot.express as dx
 
-# Deephaven express includes a number of generated data sets for examples
+# Deephaven plotly express includes a number of generated data sets for examples
 my_table = dx.data.stocks()
 
 # Create a line plot, and assign colors by distinct values in the `sym` column
@@ -136,12 +136,12 @@ The following terms define relationships between variables. They do not describe
 
 ## Contributing
 
-We welcome contributions to Deephaven Express! If you encounter any issues, have ideas for improvements, or would like to add new features, please open an issue or submit a pull request on the [GitHub repository](https://github.com/deephaven/deephaven-plugins).
+We welcome contributions to Deephaven Plotly Express! If you encounter any issues, have ideas for improvements, or would like to add new features, please open an issue or submit a pull request on the [GitHub repository](https://github.com/deephaven/deephaven-plugins).
 
 ## License
 
-Deephaven's Express plugin is licensed under the [Apache License 2.0](https://github.com/deephaven/deephaven-plugins/blob/main/plugins/plotly-express/LICENSE). You are free to use, modify, and distribute this library in compliance with the terms of the license.
+Deephaven's Plotly Express plugin is licensed under the [Apache License 2.0](https://github.com/deephaven/deephaven-plugins/blob/main/plugins/plotly-express/LICENSE). You are free to use, modify, and distribute this library in compliance with the terms of the license.
 
 ## Acknowledgments
 
-We would like to express our gratitude to the Plotly and the Plotly Express team for creating a remarkable plotting library and making it open-source. Their work forms the foundation of the Deephaven Express plugin.
+We would like to express our gratitude to the Plotly and the Plotly Express team for creating a remarkable plotting library and making it open-source. Their work forms the foundation of the Deephaven Plotly Express plugin.

--- a/plugins/plotly-express/src/deephaven/plot/express/plots/_private_utils.py
+++ b/plugins/plotly-express/src/deephaven/plot/express/plots/_private_utils.py
@@ -23,7 +23,7 @@ from ..shared.distribution_args import (
     HISTOGRAM_DEFAULTS,
     SPREAD_GROUPS,
 )
-from ..types import TableDataBy
+from ..types import PartitionableTableLike
 
 
 def validate_common_args(args: dict) -> None:
@@ -255,7 +255,7 @@ def create_deephaven_figure(
     )
 
 
-def convert_to_table(table: TableDataBy) -> Table | PartitionedTable:
+def convert_to_table(table: PartitionableTableLike) -> Table | PartitionedTable:
     """
     Convert a Dataframe to a Table if it is one
 

--- a/plugins/plotly-express/src/deephaven/plot/express/plots/_private_utils.py
+++ b/plugins/plotly-express/src/deephaven/plot/express/plots/_private_utils.py
@@ -23,7 +23,7 @@ from ..shared.distribution_args import (
     HISTOGRAM_DEFAULTS,
     SPREAD_GROUPS,
 )
-from ..types.plots import TableDataBy
+from ..types import TableDataBy
 
 
 def validate_common_args(args: dict) -> None:

--- a/plugins/plotly-express/src/deephaven/plot/express/plots/_private_utils.py
+++ b/plugins/plotly-express/src/deephaven/plot/express/plots/_private_utils.py
@@ -3,11 +3,13 @@ from __future__ import annotations
 from functools import partial
 from collections.abc import Callable
 from typing import Any
+from pandas import DataFrame
 
 import plotly.express as px
 
 from deephaven.table import Table, PartitionedTable
 from deephaven.execution_context import make_user_exec_ctx
+import deephaven.pandas as dhpd
 
 from ._layer import atomic_layer
 from .PartitionManager import PartitionManager
@@ -21,6 +23,7 @@ from ..shared.distribution_args import (
     HISTOGRAM_DEFAULTS,
     SPREAD_GROUPS,
 )
+from ..types.plots import TableDataBy
 
 
 def validate_common_args(args: dict) -> None:
@@ -252,6 +255,21 @@ def create_deephaven_figure(
     )
 
 
+def convert_to_table(table: TableDataBy) -> Table | PartitionedTable:
+    """
+    Convert a Dataframe to a Table if it is one
+
+    Args:
+      table: The PartitionableTableData to convert
+
+    Returns:
+        The Table or PartitionedTable
+    """
+    if isinstance(table, DataFrame):
+        return dhpd.to_table(table)
+    return table
+
+
 def process_args(
     args: dict[str, Any],
     groups: set[str] | None = None,
@@ -278,11 +296,13 @@ def process_args(
         DeephavenFigure: The new figure
 
     """
-    use_args = locals()
-    orig_process_args = args_copy(use_args)
+    render_args = locals()
+    render_args["args"]["table"] = convert_to_table(render_args["args"]["table"])
+
+    orig_process_args = args_copy(render_args)
     orig_process_func = lambda **local_args: create_deephaven_figure(**local_args)[0]
 
-    new_fig, table, key_column_table, update = create_deephaven_figure(**use_args)
+    new_fig, table, key_column_table, update = create_deephaven_figure(**render_args)
 
     orig_process_args["args"].update(update)
 

--- a/plugins/plotly-express/src/deephaven/plot/express/plots/area.py
+++ b/plugins/plotly-express/src/deephaven/plot/express/plots/area.py
@@ -7,11 +7,11 @@ from plotly import express as px
 from ._private_utils import process_args
 from ..shared import default_callback
 from ..deephaven_figure import DeephavenFigure
-from ..types import TableDataBy
+from ..types import PartitionableTableLike
 
 
 def area(
-    table: TableDataBy,
+    table: PartitionableTableLike,
     x: str | list[str] | None = None,
     y: str | list[str] | None = None,
     by: str | list[str] | None = None,

--- a/plugins/plotly-express/src/deephaven/plot/express/plots/area.py
+++ b/plugins/plotly-express/src/deephaven/plot/express/plots/area.py
@@ -4,15 +4,14 @@ from typing import Callable
 
 from plotly import express as px
 
-from deephaven.table import Table
-
 from ._private_utils import process_args
 from ..shared import default_callback
 from ..deephaven_figure import DeephavenFigure
+from ..types import TableDataBy
 
 
 def area(
-    table: Table | None = None,
+    table: TableDataBy,
     x: str | list[str] | None = None,
     y: str | list[str] | None = None,
     by: str | list[str] | None = None,

--- a/plugins/plotly-express/src/deephaven/plot/express/plots/bar.py
+++ b/plugins/plotly-express/src/deephaven/plot/express/plots/bar.py
@@ -10,11 +10,11 @@ from deephaven.table import Table
 from ._private_utils import validate_common_args, process_args
 from ..shared import default_callback
 from ..deephaven_figure import generate_figure, DeephavenFigure
-from ..types import TableDataBy
+from ..types import PartitionableTableLike
 
 
 def bar(
-    table: TableDataBy,
+    table: PartitionableTableLike,
     x: str | list[str] | None = None,
     y: str | list[str] | None = None,
     by: str | list[str] | None = None,
@@ -207,7 +207,7 @@ def _bar_polar(
 
 
 def timeline(
-    table: TableDataBy,
+    table: PartitionableTableLike,
     x_start: str | None = None,
     x_end: str | None = None,
     y: str | None = None,

--- a/plugins/plotly-express/src/deephaven/plot/express/plots/bar.py
+++ b/plugins/plotly-express/src/deephaven/plot/express/plots/bar.py
@@ -10,10 +10,11 @@ from deephaven.table import Table
 from ._private_utils import validate_common_args, process_args
 from ..shared import default_callback
 from ..deephaven_figure import generate_figure, DeephavenFigure
+from ..types import TableDataBy
 
 
 def bar(
-    table: Table | None = None,
+    table: TableDataBy,
     x: str | list[str] | None = None,
     y: str | list[str] | None = None,
     by: str | list[str] | None = None,
@@ -206,7 +207,7 @@ def _bar_polar(
 
 
 def timeline(
-    table: Table | None = None,
+    table: TableDataBy,
     x_start: str | None = None,
     x_end: str | None = None,
     y: str | None = None,

--- a/plugins/plotly-express/src/deephaven/plot/express/plots/distribution.py
+++ b/plugins/plotly-express/src/deephaven/plot/express/plots/distribution.py
@@ -18,11 +18,11 @@ from ..shared import (
     HISTOGRAM_DEFAULTS,
     default_callback,
 )
-from ..types import TableDataBy
+from ..types import PartitionableTableLike
 
 
 def violin(
-    table: TableDataBy,
+    table: PartitionableTableLike,
     x: str | list[str] | None = None,
     y: str | list[str] | None = None,
     by: str | list[str] | None = None,
@@ -103,7 +103,7 @@ def violin(
 
 
 def box(
-    table: TableDataBy,
+    table: PartitionableTableLike,
     x: str | list[str] | None = None,
     y: str | list[str] | None = None,
     by: str | list[str] | None = None,
@@ -184,7 +184,7 @@ def box(
 
 
 def strip(
-    table: TableDataBy,
+    table: PartitionableTableLike,
     x: str | list[str] | None = None,
     y: str | list[str] | None = None,
     by: str | list[str] | None = None,
@@ -307,7 +307,7 @@ def _ecdf(
 
 
 def histogram(
-    table: TableDataBy,
+    table: PartitionableTableLike,
     x: str | list[str] | None = None,
     y: str | list[str] | None = None,
     by: str | list[str] | None = None,

--- a/plugins/plotly-express/src/deephaven/plot/express/plots/distribution.py
+++ b/plugins/plotly-express/src/deephaven/plot/express/plots/distribution.py
@@ -11,7 +11,6 @@ from ._private_utils import (
     shared_histogram,
 )
 from ..deephaven_figure import DeephavenFigure
-
 from ..shared import (
     VIOLIN_DEFAULTS,
     BOX_DEFAULTS,
@@ -19,10 +18,11 @@ from ..shared import (
     HISTOGRAM_DEFAULTS,
     default_callback,
 )
+from ..types import TableDataBy
 
 
 def violin(
-    table: Table | None = None,
+    table: TableDataBy,
     x: str | list[str] | None = None,
     y: str | list[str] | None = None,
     by: str | list[str] | None = None,
@@ -103,7 +103,7 @@ def violin(
 
 
 def box(
-    table: Table | None = None,
+    table: TableDataBy,
     x: str | list[str] | None = None,
     y: str | list[str] | None = None,
     by: str | list[str] | None = None,
@@ -184,7 +184,7 @@ def box(
 
 
 def strip(
-    table: Table | None = None,
+    table: TableDataBy,
     x: str | list[str] | None = None,
     y: str | list[str] | None = None,
     by: str | list[str] | None = None,
@@ -307,7 +307,7 @@ def _ecdf(
 
 
 def histogram(
-    table: Table | None = None,
+    table: TableDataBy,
     x: str | list[str] | None = None,
     y: str | list[str] | None = None,
     by: str | list[str] | None = None,

--- a/plugins/plotly-express/src/deephaven/plot/express/plots/financial.py
+++ b/plugins/plotly-express/src/deephaven/plot/express/plots/financial.py
@@ -5,11 +5,11 @@ from typing import Callable
 from ._private_utils import process_args
 from ..shared import default_callback
 from ..deephaven_figure import draw_ohlc, draw_candlestick, DeephavenFigure
-from ..types import TableData
+from ..types import TableLike
 
 
 def ohlc(
-    table: TableData,
+    table: TableLike,
     x: str | None = None,
     open: str | list[str] | None = None,
     high: str | list[str] | None = None,
@@ -74,7 +74,7 @@ def ohlc(
 
 
 def candlestick(
-    table: TableData,
+    table: TableLike,
     x: str | None = None,
     open: str | list[str] | None = None,
     high: str | list[str] | None = None,

--- a/plugins/plotly-express/src/deephaven/plot/express/plots/financial.py
+++ b/plugins/plotly-express/src/deephaven/plot/express/plots/financial.py
@@ -2,15 +2,14 @@ from __future__ import annotations
 
 from typing import Callable
 
-from deephaven.table import Table
-
 from ._private_utils import process_args
 from ..shared import default_callback
 from ..deephaven_figure import draw_ohlc, draw_candlestick, DeephavenFigure
+from ..types import TableData
 
 
 def ohlc(
-    table: Table | None = None,
+    table: TableData,
     x: str | None = None,
     open: str | list[str] | None = None,
     high: str | list[str] | None = None,
@@ -75,7 +74,7 @@ def ohlc(
 
 
 def candlestick(
-    table: Table | None = None,
+    table: TableData,
     x: str | None = None,
     open: str | list[str] | None = None,
     high: str | list[str] | None = None,

--- a/plugins/plotly-express/src/deephaven/plot/express/plots/heatmap.py
+++ b/plugins/plotly-express/src/deephaven/plot/express/plots/heatmap.py
@@ -6,11 +6,11 @@ from deephaven.plot.express.shared import default_callback
 
 from ._private_utils import process_args
 from ..deephaven_figure import DeephavenFigure, draw_density_heatmap
-from ..types import TableData
+from ..types import TableLike
 
 
 def density_heatmap(
-    table: TableData,
+    table: TableLike,
     x: str | None = None,
     y: str | None = None,
     z: str | None = None,

--- a/plugins/plotly-express/src/deephaven/plot/express/plots/heatmap.py
+++ b/plugins/plotly-express/src/deephaven/plot/express/plots/heatmap.py
@@ -6,11 +6,11 @@ from deephaven.plot.express.shared import default_callback
 
 from ._private_utils import process_args
 from ..deephaven_figure import DeephavenFigure, draw_density_heatmap
-from deephaven.table import Table
+from ..types import TableData
 
 
 def density_heatmap(
-    table: Table,
+    table: TableData,
     x: str | None = None,
     y: str | None = None,
     z: str | None = None,

--- a/plugins/plotly-express/src/deephaven/plot/express/plots/hierarchial.py
+++ b/plugins/plotly-express/src/deephaven/plot/express/plots/hierarchial.py
@@ -7,11 +7,11 @@ from plotly import express as px
 from ._private_utils import process_args
 from ..shared import default_callback
 from ..deephaven_figure import DeephavenFigure
-from ..types import TableData
+from ..types import TableLike
 
 
 def treemap(
-    table: TableData,
+    table: TableLike,
     names: str | None = None,
     values: str | None = None,
     parents: str | None = None,
@@ -79,7 +79,7 @@ def treemap(
 
 
 def sunburst(
-    table: TableData,
+    table: TableLike,
     names: str | None = None,
     values: str | None = None,
     parents: str | None = None,
@@ -147,7 +147,7 @@ def sunburst(
 
 
 def icicle(
-    table: TableData,
+    table: TableLike,
     names: str | None = None,
     values: str | None = None,
     parents: str | None = None,
@@ -215,7 +215,7 @@ def icicle(
 
 
 def funnel(
-    table: TableData,
+    table: TableLike,
     x: str | list[str] | None = None,
     y: str | list[str] | None = None,
     by: str | list[str] | None = None,
@@ -292,7 +292,7 @@ def funnel(
 
 
 def funnel_area(
-    table: TableData,
+    table: TableLike,
     names: str | None = None,
     values: str | None = None,
     color: str | list[str] | None = None,

--- a/plugins/plotly-express/src/deephaven/plot/express/plots/hierarchial.py
+++ b/plugins/plotly-express/src/deephaven/plot/express/plots/hierarchial.py
@@ -4,15 +4,14 @@ from typing import Callable
 
 from plotly import express as px
 
-from deephaven.table import Table
-
 from ._private_utils import process_args
 from ..shared import default_callback
 from ..deephaven_figure import DeephavenFigure
+from ..types import TableData
 
 
 def treemap(
-    table: Table | None = None,
+    table: TableData,
     names: str | None = None,
     values: str | None = None,
     parents: str | None = None,
@@ -80,7 +79,7 @@ def treemap(
 
 
 def sunburst(
-    table: Table | None = None,
+    table: TableData,
     names: str | None = None,
     values: str | None = None,
     parents: str | None = None,
@@ -148,7 +147,7 @@ def sunburst(
 
 
 def icicle(
-    table: Table | None = None,
+    table: TableData,
     names: str | None = None,
     values: str | None = None,
     parents: str | None = None,
@@ -216,7 +215,7 @@ def icicle(
 
 
 def funnel(
-    table: Table | None = None,
+    table: TableData,
     x: str | list[str] | None = None,
     y: str | list[str] | None = None,
     by: str | list[str] | None = None,
@@ -293,7 +292,7 @@ def funnel(
 
 
 def funnel_area(
-    table: Table | None = None,
+    table: TableData,
     names: str | None = None,
     values: str | None = None,
     color: str | list[str] | None = None,

--- a/plugins/plotly-express/src/deephaven/plot/express/plots/line.py
+++ b/plugins/plotly-express/src/deephaven/plot/express/plots/line.py
@@ -7,11 +7,11 @@ from plotly import express as px
 from ._private_utils import process_args
 from ..shared import default_callback
 from ..deephaven_figure import DeephavenFigure
-from ..types import TableDataBy
+from ..types import PartitionableTableLike
 
 
 def line(
-    table: TableDataBy,
+    table: PartitionableTableLike,
     x: str | list[str] | None = None,
     y: str | list[str] | None = None,
     error_x: str | None = None,
@@ -191,7 +191,7 @@ def line(
 
 
 def line_3d(
-    table: TableDataBy,
+    table: PartitionableTableLike,
     x: str | None = None,
     y: str | None = None,
     z: str | None = None,
@@ -351,7 +351,7 @@ def line_3d(
 
 
 def line_polar(
-    table: TableDataBy,
+    table: PartitionableTableLike,
     r: str | None = None,
     theta: str | None = None,
     by: str | list[str] | None = None,
@@ -489,7 +489,7 @@ def line_polar(
 
 
 def line_ternary(
-    table: TableDataBy,
+    table: PartitionableTableLike,
     a: str | None = None,
     b: str | None = None,
     c: str | None = None,

--- a/plugins/plotly-express/src/deephaven/plot/express/plots/line.py
+++ b/plugins/plotly-express/src/deephaven/plot/express/plots/line.py
@@ -4,15 +4,14 @@ from typing import Callable
 
 from plotly import express as px
 
-from deephaven.table import Table
-
 from ._private_utils import process_args
 from ..shared import default_callback
 from ..deephaven_figure import DeephavenFigure
+from ..types import TableDataBy
 
 
 def line(
-    table: Table | None = None,
+    table: TableDataBy,
     x: str | list[str] | None = None,
     y: str | list[str] | None = None,
     error_x: str | None = None,
@@ -192,7 +191,7 @@ def line(
 
 
 def line_3d(
-    table: Table | None = None,
+    table: TableDataBy,
     x: str | None = None,
     y: str | None = None,
     z: str | None = None,
@@ -352,7 +351,7 @@ def line_3d(
 
 
 def line_polar(
-    table: Table | None = None,
+    table: TableDataBy,
     r: str | None = None,
     theta: str | None = None,
     by: str | list[str] | None = None,
@@ -490,7 +489,7 @@ def line_polar(
 
 
 def line_ternary(
-    table: Table | None = None,
+    table: TableDataBy,
     a: str | None = None,
     b: str | None = None,
     c: str | None = None,

--- a/plugins/plotly-express/src/deephaven/plot/express/plots/maps.py
+++ b/plugins/plotly-express/src/deephaven/plot/express/plots/maps.py
@@ -7,11 +7,11 @@ from plotly import express as px
 from ._private_utils import process_args
 from ..shared import default_callback
 from ..deephaven_figure import DeephavenFigure
-from ..types import TableDataBy, TableData
+from ..types import PartitionableTableLike, TableLike
 
 
 def scatter_geo(
-    table: TableDataBy,
+    table: PartitionableTableLike,
     lat: str | None = None,
     lon: str | None = None,
     locations: str | None = None,
@@ -149,7 +149,7 @@ def scatter_geo(
 
 
 def scatter_mapbox(
-    table: TableDataBy,
+    table: PartitionableTableLike,
     lat: str | None = None,
     lon: str | None = None,
     by: str | list[str] | None = None,
@@ -263,7 +263,7 @@ def scatter_mapbox(
 
 
 def line_geo(
-    table: TableDataBy,
+    table: PartitionableTableLike,
     lat: str | None = None,
     lon: str | None = None,
     locations: str | None = None,
@@ -409,7 +409,7 @@ def line_geo(
 
 
 def line_mapbox(
-    table: TableDataBy,
+    table: PartitionableTableLike,
     lat: str | None = None,
     lon: str | None = None,
     by: str | list[str] | None = None,
@@ -529,7 +529,7 @@ def line_mapbox(
 
 
 def density_mapbox(
-    table: TableData,
+    table: TableLike,
     lat: str | None = None,
     lon: str | None = None,
     z: str | None = None,

--- a/plugins/plotly-express/src/deephaven/plot/express/plots/maps.py
+++ b/plugins/plotly-express/src/deephaven/plot/express/plots/maps.py
@@ -4,15 +4,14 @@ from typing import Callable
 
 from plotly import express as px
 
-from deephaven.table import Table
-
 from ._private_utils import process_args
 from ..shared import default_callback
 from ..deephaven_figure import DeephavenFigure
+from ..types import TableDataBy, TableData
 
 
 def scatter_geo(
-    table: Table | None = None,
+    table: TableDataBy,
     lat: str | None = None,
     lon: str | None = None,
     locations: str | None = None,
@@ -150,7 +149,7 @@ def scatter_geo(
 
 
 def scatter_mapbox(
-    table: Table | None = None,
+    table: TableDataBy,
     lat: str | None = None,
     lon: str | None = None,
     by: str | list[str] | None = None,
@@ -264,7 +263,7 @@ def scatter_mapbox(
 
 
 def line_geo(
-    table: Table | None = None,
+    table: TableDataBy,
     lat: str | None = None,
     lon: str | None = None,
     locations: str | None = None,
@@ -410,7 +409,7 @@ def line_geo(
 
 
 def line_mapbox(
-    table: Table | None = None,
+    table: TableDataBy,
     lat: str | None = None,
     lon: str | None = None,
     by: str | list[str] | None = None,
@@ -530,7 +529,7 @@ def line_mapbox(
 
 
 def density_mapbox(
-    table: Table | None = None,
+    table: TableData,
     lat: str | None = None,
     lon: str | None = None,
     z: str | None = None,

--- a/plugins/plotly-express/src/deephaven/plot/express/plots/pie.py
+++ b/plugins/plotly-express/src/deephaven/plot/express/plots/pie.py
@@ -4,15 +4,14 @@ from typing import Callable
 
 from plotly import express as px
 
-from deephaven.table import Table
-
 from ._private_utils import process_args
 from ..shared import default_callback
 from ..deephaven_figure import DeephavenFigure
+from ..types import TableData
 
 
 def pie(
-    table: Table | None = None,
+    table: TableData,
     names: str | None = None,
     values: str | None = None,
     color: str | list[str] | None = None,

--- a/plugins/plotly-express/src/deephaven/plot/express/plots/pie.py
+++ b/plugins/plotly-express/src/deephaven/plot/express/plots/pie.py
@@ -7,11 +7,11 @@ from plotly import express as px
 from ._private_utils import process_args
 from ..shared import default_callback
 from ..deephaven_figure import DeephavenFigure
-from ..types import TableData
+from ..types import TableLike
 
 
 def pie(
-    table: TableData,
+    table: TableLike,
     names: str | None = None,
     values: str | None = None,
     color: str | list[str] | None = None,

--- a/plugins/plotly-express/src/deephaven/plot/express/plots/scatter.py
+++ b/plugins/plotly-express/src/deephaven/plot/express/plots/scatter.py
@@ -7,11 +7,11 @@ from plotly import express as px
 from ._private_utils import process_args
 from ..shared import default_callback
 from ..deephaven_figure import DeephavenFigure
-from ..types import TableDataBy
+from ..types import PartitionableTableLike
 
 
 def scatter(
-    table: TableDataBy,
+    table: PartitionableTableLike,
     x: str | list[str] | None = None,
     y: str | list[str] | None = None,
     error_x: str | None = None,
@@ -185,7 +185,7 @@ def scatter(
 
 
 def scatter_3d(
-    table: TableDataBy,
+    table: PartitionableTableLike,
     x: str | None = None,
     y: str | None = None,
     z: str | None = None,
@@ -338,7 +338,7 @@ def scatter_3d(
 
 
 def scatter_polar(
-    table: TableDataBy,
+    table: PartitionableTableLike,
     r: str | None = None,
     theta: str | None = None,
     by: str | list[str] | None = None,
@@ -463,7 +463,7 @@ def scatter_polar(
 
 
 def scatter_ternary(
-    table: TableDataBy,
+    table: PartitionableTableLike,
     a: str | None = None,
     b: str | None = None,
     c: str | None = None,

--- a/plugins/plotly-express/src/deephaven/plot/express/plots/scatter.py
+++ b/plugins/plotly-express/src/deephaven/plot/express/plots/scatter.py
@@ -4,15 +4,14 @@ from typing import Callable
 
 from plotly import express as px
 
-from deephaven.table import Table
-
 from ._private_utils import process_args
 from ..shared import default_callback
 from ..deephaven_figure import DeephavenFigure
+from ..types import TableDataBy
 
 
 def scatter(
-    table: Table | None = None,
+    table: TableDataBy,
     x: str | list[str] | None = None,
     y: str | list[str] | None = None,
     error_x: str | None = None,
@@ -186,7 +185,7 @@ def scatter(
 
 
 def scatter_3d(
-    table: Table | None = None,
+    table: TableDataBy,
     x: str | None = None,
     y: str | None = None,
     z: str | None = None,
@@ -339,7 +338,7 @@ def scatter_3d(
 
 
 def scatter_polar(
-    table: Table | None = None,
+    table: TableDataBy,
     r: str | None = None,
     theta: str | None = None,
     by: str | list[str] | None = None,
@@ -464,7 +463,7 @@ def scatter_polar(
 
 
 def scatter_ternary(
-    table: Table | None = None,
+    table: TableDataBy,
     a: str | None = None,
     b: str | None = None,
     c: str | None = None,

--- a/plugins/plotly-express/src/deephaven/plot/express/types/__init__.py
+++ b/plugins/plotly-express/src/deephaven/plot/express/types/__init__.py
@@ -1,1 +1,1 @@
-from plots import TableDataBy, TableData
+from .plots import TableDataBy, TableData

--- a/plugins/plotly-express/src/deephaven/plot/express/types/__init__.py
+++ b/plugins/plotly-express/src/deephaven/plot/express/types/__init__.py
@@ -1,0 +1,1 @@
+from plots import TableDataBy, TableData

--- a/plugins/plotly-express/src/deephaven/plot/express/types/__init__.py
+++ b/plugins/plotly-express/src/deephaven/plot/express/types/__init__.py
@@ -1,1 +1,1 @@
-from .plots import TableDataBy, TableData
+from .plots import PartitionableTableLike, TableLike

--- a/plugins/plotly-express/src/deephaven/plot/express/types/plots.py
+++ b/plugins/plotly-express/src/deephaven/plot/express/types/plots.py
@@ -2,5 +2,5 @@ from typing import Union
 from pandas import DataFrame
 from deephaven.table import Table, PartitionedTable
 
-TableData = Union[Table, DataFrame]
-TableDataBy = Union[PartitionedTable, TableData]
+TableLike = Union[Table, DataFrame]
+PartitionableTableLike = Union[PartitionedTable, TableLike]

--- a/plugins/plotly-express/src/deephaven/plot/express/types/plots.py
+++ b/plugins/plotly-express/src/deephaven/plot/express/types/plots.py
@@ -1,0 +1,6 @@
+from typing import Union
+from pandas import DataFrame
+from deephaven.table import Table, PartitionedTable
+
+TableData = Union[Table, DataFrame]
+TableDataBy = Union[PartitionedTable, TableData]

--- a/plugins/plotly-express/test/deephaven/plot/express/BaseTest.py
+++ b/plugins/plotly-express/test/deephaven/plot/express/BaseTest.py
@@ -2,7 +2,9 @@ import unittest
 from unittest.mock import patch
 
 import pandas as pd
+from deephaven.plot.express import DeephavenFigure
 from deephaven_server import Server
+from typing import List
 
 
 def remap_types(
@@ -35,6 +37,72 @@ class BaseTestCase(unittest.TestCase):
 
         cls.reference.id = 0
         cls.exporter.reference.return_value = MockReference()
+
+    def assert_chart_equals(
+        self,
+        chart: DeephavenFigure,
+        matching_chart: DeephavenFigure = None,
+        expected_data: List[dict] = None,
+        expected_layout: dict = None,
+        expected_mappings: List[dict] = None,
+        expected_is_user_set_template: bool = None,
+        expected_is_user_set_color: bool = None,
+        pop_template: bool = True,
+    ) -> None:
+        """
+        Verify that the chart is as expected
+        If matching_chart is provided, the different charts are compared
+        The "expected" parameters take precedence over the values extracted from matching_chart
+        All "expected" parameters are optional to only match part of the chart if desired
+
+        Args:
+            chart: The chart to verify
+            matching_chart: A second chart to verify against
+            expected_data: The expected data
+            expected_layout: The expected layout
+            expected_mappings: The expected mappings
+            expected_is_user_set_template: The expected is_user_set_template
+            expected_is_user_set_color: The expected is_user_set_color
+            pop_template: Whether to pop the template from the chart.
+                Pops from both the chart and the expected values, if provided.
+        """
+        plotly, deephaven = chart["plotly"], chart["deephaven"]
+
+        if matching_chart:
+            matching_plotly, matching_deephaven = (
+                matching_chart["plotly"],
+                matching_chart["deephaven"],
+            )
+            expected_data = expected_data or matching_plotly["data"]
+            expected_layout = expected_layout or matching_plotly["layout"]
+            expected_mappings = expected_mappings or matching_deephaven["mappings"]
+            expected_is_user_set_template = (
+                expected_is_user_set_template
+                if expected_is_user_set_template is not None
+                else matching_deephaven["is_user_set_template"]
+            )
+            expected_is_user_set_color = (
+                expected_is_user_set_color
+                if expected_is_user_set_color is not None
+                else matching_deephaven["is_user_set_color"]
+            )
+
+        if pop_template:
+            plotly["layout"].pop("template", None)
+            expected_layout.pop("template", None)
+
+        if expected_data:
+            self.assertEqual(plotly["data"], expected_data)
+        if expected_layout:
+            self.assertEqual(plotly["layout"], expected_layout)
+        if expected_mappings:
+            self.assertEqual(deephaven["mappings"], expected_mappings)
+        if expected_is_user_set_template is not None:
+            self.assertEqual(
+                deephaven["is_user_set_template"], expected_is_user_set_template
+            )
+        if expected_is_user_set_color is not None:
+            self.assertEqual(deephaven["is_user_set_color"], expected_is_user_set_color)
 
 
 if __name__ == "__main__":

--- a/plugins/plotly-express/test/deephaven/plot/express/plots/test_area.py
+++ b/plugins/plotly-express/test/deephaven/plot/express/plots/test_area.py
@@ -213,8 +213,8 @@ class AreaTestCase(BaseTestCase):
     def test_area_table_pandas_same(self):
         import src.deephaven.plot.express as dx
 
-        chart_pandas = dx.area(self.pandas_source, x="X", y="Y").to_dict(self.exporter)
-        chart_table = dx.area(self.source, x="X", y="Y").to_dict(self.exporter)
+        chart_pandas = dx.area(self.pandas_source, x="X", y="Y")
+        chart_table = dx.area(self.source, x="X", y="Y")
 
         self.assert_chart_equals(chart_pandas, chart_table)
 

--- a/plugins/plotly-express/test/deephaven/plot/express/plots/test_area.py
+++ b/plugins/plotly-express/test/deephaven/plot/express/plots/test_area.py
@@ -7,6 +7,7 @@ class AreaTestCase(BaseTestCase):
     def setUp(self) -> None:
         from deephaven import new_table
         from deephaven.column import int_col
+        import deephaven.pandas as dhpd
 
         self.source = new_table(
             [
@@ -19,6 +20,8 @@ class AreaTestCase(BaseTestCase):
                 int_col("hover_name", [1, 2, 2, 3, 3, 3, 4, 4, 5]),
             ]
         )
+
+        self.pandas_source = dhpd.to_pandas(self.source)
 
     def test_basic_area(self):
         import src.deephaven.plot.express as dx
@@ -147,6 +150,73 @@ class AreaTestCase(BaseTestCase):
 
         self.assertEqual(deephaven["is_user_set_template"], False)
         self.assertEqual(deephaven["is_user_set_color"], False)
+
+    def test_area_pandas(self):
+        import src.deephaven.plot.express as dx
+        from deephaven.constants import NULL_INT
+
+        chart = dx.area(self.pandas_source, x="X", y="Y").to_dict(self.exporter)
+
+        expected_data = [
+            {
+                "fillpattern": {"shape": ""},
+                "hovertemplate": "X=%{x}<br>Y=%{y}<extra></extra>",
+                "legendgroup": "",
+                "line": {"color": "#636efa", "shape": "linear"},
+                "marker": {"symbol": "circle"},
+                "mode": "lines",
+                "name": "",
+                "orientation": "v",
+                "showlegend": False,
+                "stackgroup": "1",
+                "x": [NULL_INT],
+                "xaxis": "x",
+                "y": [NULL_INT],
+                "yaxis": "y",
+                "type": "scatter",
+            }
+        ]
+
+        expected_layout = {
+            "xaxis": {
+                "anchor": "y",
+                "domain": [0.0, 1.0],
+                "title": {"text": "X"},
+                "side": "bottom",
+            },
+            "yaxis": {
+                "anchor": "x",
+                "domain": [0.0, 1.0],
+                "title": {"text": "Y"},
+                "side": "left",
+            },
+            "legend": {"tracegroupgap": 0},
+            "margin": {"t": 60},
+        }
+
+        expected_mappings = [
+            {
+                "table": 0,
+                "data_columns": {"X": ["/plotly/data/0/x"], "Y": ["/plotly/data/0/y"]},
+            }
+        ]
+
+        self.assert_chart_equals(
+            chart,
+            expected_data=expected_data,
+            expected_layout=expected_layout,
+            expected_mappings=expected_mappings,
+            expected_is_user_set_template=False,
+            expected_is_user_set_color=False,
+        )
+
+    def test_area_table_pandas_same(self):
+        import src.deephaven.plot.express as dx
+
+        chart_pandas = dx.area(self.pandas_source, x="X", y="Y").to_dict(self.exporter)
+        chart_table = dx.area(self.source, x="X", y="Y").to_dict(self.exporter)
+
+        self.assert_chart_equals(chart_pandas, chart_table)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #8 

Allows passing in a pandas dataframe to all plots that take a table.

Example:
```import plotly.express as px
import deephaven.plot.express as dx
df = px.data.iris()
fig = dx.scatter(df, x="sepal_width", y="sepal_length", color="species", symbol="species")
```
<img width="844" alt="Screenshot 2024-10-28 at 2 36 19 PM" src="https://github.com/user-attachments/assets/2716c662-a5dd-49ae-b6de-6ce8a445373f">

Also now require a table (or similar) passed in for all plot types, as is already done for `density_heatmap`. This was part of #1, although not the full changes needed, but made sense to do now. This doesn't break anything as the plot isn't expected to work without a table anyways.

Additionally adds a test utility for chart comparisons. Not so essential that all tests need to change per se but reduces future  test boilerplate.