### PR TITLE
refactor: Separate remove_empty_keys and dict_to_camel_case behavior

### DIFF
--- a/plugins/ui/src/deephaven/ui/_internal/__init__.py
+++ b/plugins/ui/src/deephaven/ui/_internal/__init__.py
@@ -15,6 +15,7 @@ from .utils import (
     get_component_qualname,
     to_camel_case,
     dict_to_camel_case,
+    dict_to_react_props,
     remove_empty_keys,
     wrap_callable,
 )

--- a/plugins/ui/src/deephaven/ui/_internal/utils.py
+++ b/plugins/ui/src/deephaven/ui/_internal/utils.py
@@ -103,15 +103,13 @@ def to_react_prop_case(snake_case_text: str) -> str:
 
 def dict_to_camel_case(
     snake_case_dict: dict[str, Any],
-    omit_none: bool = True,
-    convert_key: Callable[[str], str] = to_react_prop_case,
+    convert_key: Callable[[str], str] = to_camel_case,
 ) -> dict[str, Any]:
     """
     Convert a dict with snake_case keys to a dict with camelCase keys.
 
     Args:
         snake_case_dict: The snake_case dict to convert.
-        omit_none: Whether to omit keys with a value of None.
         convert_key: The function to convert the keys. Can be used to customize the conversion behaviour
 
     Returns:
@@ -119,10 +117,23 @@ def dict_to_camel_case(
     """
     camel_case_dict: dict[str, Any] = {}
     for key, value in snake_case_dict.items():
-        if omit_none and value is None:
-            continue
         camel_case_dict[convert_key(key)] = value
     return camel_case_dict
+
+
+def dict_to_react_props(dict: dict[str, Any]) -> dict[str, Any]:
+    """
+    Convert a dict to React-style prop names ready for the web.
+    Converts snake_case to camelCase with the exception of special props like `UNSAFE_` or `aria_` props.
+    Removes empty keys.
+
+    Args:
+        dict: The dict to convert.
+
+    Returns:
+        The React props dict.
+    """
+    return dict_to_camel_case(remove_empty_keys(dict), to_react_prop_case)
 
 
 def remove_empty_keys(dict: dict[str, Any]) -> dict[str, Any]:

--- a/plugins/ui/src/deephaven/ui/_internal/utils.py
+++ b/plugins/ui/src/deephaven/ui/_internal/utils.py
@@ -101,24 +101,35 @@ def to_react_prop_case(snake_case_text: str) -> str:
     return to_camel_case(snake_case_text)
 
 
