### PR TITLE
fix: Make docs links passthrough

### DIFF
--- a/plugins/plotly-express/conf.py
+++ b/plugins/plotly-express/conf.py
@@ -39,6 +39,8 @@ exclude_patterns = ["build", "Thumbs.db", ".DS_Store"]
 # options for sphinx_autodoc_typehints
 always_use_bars_union = True
 
+myst_all_links_external = True
+
 from deephaven_server import Server
 
 # need a server instance to pull types from the autodocs

--- a/plugins/ui/conf.py
+++ b/plugins/ui/conf.py
@@ -43,5 +43,7 @@ strip_signature_backslash = True
 
 from deephaven_server import Server
 
+myst_all_links_external = True
+
 # need a server instance to pull types from the autodocs
 Server(port=10075)

--- a/plugins/ui/docs/hooks/use_row_list.md
+++ b/plugins/ui/docs/hooks/use_row_list.md
@@ -98,5 +98,5 @@ table_row_list = ui_table_row_list(
 ## API reference
 
 ```{eval-rst}
-.. dhaufunction:: deephaven.ui.use_row_list
+.. dhautofunction:: deephaven.ui.use_row_list
 ```


### PR DESCRIPTION
Fixes https://deephaven.atlassian.net/browse/DOC-355 by "making all links external", meaning they are passthrough instead of being processed by myst parser. In particular the absolute paths were considered invalid because they were file locations that didn't exist at build time.