### PR TITLE
test: Fix e2e docker writing files as root on Linux

### DIFF
--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -2,8 +2,15 @@
 
 # Dockerfile for running and updating snapshots locally and on CI
 FROM mcr.microsoft.com/playwright:v1.44.1-jammy AS playwright
+ARG UID=0
+ARG GID=0
+# Set user so it owns the work directory
+# Without this, we need to run snapshots as root and results are written as root
+USER ${UID}:${GID}
 WORKDIR /work/
 
+# Reset to root user to install packages
+USER 0:0
 # Update packages list and install some build tools.
 # Installing fonts-dejavu-core so we have some common fonts with the GH actions
 # runner that can be used to render unicode fonts. See web-client-ui README for more info.
@@ -19,10 +26,10 @@ RUN fc-list : family;
 COPY .nvmrc .
 
 # nvm needs to be run in a bash shell
-SHELL ["/bin/bash", "--login", "-c"]  
-# The default `.bashrc` bails on the first line if not in interactive shell. 
-# We can just empty it so that the nvm install below will actually run when sourcing 
-# `.bashrc`  
+SHELL ["/bin/bash", "--login", "-c"]
+# The default `.bashrc` bails on the first line if not in interactive shell.
+# We can just empty it so that the nvm install below will actually run when sourcing
+# `.bashrc`
 RUN echo "" > /root/.bashrc  
 RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.3/install.sh | bash
 RUN source /root/.bashrc && nvm install

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
   deephaven-plugins:
     container_name: deephaven-plugins
@@ -20,8 +18,12 @@ services:
       context: ../
       dockerfile: ./tests/Dockerfile
       pull: true # We only use FROM with a pinned version here, but adding this just in case that changes in the future
+      args:
+        UID: $DOCKER_UID
+        GID: $DOCKER_GID
     ports:
       - '9323:9323'
+    user: ${DOCKER_UID}:${DOCKER_GID}
     ipc: host
     volumes:
       - ../tests:/work/tests
@@ -33,6 +35,7 @@ services:
         condition: service_healthy
 
   update-snapshots:
+    user: ${DOCKER_UID}:${DOCKER_GID}
     extends:
       service: e2e-tests
     entrypoint: 'npx playwright test --config=playwright-docker.config.ts --update-snapshots'

--- a/tools/run_docker.sh
+++ b/tools/run_docker.sh
@@ -1,10 +1,37 @@
 #!/bin/bash
 
+IS_CI=0
+if [[ "${CI}" == "1" || "${CI}" == "true" ]]; then
+  IS_CI=1
+fi
+
+# Create directories if they don't exist
+# Otherwise, Docker will create them owned by root
+createDirectory () {
+  if [[ ! -d "$1" ]]; then
+    echo "Creating $1 directory"
+    mkdir $1
+  fi
+  if [[ $IS_CI -eq 0 && ! -O "$1" ]]; then
+    echo "$1 directory not owned by current user"
+    echo "Running 'sudo chown -R $(id -u):$(id -g) $1' to take ownership"
+    echo "Please enter your password if prompted"
+    echo ""
+    sudo chown -R $(id -u):$(id -g) $1
+  fi
+}
+
+createDirectory "./test-results"
+createDirectory "./playwright-report"
+
 # Set pwd to this directory
 pushd "$(dirname "$0")"
 
+export DOCKER_UID=$(id -u)
+export DOCKER_GID=$(id -g)
+
 # Start the containers
-if [[ "${CI}" == "1" || "${CI}" == "true" ]]; then
+if [[ $IS_CI -eq 1 ]]; then
   # In CI, keep the container in case we need to dump logs in another
   # step of the GH action. It should be cleaned up automatically by the CI runner.
   docker compose -f ../tests/docker-compose.yml run --service-ports --build -e CI=true "$@"
@@ -12,6 +39,7 @@ if [[ "${CI}" == "1" || "${CI}" == "true" ]]; then
   # stop instead of down to preserve container logs
   docker compose -f ../tests/docker-compose.yml stop deephaven-plugins
 else
+  # Use current user/group ID so docker doesn't write files as root
   docker compose -f ../tests/docker-compose.yml run --service-ports --rm --build "$@"
   exit_code=$?
   docker compose -f ../tests/docker-compose.yml down

--- a/tools/run_docker.sh
+++ b/tools/run_docker.sh
@@ -27,6 +27,7 @@ createDirectory "./playwright-report"
 # Set pwd to this directory
 pushd "$(dirname "$0")"
 
+# Use current user/group ID so docker doesn't write files as root
 export DOCKER_UID=$(id -u)
 export DOCKER_GID=$(id -g)
 
@@ -39,7 +40,6 @@ if [[ $IS_CI -eq 1 ]]; then
   # stop instead of down to preserve container logs
   docker compose -f ../tests/docker-compose.yml stop deephaven-plugins
 else
-  # Use current user/group ID so docker doesn't write files as root
   docker compose -f ../tests/docker-compose.yml run --service-ports --rm --build "$@"
   exit_code=$?
   docker compose -f ../tests/docker-compose.yml down


### PR DESCRIPTION
I think this only affects Linux from what I could find online.

Essentially, Docker creates volume directories as root if the directory doesn't exist on the host machine. It also runs and writes files as root, so even if you create the directory ahead of time, the files are still owned by root. This is really annoying if you run say `npm run e2e:docker` and then `npm run e2e:ui` to start in headed mode because running outside of Docker can't write to the directories it needs to. You then need to `sudo rm -r test-results playwright-report` and possibly some snapshot files at times if you change tests.

This should fix all of that and offer a prompt to fix the directories if they aren't owned by you when you run with Docker. After that, snapshots should work smoothly and write all the files as your user instead of root.