-def dict_to_camel_case(
-    snake_case_dict: dict[str, Any],
-    convert_key: Callable[[str], str] = to_camel_case,
+def convert_dict_keys(
+    dict: dict[str, Any], convert_key: Callable[[str], str]
 ) -> dict[str, Any]:
     """
-    Convert a dict with snake_case keys to a dict with camelCase keys.
+    Convert the keys of a dict using a function.
 
     Args:
-        snake_case_dict: The snake_case dict to convert.
-        convert_key: The function to convert the keys. Can be used to customize the conversion behaviour
+        dict: The dict to convert the keys of.
+        convert_key: The function to convert the keys.
+
+    Returns:
+        The dict with the converted keys.
+    """
+    return {convert_key(k): v for k, v in dict.items()}
+
+
+def dict_to_camel_case(
+    dict: dict[str, Any],
+) -> dict[str, Any]:
+    """
+    Convert a dict to a dict with camelCase keys.
+
+    Args:
+        dict: The dict to convert.
 
     Returns:
         The camelCase dict.
     """
-    camel_case_dict: dict[str, Any] = {}
-    for key, value in snake_case_dict.items():
-        camel_case_dict[convert_key(key)] = value
-    return camel_case_dict
+    return convert_dict_keys(dict, to_camel_case)
 
 
 def dict_to_react_props(dict: dict[str, Any]) -> dict[str, Any]:
@@ -133,7 +144,7 @@ def dict_to_react_props(dict: dict[str, Any]) -> dict[str, Any]:
     Returns:
         The React props dict.
     """
-    return dict_to_camel_case(remove_empty_keys(dict), to_react_prop_case)
+    return convert_dict_keys(remove_empty_keys(dict), to_react_prop_case)
 
 
 def remove_empty_keys(dict: dict[str, Any]) -> dict[str, Any]:

--- a/plugins/ui/src/deephaven/ui/elements/BaseElement.py
+++ b/plugins/ui/src/deephaven/ui/elements/BaseElement.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any
 from .Element import Element
-from .._internal import dict_to_camel_case, RenderContext
+from .._internal import dict_to_react_props, RenderContext
 
 
 class BaseElement(Element):
@@ -27,7 +27,7 @@ class BaseElement(Element):
             # If there's only one child, we pass it as a single child, not a list
             # There are many React elements that expect only a single child, and will fail if they get a list (even if it only has one element)
             props["children"] = children[0]
-        self._props = dict_to_camel_case(props)
+        self._props = dict_to_react_props(props)
 
     @property
     def name(self) -> str:

--- a/plugins/ui/src/deephaven/ui/elements/UITable.py
+++ b/plugins/ui/src/deephaven/ui/elements/UITable.py
@@ -28,7 +28,7 @@ from ..types import (
     RowPressCallback,
     StringSortDirection,
 )
-from .._internal import dict_to_camel_case, RenderContext
+from .._internal import dict_to_react_props, RenderContext
 
 logger = logging.getLogger(__name__)
 
@@ -192,7 +192,7 @@ class UITable(Element):
 
     def render(self, context: RenderContext) -> dict[str, Any]:
         logger.debug("Returning props %s", self._props)
-        return dict_to_camel_case({**self._props})
+        return dict_to_react_props({**self._props})
 
     def aggregations(
         self,

--- a/plugins/ui/test/deephaven/ui/test_utils.py
+++ b/plugins/ui/test/deephaven/ui/test_utils.py
@@ -60,16 +60,12 @@ class UtilsTest(BaseTestCase):
             {"alreadyCamelCase": "foo", "alignItems": "bar"},
         )
         self.assertDictEqual(
-            dict_to_camel_case({"foo": None, "bar": "biz"}),
-            {"bar": "biz"},
-        )
-        self.assertDictEqual(
-            dict_to_camel_case({"foo": None, "bar": "biz"}, omit_none=False),
-            {"foo": None, "bar": "biz"},
+            dict_to_camel_case({"foo": "bar"}),
+            {"foo": "bar"},
         )
         self.assertDictEqual(
             dict_to_camel_case({"bar": "biz", "UNSAFE_class_name": "harry"}),
-            {"bar": "biz", "UNSAFE_className": "harry"},
+            {"bar": "biz", "UNSAFEClassName": "harry"},
         )
         # Test with a function reversing the keys
         self.assertDictEqual(
@@ -77,6 +73,28 @@ class UtilsTest(BaseTestCase):
                 {"foo": "fiz", "bar": "biz"}, convert_key=lambda x: x[::-1]
             ),
             {"oof": "fiz", "rab": "biz"},
+        )
+
+    def test_dict_to_react_props(self):
+        from deephaven.ui._internal.utils import dict_to_react_props
+
+        self.assertDictEqual(
+            dict_to_react_props({"test_string": "foo", "test_string_2": "bar_biz"}),
+            {"testString": "foo", "testString2": "bar_biz"},
+        )
+        self.assertDictEqual(
+            dict_to_react_props({"alreadyCamelCase": "foo", "align_items": "bar"}),
+            {"alreadyCamelCase": "foo", "alignItems": "bar"},
+        )
+        self.assertDictEqual(
+            dict_to_react_props({"foo": None, "bar": "biz"}),
+            {"bar": "biz"},
+        )
+        self.assertDictEqual(
+            dict_to_react_props(
+                {"bar": "biz", "UNSAFE_class_name": "harry", "aria_label": "ron"}
+            ),
+            {"bar": "biz", "UNSAFE_className": "harry", "aria-label": "ron"},
         )
 
     def test_remove_empty_keys(self):

--- a/plugins/ui/test/deephaven/ui/test_utils.py
+++ b/plugins/ui/test/deephaven/ui/test_utils.py
@@ -48,6 +48,17 @@ class UtilsTest(BaseTestCase):
         self.assertEqual(to_react_prop_case("aria_expanded"), "aria-expanded")
         self.assertEqual(to_react_prop_case("aria_labelledby"), "aria-labelledby")
 
+    def test_convert_dict_keys(self):
+        from deephaven.ui._internal.utils import convert_dict_keys
+
+        # Test with a function reversing the keys
+        self.assertDictEqual(
+            convert_dict_keys(
+                {"foo": "fiz", "bar": "biz"}, convert_key=lambda x: x[::-1]
+            ),
+            {"oof": "fiz", "rab": "biz"},
+        )
+
     def test_dict_to_camel_case(self):
         from deephaven.ui._internal.utils import dict_to_camel_case
 
@@ -66,13 +77,6 @@ class UtilsTest(BaseTestCase):
         self.assertDictEqual(
             dict_to_camel_case({"bar": "biz", "UNSAFE_class_name": "harry"}),
             {"bar": "biz", "UNSAFEClassName": "harry"},
-        )
-        # Test with a function reversing the keys
-        self.assertDictEqual(
-            dict_to_camel_case(
-                {"foo": "fiz", "bar": "biz"}, convert_key=lambda x: x[::-1]
-            ),
-            {"oof": "fiz", "rab": "biz"},
         )
 
     def test_dict_to_react_props(self):


### PR DESCRIPTION
The `dict_to_camel_case` function was doing a bit too much based on its name. This separates the utils a bit so they are better named and `dict_to_camel_case` is true camel case without our special keys and removing Nones.