### PR TITLE
fix: label prop typing

### DIFF
--- a/plugins/ui/src/deephaven/ui/components/combo_box.py
+++ b/plugins/ui/src/deephaven/ui/components/combo_box.py
@@ -27,7 +27,7 @@ from deephaven.table import Table, PartitionedTable
 from .section import SectionElement
 from .item import Item
 from .item_table_source import ItemTableSource
-from ..elements import BaseElement, Element
+from ..elements import BaseElement, Element, NodeType
 from .._internal.utils import create_props, unpack_item_table_source
 from ..types import Key, Undefined, UndefinedType
 from .basic import component_element
@@ -67,7 +67,7 @@ def combo_box(
     is_required: bool | None = None,
     validation_behavior: ValidationBehavior = "aria",
     auto_focus: bool | None = None,
-    label: Element | None = None,
+    label: NodeType = None,
     description: Element | None = None,
     error_message: Element | None = None,
     name: str | None = None,

--- a/plugins/ui/src/deephaven/ui/components/date_field.py
+++ b/plugins/ui/src/deephaven/ui/components/date_field.py
@@ -20,7 +20,7 @@ from .types import (
     Alignment,
 )
 
-from ..elements import Element
+from ..elements import Element, NodeType
 from .._internal.utils import (
     create_props,
     convert_date_props,
@@ -93,7 +93,7 @@ def date_field(
     is_required: bool | None = None,
     validation_behavior: ValidationBehavior | None = None,
     auto_focus: bool | None = None,
-    label: Element | None = None,
+    label: NodeType = None,
     description: Element | None = None,
     error_message: Element | None = None,
     is_open: bool | None = None,

--- a/plugins/ui/src/deephaven/ui/components/date_picker.py
+++ b/plugins/ui/src/deephaven/ui/components/date_picker.py
@@ -22,7 +22,7 @@ from .types import (
 )
 
 from ..hooks import use_memo
-from ..elements import Element
+from ..elements import Element, NodeType
 from .._internal.utils import (
     create_props,
     convert_date_props,
@@ -98,7 +98,7 @@ def date_picker(
     is_required: bool | None = None,
     validation_behavior: ValidationBehavior | None = None,
     auto_focus: bool | None = None,
-    label: Element | None = None,
+    label: NodeType = None,
     description: Element | None = None,
     error_message: Element | None = None,
     is_open: bool | None = None,

--- a/plugins/ui/src/deephaven/ui/components/date_range_picker.py
+++ b/plugins/ui/src/deephaven/ui/components/date_range_picker.py
@@ -22,7 +22,7 @@ from .types import (
 )
 
 from ..hooks import use_memo
-from ..elements import Element
+from ..elements import Element, NodeType
 from .._internal.utils import (
     create_props,
     convert_date_props,
@@ -96,7 +96,7 @@ def date_range_picker(
     is_required: bool | None = None,
     validation_behavior: ValidationBehavior | None = None,
     auto_focus: bool | None = None,
-    label: Element | None = None,
+    label: NodeType = None,
     description: Element | None = None,
     error_message: Element | None = None,
     is_open: bool | None = None,

--- a/plugins/ui/src/deephaven/ui/components/picker.py
+++ b/plugins/ui/src/deephaven/ui/components/picker.py
@@ -6,7 +6,7 @@ from deephaven.table import Table, PartitionedTable
 from .basic import component_element
 from .section import SectionElement, Item
 from .item_table_source import ItemTableSource
-from ..elements import BaseElement, Element
+from ..elements import BaseElement, Element, NodeType
 from .._internal.utils import create_props, unpack_item_table_source
 from ..types import Key, Undefined, UndefinedType
 from .types import (
@@ -60,7 +60,7 @@ def picker(
     validation_behavior: ValidationBehavior | None = None,
     description: Element | None = None,
     error_message: Element | None = None,
-    label: Element | None = None,
+    label: NodeType = None,
     placeholder: str | None = None,
     is_loading: bool | None = None,
     label_position: LabelPosition = "top",

--- a/plugins/ui/src/deephaven/ui/components/progress_bar.py
+++ b/plugins/ui/src/deephaven/ui/components/progress_bar.py
@@ -14,9 +14,8 @@ from .types import (
     Position,
     ProgressBarSize,
 )
-
 from .basic import component_element
-from ..elements import Element
+from ..elements import Element, NodeType
 
 ProgressBarElement = Element
 
@@ -26,9 +25,9 @@ def progress_bar(
     static_color: StaticColor | None = None,
     label_position: LabelPosition = "top",
     show_value_label: bool | None = None,
-    label: Element | None = None,
+    label: NodeType = None,
     # format_options, # omitted because need to connect it to Deephaven formatting options as well
-    value_label: Element | None = None,
+    value_label: NodeType = None,
     value: float = 0,
     min_value: float = 0,
     max_value: float = 100,

--- a/plugins/ui/src/deephaven/ui/components/time_field.py
+++ b/plugins/ui/src/deephaven/ui/components/time_field.py
@@ -20,7 +20,7 @@ from .types import (
     Alignment,
 )
 
-from ..elements import Element
+from ..elements import Element, NodeType
 from .._internal.utils import (
     create_props,
     convert_time_props,
@@ -86,7 +86,7 @@ def time_field(
     is_required: bool | None = None,
     validation_behavior: ValidationBehavior | None = None,
     auto_focus: bool | None = None,
-    label: Element | None = None,
+    label: NodeType = None,
     description: Element | None = None,
     error_message: Element | None = None,
     name: str | None = None,

--- a/plugins/ui/src/deephaven/ui/elements/Element.py
+++ b/plugins/ui/src/deephaven/ui/elements/Element.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Any, Dict
+from typing import Any, Dict, List, Union
 from .._internal import RenderContext
 
 PropsType = Dict[str, Any]
@@ -45,3 +45,7 @@ class Element(ABC):
             The props of this element.
         """
         pass
+
+
+# Some props don't support Undefined, so they need to add it themselves
+NodeType = Union[None, bool, int, str, Element, List["NodeType"]]

--- a/plugins/ui/src/deephaven/ui/elements/__init__.py
+++ b/plugins/ui/src/deephaven/ui/elements/__init__.py
@@ -1,4 +1,4 @@
-from .Element import Element, PropsType
+from .Element import Element, PropsType, NodeType
 from .BaseElement import BaseElement
 from .DashboardElement import DashboardElement
 from .FunctionElement import FunctionElement


### PR DESCRIPTION
- Fixes #988 
- Adds `NodeType`, which mirrors the React Node type