### PR TITLE
fix: add menu and menu_trigger to sidebar

### DIFF
--- a/plugins/ui/docs/sidebar.json
+++ b/plugins/ui/docs/sidebar.json
@@ -188,6 +188,14 @@
             "path": "components/markdown.md"
           },
           {
+            "label": "menu",
+            "path": "components/menu.md"
+          },
+          {
+            "label": "menu_trigger",
+            "path": "components/menu_trigger.md"
+          },
+          {
             "label": "meter",
             "path": "components/meter.md"
           },


### PR DESCRIPTION
Forgot to add `menu` and `menu_trigger` to the side bar.
https://deephaven.atlassian.net/browse/DH-18089