### PR TITLE
fix: DH-18415: Cannot expand rows after applying rollup to ui.table

### DIFF
--- a/plugins/ui/src/js/src/elements/UITable/JsTableProxy.ts
+++ b/plugins/ui/src/js/src/elements/UITable/JsTableProxy.ts
@@ -100,7 +100,11 @@ class JsTableProxy implements dh.Table {
         const trueTarget = proxyHasProp || proxyHasFn ? target : target.table;
         const value = Reflect.get(trueTarget, prop, receiver);
 
-        if (typeof value === 'function') {
+        // Don't do this if the trueTarget is this proxy model (aka target).
+        // Otherwise we'll bind to the class instance and not the proxy instance.
+        // That can cause issues if this class implements something referencing a value
+        // that is defined in the model.
+        if (typeof value === 'function' && trueTarget === target.table) {
           return value.bind(trueTarget);
         }
 


### PR DESCRIPTION
Tested with the steps in DH-18415

The issue was the ui.table proxy model was set as `this` for any function calls which were passed through to the underlying model. This mostly worked before because most calls to `this.X` from the underlying models ended up getting routed back to themselves anyway (through the proxy). The catch was `this.table` which is also implemented by `UITableModel` after #587 

There might be a more robust fix to override `setModel` from the proxy and create a new proxied JS Table instead of binding method calls to the underlying model.