### PR TITLE
ci: Switch to salmon-sync action and fix action warnings

### DIFF
--- a/.github/workflows/build-python-package.yml
+++ b/.github/workflows/build-python-package.yml
@@ -36,7 +36,7 @@ jobs:
         run: npm run build -- --scope "@deephaven/js-plugin-${{ inputs.package }}"
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.x'
 

--- a/.github/workflows/build-python-package.yml
+++ b/.github/workflows/build-python-package.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Check file existence
         id: check_files
@@ -47,7 +47,7 @@ jobs:
         run: python -m build --wheel --sdist plugins/${{ inputs.package }}
 
       - name: Upload dist
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: dist-${{ inputs.package }}
           path: plugins/${{ inputs.package }}/dist/

--- a/.github/workflows/build-python-package.yml
+++ b/.github/workflows/build-python-package.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v4
 
       - name: Check file existence
         id: check_files

--- a/.github/workflows/make-docs.yml
+++ b/.github/workflows/make-docs.yml
@@ -27,7 +27,7 @@ jobs:
 
         # assume that the dist artifact is already available from calling build-python-package.yml before this workflow
       - name: Download dist
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: dist-${{ inputs.package }}
           path: plugins/${{ inputs.package }}/dist/
@@ -41,29 +41,16 @@ jobs:
       - name: Run make_docs.py
         run: python plugins/${{ inputs.package }}/make_docs.py
 
-      - name: Setup rclone
+      - name: Sync to the plugins folder
         # pull requests should run the make_docs.py script, but not sync the docs
         if: inputs.event_name == 'push'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y rclone
-
-          mkdir -p $HOME/.config
-          mkdir -p $HOME/.config/rclone
-
-          cat << EOF > $HOME/.config/rclone/rclone.conf
-          [plugindocs]
-          type = google cloud storage
-          service_account_file = $HOME/credentials.json
-          project_number = ${{ secrets.DOCS_GOOGLE_CLOUD_PROJECT_NUMBER }}
-          bucket_policy_only = true
-          EOF
-          
-          echo ${{ secrets.DOCS_GOOGLE_CLOUD_CREDENTIALS }} | base64 -d > $HOME/credentials.json
-
-      - name: Sync docs
-        if: inputs.event_name == 'push'
-        run: rclone sync plugins/${{ inputs.package }}/docs/build/markdown/ plugindocs:${{ secrets.DOCS_GOOGLE_CLOUD_BUCKET }}/deephaven/deephaven-plugins/${{ inputs.package }}/${{ inputs.version }}/
+        uses: deephaven/salmon-sync@v1
+        with:
+          source: plugins/${{ inputs.package }}/docs/build/markdown/
+          destination: deephaven/deephaven-plugins/${{ inputs.package }}/${{ inputs.version }}/
+          project_number: ${{ secrets.DOCS_GOOGLE_CLOUD_PROJECT_NUMBER}}
+          bucket: ${{ vars.DOCS_GOOGLE_CLOUD_BUCKET }}
+          credentials: ${{ secrets.DOCS_GOOGLE_CLOUD_CREDENTIALS }}
 
       - name: Setup gsutil auth
         if: inputs.fix_mime_types == true

--- a/.github/workflows/modified-plugin.yml
+++ b/.github/workflows/modified-plugin.yml
@@ -27,8 +27,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
       - name: Filter paths
-        uses: dorny/paths-filter@v2
+        uses: dorny/paths-filter@v3
         id: filter
         with:
           filters: |

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -17,5 +17,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v5
       - uses: pre-commit/action@v3.0.0

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -18,4 +18,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
       - uses: pre-commit/action@v3.0.1

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,4 +1,4 @@
-name: Pre-commit for Black and Blacken-docs
+name: Pre-commit for code style and formatting checks
 
 on:
   push:
@@ -18,4 +18,4 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
-      - uses: pre-commit/action@v3.0.0
+      - uses: pre-commit/action@v3.0.1

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -19,5 +19,5 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.x'
+          python-version: '3.8'
       - uses: pre-commit/action@v3.0.1

--- a/.github/workflows/release-python-package.yml
+++ b/.github/workflows/release-python-package.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Download dist
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: dist-${{ inputs.package }}
           path: plugins/${{ inputs.package }}/dist/

--- a/.github/workflows/test-js-packages.yml
+++ b/.github/workflows/test-js-packages.yml
@@ -55,6 +55,12 @@ jobs:
         if: steps.restore-node-modules.outputs.cache-hit != 'true'
         run: npm ci --no-audit
 
+      # Run all tests for all the packages
+      # Caching with the absolute path b/c Jest will make a folder in each project
+      # Then there's caches in all plugin folders
+      - name: Run Tests
+        run: npm run test:ci
+
       - name: Always cache node modules
         id: cache-node-modules
         if: always() && steps.restore-node-modules.outputs.cache-hit != 'true'
@@ -64,9 +70,3 @@ jobs:
           path: |
             node_modules
             plugins/**/node_modules
-
-      # Run all tests for all the packages
-      # Caching with the absolute path b/c Jest will make a folder in each project
-      # Then there's caches in all plugin folders
-      - name: Run Tests
-        run: npm run test:ci

--- a/.github/workflows/test-js-packages.yml
+++ b/.github/workflows/test-js-packages.yml
@@ -42,19 +42,28 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-lintcache-
 
-      - name: Cache node modules
-        id: cache-node-modules
-        uses: actions/cache@v4
+      - name: Restore cached node modules
+        id: restore-node-modules
+        uses: actions/cache/restore@v4
         with:
-          save-always: true
           path: |
             node_modules
             plugins/**/node_modules
           key: unit-node-modules-${{ hashFiles('package-lock.json')}}
 
       - name: Install dependencies
-        if: steps.cache-node-modules.outputs.cache-hit != 'true'
+        if: steps.restore-node-modules.outputs.cache-hit != 'true'
         run: npm ci --no-audit
+
+      - name: Always cache node modules
+        id: cache-node-modules
+        if: always() && steps.restore-node-modules.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          key: ${{ steps.restore-node-modules.outputs.cache-primary-key }}
+          path: |
+            node_modules
+            plugins/**/node_modules
 
       # Run all tests for all the packages
       # Caching with the absolute path b/c Jest will make a folder in each project

--- a/.github/workflows/test-python-package.yml
+++ b/.github/workflows/test-python-package.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
 


### PR DESCRIPTION
Fixes #969 - Switches to use the `salmon-sync` action for docs uploads 
Fixes #970 - Cleans up warnings. For the most part this was just version bumps. The most significant change was in caching for `test-js-packages.yml`. I followed [these](https://github.com/actions/cache/blob/main/save/README.md#always-save-cache) directions to migrate that.

Tested on my fork