### PR TITLE
docs: fix renamed unsafe-figure-update

### DIFF
--- a/plugins/plotly-express/docs/sidebar.json
+++ b/plugins/plotly-express/docs/sidebar.json
@@ -137,8 +137,8 @@
             "path": "multiple-axes.md"
           },
           {
-            "label": "`unsafe_update_figure` Chart Customization",
-            "path": "unsafe_update_figure.md"
+            "label": "Chart Customization",
+            "path": "unsafe-update-figure.md"
           }
         ]
       }


### PR DESCRIPTION
file was renamed, but not updated in sidebar. In future the sidebar vailidator would have caught this.

Also renamed it to drop the command from the title, just the concept to match the style of the other names.