### PR TITLE
fix: to_camel_case fails on leading or trailing underscores

### DIFF
--- a/plugins/ui/src/deephaven/ui/_internal/utils.py
+++ b/plugins/ui/src/deephaven/ui/_internal/utils.py
@@ -71,6 +71,7 @@ def get_component_qualname(component: Any) -> str:
 def to_camel_case(snake_case_text: str) -> str:
     """
     Convert a snake_case string to camelCase.
+    Preserves any leading or trailing underscores.
 
     Args:
         snake_case_text: The snake_case string to convert.
@@ -78,8 +79,13 @@ def to_camel_case(snake_case_text: str) -> str:
     Returns:
         The camelCase string.
     """
-    components = snake_case_text.split("_")
-    return components[0] + "".join((x[0].upper() + x[1:]) for x in components[1:])
+    leading_underscores = len(snake_case_text) - len(snake_case_text.lstrip("_"))
+    trailing_underscores = len(snake_case_text) - len(snake_case_text.rstrip("_"))
+    components = snake_case_text.strip("_").split("_")
+    camel_case_text = components[0] + "".join(
+        (x[0].upper() + x[1:]) for x in components[1:]
+    )
+    return "_" * leading_underscores + camel_case_text + "_" * trailing_underscores
 
 
 def to_react_prop_case(snake_case_text: str) -> str:

--- a/plugins/ui/test/deephaven/ui/test_utils.py
+++ b/plugins/ui/test/deephaven/ui/test_utils.py
@@ -78,6 +78,13 @@ class UtilsTest(BaseTestCase):
             dict_to_camel_case({"bar": "biz", "UNSAFE_class_name": "harry"}),
             {"bar": "biz", "UNSAFEClassName": "harry"},
         )
+        # Test leading/trailing underscore
+        self.assertDictEqual(
+            dict_to_camel_case(
+                {"foo_": "bar", "_baz": "biz", "__youre_a_wizard__": "Harry"}
+            ),
+            {"foo_": "bar", "_baz": "biz", "__youreAWizard__": "Harry"},
+        )
 
     def test_dict_to_react_props(self):
         from deephaven.ui._internal.utils import dict_to_react_props
@@ -99,6 +106,13 @@ class UtilsTest(BaseTestCase):
                 {"bar": "biz", "UNSAFE_class_name": "harry", "aria_label": "ron"}
             ),
             {"bar": "biz", "UNSAFE_className": "harry", "aria-label": "ron"},
+        )
+        # Test trailing underscore
+        self.assertDictEqual(
+            dict_to_react_props(
+                {"foo_": "bar", "_baz": "biz", "__youre_a_wizard__": "Harry"}
+            ),
+            {"foo_": "bar", "_baz": "biz", "__youreAWizard__": "Harry"},
         )
 
     def test_remove_empty_keys(self):


### PR DESCRIPTION
Changed a prop to `if_` and noticed the `to_camel_case` method throws with index out of bounds because it ends up trying to access characters of an empty string. Figured we should preserve leading and trailing underscores, but convert anything in the middle to camelCase.