### PR TITLE
build: Update the changelogPreset to use conventionalcommits, allow release branches to bump versions

### DIFF
--- a/cog.toml
+++ b/cog.toml
@@ -4,7 +4,7 @@ disable_changelog = false
 # we never tag any code outside the plugins/ directory. Everything else is build glue.
 generate_mono_repository_global_tag = false
 # limit which branches to perform bumps from
-branch_whitelist = [ "main" ]
+branch_whitelist = [ "main", "release/*" ]
 # we don't really use [skip ci] action filtering, but leaving here in case we decide to someday
 skip_ci = "[skip ci]"
 skip_untracked = false

--- a/lerna.json
+++ b/lerna.json
@@ -3,5 +3,10 @@
   "useWorkspaces": true,
   "useNx": false,
   "version": "independent",
-  "packages": ["plugins/*/src/js/"]
+  "packages": ["plugins/*/src/js/"],
+  "command": {
+    "version": {
+      "changelogPreset": "conventionalcommits"
+    }
+  }
 }

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@types/node": "^20.11.17",
     "@types/prop-types": "^15.7.10",
     "@vitejs/plugin-react-swc": "^3.7.0",
+    "conventional-changelog-conventionalcommits": "^7.0.0",
     "eslint": "^8.37.0",
     "identity-obj-proxy": "^3.0.0",
     "jest": "^29.6.2",


### PR DESCRIPTION
- Allow release branches to bump versions - we need this for hotfix branches, and already have it on the ui-v0.15 branch: 2803feae22dce73a6fe38fdb85a8a07b4f35cc79
- Need to update template to the correct format. Already did this on the `release/ui-v0.15` branch: #570 
- Take note there are still some issues to beware of when bumping a release branch: https://github.com/deephaven/deephaven-plugins/issues/557