### PR TITLE
fix: switch to webgl by default for line plot

### DIFF
--- a/plugins/plotly-express/src/deephaven/plot/express/plots/line.py
+++ b/plugins/plotly-express/src/deephaven/plot/express/plots/line.py
@@ -56,7 +56,7 @@ def line(
     line_shape: str = "linear",
     title: str | None = None,
     template: str | None = None,
-    render_mode: str = "svg",
+    render_mode: str = "webgl",
     unsafe_update_figure: Callable = default_callback,
 ) -> DeephavenFigure:
     """Returns a line chart
@@ -170,8 +170,9 @@ def line(
         'spline', 'vhv', 'hvh', 'vh', 'hv'. Default 'linear'
       title: The title of the chart
       template: The template for the chart.
-      render_mode: Either "svg" or "webgl". Setting to "webgl" will lead to a more
-        performant plot but there may be graphical bugs.
+      render_mode: Either "svg" or "webgl". The default is "webgl" as it leads to a more
+        performant plot but there may be graphical bugs, in which case it is
+        recommended to switch to "svg"
       unsafe_update_figure: An update function that takes a plotly figure
         as an argument and optionally returns a plotly figure. If a figure is
         not returned, the plotly figure passed will be assumed to be the return

--- a/plugins/plotly-express/test/deephaven/plot/express/plots/test_line.py
+++ b/plugins/plotly-express/test/deephaven/plot/express/plots/test_line.py
@@ -1,0 +1,78 @@
+import unittest
+
+from ..BaseTest import BaseTestCase
+
+
+class LineTestCase(BaseTestCase):
+    def setUp(self) -> None:
+        from deephaven import new_table
+        from deephaven.column import int_col
+
+        self.source = new_table(
+            [
+                int_col("X", [1, 2, 2, 3, 3, 3, 4, 4, 5]),
+                int_col("X2", [1, 2, 2, 3, 3, 3, 4, 4, 5]),
+                int_col("Y", [1, 2, 2, 3, 3, 3, 4, 4, 5]),
+                int_col("Y2", [1, 2, 2, 3, 3, 3, 4, 4, 5]),
+                int_col("size", [1, 2, 2, 3, 3, 3, 4, 4, 5]),
+                int_col("text", [1, 2, 2, 3, 3, 3, 4, 4, 5]),
+                int_col("hover_name", [1, 2, 2, 3, 3, 3, 4, 4, 5]),
+                int_col("category", [1, 2, 1, 2, 1, 2, 1, 2, 1]),
+            ]
+        )
+
+    def test_basic_scatter(self):
+        import src.deephaven.plot.express as dx
+        from deephaven.constants import NULL_INT
+
+        chart = dx.line(self.source, x="X", y="Y").to_dict(self.exporter)
+
+        expected_data = [
+            {
+                "hovertemplate": "X=%{x}<br>Y=%{y}<extra></extra>",
+                "legendgroup": "",
+                "line": {"color": "#636efa", "dash": "solid", "shape": "linear"},
+                "marker": {"symbol": "circle"},
+                "mode": "lines",
+                "name": "",
+                "showlegend": False,
+                "x": [NULL_INT],
+                "xaxis": "x",
+                "y": [NULL_INT],
+                "yaxis": "y",
+                "type": "scattergl",
+            }
+        ]
+
+        expected_layout = {
+            "legend": {"tracegroupgap": 0},
+            "margin": {"t": 60},
+            "xaxis": {
+                "anchor": "y",
+                "domain": [0.0, 1.0],
+                "side": "bottom",
+                "title": {"text": "X"},
+            },
+            "yaxis": {
+                "anchor": "x",
+                "domain": [0.0, 1.0],
+                "side": "left",
+                "title": {"text": "Y"},
+            },
+        }
+
+        expected_mappings = [
+            {
+                "table": 0,
+                "data_columns": {"X": ["/plotly/data/0/x"], "Y": ["/plotly/data/0/y"]},
+            }
+        ]
+
+        self.assert_chart_equals(
+            chart,
+            expected_data=expected_data,
+            expected_layout=expected_layout,
+            expected_mappings=expected_mappings,
+            expected_is_user_set_template=False,
+            expected_is_user_set_color=False,
+        )

--- a/tests/app.d/ui_flex.py
+++ b/tests/app.d/ui_flex.py
@@ -3,7 +3,9 @@ from deephaven.plot import express as dx
 from deephaven import empty_table
 
 _t_flex = empty_table(100).update(["x = i", "y = sin(i)"])
-_p_flex = dx.line(_t_flex, x="x", y="y")
+# By default, dx.line renders with webgl but some tests use the trace class to see if the chart is rendered,
+# which is not there in webgl.
+_p_flex = dx.line(_t_flex, x="x", y="y", render_mode="svg")
 
 
 @ui.component


### PR DESCRIPTION
Fixes #991 
Used code from that issue
```
from deephaven.plot import express as dx
from deephaven.plot.figure import Figure

_stocks = dx.data.stocks()

p = dx.line(_stocks, "Timestamp", "Random")
```