### PR TITLE
test: default tox to 3.8

### DIFF
--- a/.github/workflows/test-python-package.yml
+++ b/.github/workflows/test-python-package.yml
@@ -27,5 +27,5 @@ jobs:
         working-directory: 'plugins/${{ inputs.package }}'
 
       - name: Run tox
-        run: tox -e py
+        run: tox -e py${{ matrix.python }}
         working-directory: 'plugins/${{ inputs.package }}'

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ tox -e py
 ```
 
 You can also run tests against a specific version of python by appending the version to `py`  
-This assumes that the version of python you're targeting is installed on your system.  
+This assumes that the version of Python you're targeting is installed on your system.  
 For example, to run tests against Python 3.12, run:  
 ```shell
 tox -e py3.12

--- a/README.md
+++ b/README.md
@@ -73,13 +73,20 @@ You should be able to pass arguments to these commands as if you were running Pl
 It is highly recommended to use `npm run e2e:docker` (instead of `npm run e2e`) as CI also uses the same environment. You can also use `npm run e2e:update-snapshots` to regenerate snapshots in said environment. Run Playwright in [UI Mode](https://playwright.dev/docs/test-ui-mode) with `npm run e2e:ui` when creating new tests or debugging, as this will allow you to run each test individually, see the browser as it runs it, inspect the console, evaluate locators, etc.
 
 ### Running Python tests
-
-The above steps will also set up `tox` to run tests for the python plugins that support it.
+The [venv setup](#pre-commit-hookspython-formatting) steps will also set up `tox` to run tests for the python plugins that support it.
 Note that `tox` sets up an isolated environment for running tests.  
-Be default, `tox` will run against Python 3.8, which will need to be installed on your system before running tests.  
+Be default, `tox` will run against Python 3.8, which will need to be installed on your system before running tests.
 You can run tests with the following command from the `plugins/<plugin>` directory:
 ```shell
 tox -e py
+```
+
+Linux, and possibly other setups such as MacOS depending on method, 
+may require additional packages to be installed to run Python 3.8.
+```shell
+sudo apt install python3.8 python3.8-distutils libpython3.8
+# or just full install although it will include more packages than necessary
+sudo apt install python3.8-full
 ```
 
 You can also run tests against a specific version of python by appending the version to `py`  

--- a/README.md
+++ b/README.md
@@ -81,13 +81,13 @@ You can run tests with the following command from the `plugins/<plugin>` directo
 tox -e py
 ```
 
-Linux, and possibly other setups such as MacOS depending on method, 
-may require additional packages to be installed to run Python 3.8.
-```shell
-sudo apt install python3.8 python3.8-distutils libpython3.8
-# or just full install although it will include more packages than necessary
-sudo apt install python3.8-full
-```
+> [!IMPORTANT]
+> Linux, and possibly other setups such as MacOS depending on method, may require additional packages to be installed to run Python 3.8.
+> ```shell
+> sudo apt install python3.8 python3.8-distutils libpython3.8
+> # or just full install although it will include more packages than necessary
+> sudo apt install python3.8-full
+> ```
 
 You can also run tests against a specific version of python by appending the version to `py`  
 This assumes that the version of Python you're targeting is installed on your system.  

--- a/README.md
+++ b/README.md
@@ -75,11 +75,20 @@ It is highly recommended to use `npm run e2e:docker` (instead of `npm run e2e`) 
 ### Running Python tests
 
 The above steps will also set up `tox` to run tests for the python plugins that support it.
+Note that `tox` sets up an isolated environment for running tests.  
+Be default, `tox` will run against Python 3.8, which will need to be installed on your system before running tests.  
 You can run tests with the following command from the `plugins/<plugin>` directory:
-
 ```shell
 tox -e py
 ```
+
+You can also run tests against a specific version of python by appending the version to `py`  
+This assumes that the version of python you're targeting is installed on your system.  
+For example, to run tests against Python 3.12, run:  
+```shell
+tox -e py3.12
+```
+
 
 ### Running plugin against deephaven-core
 

--- a/plugins/plotly-express/tox.ini
+++ b/plugins/plotly-express/tox.ini
@@ -6,3 +6,21 @@ deps =
     deephaven-server
 commands =
     python -m unittest discover
+basepython = python3.8
+
+[testenv:py3.8]
+basepython = python3.8
+
+[testenv:py3.9]
+basepython = python3.9
+
+[testenv:py3.10]
+basepython = python3.10
+
+[testenv:py3.11]
+basepython = python3.11
+
+[testenv:py3.12]
+basepython = python3.12
+
+

--- a/plugins/ui/tox.ini
+++ b/plugins/ui/tox.ini
@@ -6,3 +6,19 @@ deps =
     deephaven-server
 commands =
     python -m unittest {posargs}
+basepython = python3.8
+
+[testenv:py3.8]
+basepython = python3.8
+
+[testenv:py3.9]
+basepython = python3.9
+
+[testenv:py3.10]
+basepython = python3.10
+
+[testenv:py3.11]
+basepython = python3.11
+
+[testenv:py3.12]
+basepython = python3.12


### PR DESCRIPTION
fixes #965 

Default to test with 3.8

Also adds other environments to run. A tiny bit more maintenance when we add/remove version support but useful for both the gh action and easily running different versions locally