### PR TITLE
fix: Callable cleanup race (DH-18536)

### DIFF
--- a/plugins/ui/src/deephaven/ui/object_types/ElementMessageStream.py
+++ b/plugins/ui/src/deephaven/ui/object_types/ElementMessageStream.py
@@ -441,13 +441,12 @@ class ElementMessageStream(MessageStream):
 
     def _close_callable(self, callable_id: str) -> None:
         """
-        Close a callable by its ID.
+        Close a callable by its ID. Used to close a temporary callable that is outside of the render cycle.
 
         Args:
             callable_id: The ID of the callable to close
         """
         logger.debug("Closing callable %s", callable_id)
-        self._callable_dict.pop(callable_id, None)
         self._temp_callable_dict.pop(callable_id, None)
 
     def _send_document_update(

--- a/plugins/ui/src/js/src/widget/WidgetHandler.tsx
+++ b/plugins/ui/src/js/src/widget/WidgetHandler.tsx
@@ -202,7 +202,8 @@ function WidgetHandler({
           const callable = wrapCallable(
             jsonClient,
             callableId,
-            callableFinalizationRegistry
+            callableFinalizationRegistry,
+            false
           );
           renderedCallableMap.current.set(callableId, callable);
           return callable;

--- a/plugins/ui/src/js/src/widget/WidgetHandler.tsx
+++ b/plugins/ui/src/js/src/widget/WidgetHandler.tsx
@@ -244,7 +244,6 @@ function WidgetHandler({
       deadCallableMap.forEach((deadCallable, callableId) => {
         log.debug2('Callable no longer rendered:', callableId);
         renderedCallableMap.current.delete(callableId);
-        callableFinalizationRegistry.unregister(deadCallable);
       });
 
       log.debug2(

--- a/plugins/ui/src/js/src/widget/WidgetUtils.tsx
+++ b/plugins/ui/src/js/src/widget/WidgetUtils.tsx
@@ -266,12 +266,14 @@ export function getPreservedData(
  * @param jsonClient The JSON client to send callable requests to
  * @param callableId The callableId to return a wrapped callable for
  * @param registry The finalization registry to register the callable with.
+ * @param shouldRegister Whether to register the callable in the finalization registry
  * @returns A wrapped callable that will automatically wrap any nested callables returned by the server
  */
 export function wrapCallable(
   jsonClient: JSONRPCServerAndClient,
   callableId: string,
-  registry: FinalizationRegistry<string>
+  registry: FinalizationRegistry<string>,
+  shouldRegister = true
 ): (...args: unknown[]) => Promise<unknown> {
   const callable = async (...args: unknown[]) => {
     log.debug2(`Callable ${callableId} called`, args);
@@ -304,7 +306,9 @@ export function wrapCallable(
     }
   };
 
-  registry.register(callable, callableId, callable);
+  if (shouldRegister) {
+    registry.register(callable, callableId, callable);
+  }
 
   return callable;
 }


### PR DESCRIPTION
- Client was calling a closeCallable function each time any callable was no longer rendered
  - Callables as part of the regular render cycle that didn't change were being recreated every time
  - Since it wasn't the same object between renders, closeCallable was getting called for a previous instance of that callable but with the same ID
- Server side was unnecessarily listening for those to close callables as part of the regular render cycle
  - Things that are no longer rendered are already cleaned up by the server, don't need to/shouldn't listen to the client for when to clean those up. Only needed for the temporary callables
- Tested by using the snippet from DH-18536:
```python
from deephaven import ui, time_table

@ui.component
def ui_resetable_table():
    table, set_table = ui.use_state(lambda: time_table("PT1s"))
    handle_press = ui.use_liveness_scope(lambda _: set_table(time_table("PT1s")), [])
    return [
        ui.action_button(
            "Reset",
            on_press=handle_press,
        ),
        table,
    ]

resetable_table = ui_resetable_table()
```
- Also tested using the snippets from previous callable implentation ticket: https://github.com/deephaven/deephaven-plugins/pull/540
```python
from deephaven import ui

@ui.component
def my_comp():
    on_press = ui.use_callback(lambda d: print(d), [])
    on_press_nested = ui.use_callback(lambda: print, [])
    on_press_double_nested = ui.use_callback(lambda: { "nestedFn": print, "some_val": 4 }, [])
    on_press_unserializable = ui.use_callback(lambda: set([1, 2, 3]), [])
    return [
        ui.button("Normal", on_press=on_press),
        ui.button("Nested", on_press=on_press_nested),
        ui.button("Double Nested", on_press=on_press_double_nested),
        ui.button("Not Serializable", on_press=on_press_unserializable)
    ]

c = my_comp()
```
