### PR TITLE
fix: Resize contextual help popup for widget error messages

### DIFF
--- a/plugins/ui/src/js/src/styles.scss
+++ b/plugins/ui/src/js/src/styles.scss
@@ -90,3 +90,11 @@
   overflow: hidden;
   width: 100%;
 }
+
+.ui-widget-error-contextual-help {
+  section[class*='spectrum-ContextualHelp-dialog'] {
+    // Our error messages can be quite large. The default size of the contextual help is only 250px and is too small.
+    // Just set a size automatically based on the content.
+    width: auto;
+  }
+}

--- a/plugins/ui/src/js/src/widget/WidgetErrorView.tsx
+++ b/plugins/ui/src/js/src/widget/WidgetErrorView.tsx
@@ -42,7 +42,10 @@ export function WidgetErrorView({
         <Flex direction="column" gap="size-150">
           <Text UNSAFE_className="ui-text-wrap-balance">
             {shortMessage}
-            <ContextualHelp variant="info">
+            <ContextualHelp
+              variant="info"
+              UNSAFE_className="ui-widget-error-contextual-help"
+            >
               <Heading>
                 {name}{' '}
                 <CopyButton


### PR DESCRIPTION
- Default size was limited to just 250px, which is too small for this use case
- Just set width to "auto" so it resizes to the contents
- Tested with a bad widget and opening the contextual help error message:
```python
from deephaven import ui

@ui.component
def ui_boom():
    raise Exception("Boom")

boom = ui_boom()
```