### PR TITLE
fix: Allow autodoc functions to have no parameters

### DIFF
--- a/plugins/ui/src/deephaven/ui/components/action_menu.py
+++ b/plugins/ui/src/deephaven/ui/components/action_menu.py
@@ -91,7 +91,7 @@ def action_menu(
     ActionMenu combines an ActionButton with a Menu for simple "more actions" use cases.
 
     Args:
-        children: The contents of the collection.
+        *children: The contents of the collection.
         is_disabled: Whether the button is disabled.
         is_quiet: Whether the button should be displayed with a quiet style.
         auto_focus: Whether the element should receive focus on render.

--- a/plugins/ui/src/deephaven/ui/components/column.py
+++ b/plugins/ui/src/deephaven/ui/components/column.py
@@ -13,7 +13,7 @@ def column(
     Each element will be placed below its prior sibling.
 
     Args:
-        children: Elements to render in the column.
+        *children: Elements to render in the column.
         width: The percent width of the column relative to other children of its parent. If not provided, the column will be sized automatically.
         key: A unique identifier used by React to render elements in a list.
 

--- a/sphinx_ext/deephaven_autodoc.py
+++ b/sphinx_ext/deephaven_autodoc.py
@@ -266,13 +266,7 @@ def extract_desc_data(node: sphinx.addnodes.desc) -> SignatureData:
             result.update(extract_content_data(child_node))
     # map all to lowercase for consistency
     function = f"{result['module_name']}{result['name']}"
-    try:
-        result["parameters"] = result.pop("Parameters")
-    except KeyError:
-        raise ValueError(
-            "Parameters missing from description. "
-            f"Verify the function description for {function} is formatted correctly."
-        )
+    result["parameters"] = result.pop("Parameters") if "Parameters" in result else []
     try:
         result["return_description"] = result.pop("Returns")
     except KeyError:

--- a/sphinx_ext/deephaven_autodoc.py
+++ b/sphinx_ext/deephaven_autodoc.py
@@ -46,7 +46,8 @@ SignatureValue = Union[str, Params]
 
 AUTOFUNCTION_COMMENT_PREFIX = "AutofunctionCommentPrefix:"
 
-UNDOCUMENTED_PARAMS = {"*"}
+# Some parameters don't need to be documented
+UNDOCUMENTED_PARAMS = {"*", "/"}
 
 
 def extract_parameter_defaults(
@@ -115,7 +116,7 @@ def extract_list_item(node: docutils.nodes.list_item) -> ParamData:
         match = re.match(r"(.+?) \((.*?)\) -- (.+)", field, re.DOTALL)
         if match is None:
             raise ValueError(
-                f"Could not match {field} to extract param data. "
+                f"Could not match '{field}' to extract param data. "
                 f"Verify this parameter is documented correctly within 'Args:' with type and description."
             )
         matched = match.groups()

--- a/sphinx_ext/deephaven_autodoc.py
+++ b/sphinx_ext/deephaven_autodoc.py
@@ -100,7 +100,7 @@ def extract_signature_data(
         node: The node to extract the signature data from
 
     Returns:
-        The function metadata, the parameter defaults, and the expected number for comparison
+        The function metadata, the parameter defaults, and the expected parameters
     """
     result = {}
     param_defaults = {}

--- a/sphinx_ext/deephaven_autodoc.py
+++ b/sphinx_ext/deephaven_autodoc.py
@@ -46,7 +46,7 @@ SignatureValue = Union[str, Params]
 
 AUTOFUNCTION_COMMENT_PREFIX = "AutofunctionCommentPrefix:"
 
-# Some parameters don't need to be documented
+# Some parameters don't need to be documented such as function dividers
 UNDOCUMENTED_PARAMS = {"*", "/"}
 
 

--- a/sphinx_ext/deephaven_autodoc.py
+++ b/sphinx_ext/deephaven_autodoc.py
@@ -296,7 +296,7 @@ def extract_desc_data(node: sphinx.addnodes.desc) -> SignatureData:
     if missing_params:
         raise ValueError(
             f"Missing documentation for {function} parameters {missing_params}. "
-            "Verify that all parameters are documented in the 'Args:' section."
+            "Verify that parameter names have leading asterisks in the description."
         )
 
     try:

--- a/sphinx_ext/deephaven_autodoc.py
+++ b/sphinx_ext/deephaven_autodoc.py
@@ -49,19 +49,6 @@ AUTOFUNCTION_COMMENT_PREFIX = "AutofunctionCommentPrefix:"
 UNDOCUMENTED_PARAMS = {"*"}
 
 
-def filter_expected_params(expected_params: set[str]) -> set[str]:
-    """
-    Filter the expected parameters to only include the ones that need to be documented
-
-    Args:
-        expected_params: The expected parameters
-
-    Returns:
-        The filtered expected parameters
-    """
-    return expected_params - UNDOCUMENTED_PARAMS
-
-
 def extract_parameter_defaults(
     node: sphinx.addnodes.desc_parameterlist,
 ) -> tuple[ParamDefaults, set[str]]:
@@ -83,8 +70,6 @@ def extract_parameter_defaults(
         # otherwise, no default value - do not add it to defaults because None is not the same as no default
         # but add it to expected_params so that we can check that all parameters are documented
         expected_params.add(params[0])
-
-    expected_params = filter_expected_params(expected_params)
 
     return defaults, expected_params
 
@@ -276,7 +261,7 @@ def missing_parameters(params: Params, expected_params: set[str]) -> set[str]:
         expected_params: The parameters that are expected
     """
     param_names = set(param["name"] for param in params)
-    return expected_params - param_names
+    return expected_params - UNDOCUMENTED_PARAMS - param_names
 
 
 def extract_desc_data(node: sphinx.addnodes.desc) -> SignatureData:

--- a/sphinx_ext/deephaven_autodoc.py
+++ b/sphinx_ext/deephaven_autodoc.py
@@ -46,7 +46,7 @@ SignatureValue = Union[str, Params]
 
 AUTOFUNCTION_COMMENT_PREFIX = "AutofunctionCommentPrefix:"
 
-# Some parameters don't need to be documented such as function dividers
+# Some parameters don't need to be documented such as function parameter dividers
 UNDOCUMENTED_PARAMS = {"*", "/"}
 
 


### PR DESCRIPTION
Fixes https://deephaven.atlassian.net/browse/DH-18247

Allows autodoc functions to have no parameters and adds better error checking for params to ensure that all expected parameters are there in a fine-tuned way.

Tested on all existing docs as well as a local `use_render_queue` doc.
