### PR TITLE
fix: Pin plotly version

### DIFF
--- a/plugins/plotly-express/setup.cfg
+++ b/plugins/plotly-express/setup.cfg
@@ -27,7 +27,7 @@ packages=find_namespace:
 install_requires =
     deephaven-core>=0.37.0
     deephaven-plugin>=0.6.0
-    plotly
+    plotly~=5.0.0
     deephaven-plugin-utilities>=0.0.2
 include_package_data = True
 

--- a/plugins/plotly-express/setup.cfg
+++ b/plugins/plotly-express/setup.cfg
@@ -27,7 +27,7 @@ packages=find_namespace:
 install_requires =
     deephaven-core>=0.37.0
     deephaven-plugin>=0.6.0
-    plotly~=5.0.0
+    plotly>=5.15.0,<6.0.0
     deephaven-plugin-utilities>=0.0.2
 include_package_data = True
 


### PR DESCRIPTION
Plotly's version was not pinned, and there are breaking changes in 6.0.0, so tests were failing