### PR TITLE
ci: Make separate staging action

### DIFF
--- a/.github/workflows/publish-prod-docs.yml
+++ b/.github/workflows/publish-prod-docs.yml
@@ -1,5 +1,5 @@
 # Docs triggered via push will go to prod, while docs triggered via PR will go to preview
-name: Publish Docs
+name: Publish Prod Docs
 
 on:
   workflow_run:
@@ -12,6 +12,7 @@ on:
 
 jobs:
   get-docs-packages:
+    if: ${{ github.event.workflow_run.event == 'push' }}
     runs-on: ubuntu-24.04
     outputs:
       packages: ${{ steps.packages.outputs.result }}
@@ -58,30 +59,11 @@ jobs:
           echo "package=$(ls docs-build)" >> $GITHUB_ENV
           echo "version=$(ls docs-build/*)" >> $GITHUB_ENV
 
-      - name: Set production env variable
-        run: echo "production=${{ github.event.workflow_run.event == 'push' && 'true' || 'false' }}" >> $GITHUB_ENV
-
-      - name: Sync ${{ env.package }}/${{ env.version }} to ${{ env.production == 'true' && 'prod' || 'preview' }}
+      - name: Sync ${{ env.package }}/${{ env.version }} to prod
         uses: deephaven/salmon-sync@v1
         with:
           source: docs-build/${{ env.package }}/${{ env.version }}/
           destination: deephaven/deephaven-plugins/${{ env.package }}/${{ env.version }}/
-          production: ${{ env.production }}
-          temporary: ${{ env.production == 'true' && 'false' || 'true' }}
+          production: true
+          temporary: false
           aws-role: ${{ vars.DOCS_AWS_ROLE }}
-
-      - name: Comment on PR
-        if: ${{ github.event.workflow_run.event == 'pull_request' }}
-        uses: actions/github-script@v7
-        env:
-          url: ${{ vars.DOCS_PREVIEW_URL }}
-        with:
-          script: |
-            const env = process.env;
-            const path = env.package === 'ui' ? 'core/ui/docs' : 'core/plotly/docs'
-            github.rest.issues.createComment({
-              issue_number: env.version.replace('pr-', ''),
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: `[${env.package} docs preview](${env.url}/${path}/${env.version}) (Available for 14 days)`
-            });

--- a/.github/workflows/publish-prod-docs.yml
+++ b/.github/workflows/publish-prod-docs.yml
@@ -1,4 +1,3 @@
-# Docs triggered via push will go to prod, while docs triggered via PR will go to preview
 name: Publish Prod Docs
 
 on:

--- a/.github/workflows/publish-staging-docs.yml
+++ b/.github/workflows/publish-staging-docs.yml
@@ -1,4 +1,3 @@
-# Docs triggered via push will go to prod, while docs triggered via PR will go to preview
 name: Publish Staging Docs
 
 on:
@@ -6,9 +5,6 @@ on:
     workflows: ['Test Modified Plugin'] # Only runs on top level workflows, not reusable workflows called from another run
     types:
       - completed
-    branches-ignore:
-      - main
-      - 'release/**'
 
 jobs:
   get-docs-packages:

--- a/.github/workflows/publish-staging-docs.yml
+++ b/.github/workflows/publish-staging-docs.yml
@@ -1,0 +1,84 @@
+# Docs triggered via push will go to prod, while docs triggered via PR will go to preview
+name: Publish Staging Docs
+
+on:
+  workflow_run:
+    workflows: ['Test Modified Plugin'] # Only runs on top level workflows, not reusable workflows called from another run
+    types:
+      - completed
+    branches-ignore:
+      - main
+      - 'release/**'
+
+jobs:
+  get-docs-packages:
+    if: ${{ github.event.workflow_run.event == 'pull_request' }}
+    runs-on: ubuntu-24.04
+    outputs:
+      packages: ${{ steps.packages.outputs.result }}
+    steps:
+      - name: Get docs to publish
+        uses: actions/github-script@v7
+        id: packages
+        with:
+          script: |
+            const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: ${{ github.event.workflow_run.id }}
+            });
+            const versions = artifacts.data.artifacts.filter(artifact => artifact.name.startsWith('docs-build-'));
+            const packages = versions.map(artifact => artifact.name.replace('docs-build-', ''))
+            return packages;
+
+  publish-docs:
+    needs: get-docs-packages
+    if: ${{ needs.get-docs-packages.outputs.packages != '[]' && needs.get-docs-packages.outputs.packages != '' }}
+    runs-on: ubuntu-24.04
+    permissions:
+      id-token: write # Auth to AWS with OIDC
+      pull-requests: write # Add comment
+      actions: read # Download artifact
+    strategy:
+      fail-fast: false
+      matrix:
+        package: ${{fromJson(needs.get-docs-packages.outputs.packages)}}
+    steps:
+      - name: Download artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: docs-build-${{ matrix.package }}
+          path: docs-build
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+
+      # Extract the package and version from the artifact directories
+      # Each artifact should only contain 1 package and 1 version as the first 2 directories
+      - name: Extract package and version
+        run: |
+          echo "package=$(ls docs-build)" >> $GITHUB_ENV
+          echo "version=$(ls docs-build/*)" >> $GITHUB_ENV
+
+      - name: Sync ${{ env.package }}/${{ env.version }} to preview
+        uses: deephaven/salmon-sync@v1
+        with:
+          source: docs-build/${{ env.package }}/${{ env.version }}/
+          destination: deephaven/deephaven-plugins/${{ env.package }}/${{ env.version }}/
+          production: false
+          temporary: true
+          aws-role: ${{ vars.DOCS_AWS_ROLE }}
+
+      - name: Comment on PR
+        uses: actions/github-script@v7
+        env:
+          url: ${{ vars.DOCS_PREVIEW_URL }}
+        with:
+          script: |
+            const env = process.env;
+            const path = env.package === 'ui' ? 'core/ui/docs' : 'core/plotly/docs'
+            github.rest.issues.createComment({
+              issue_number: env.version.replace('pr-', ''),
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `[${env.package} docs preview](${env.url}/${path}/${env.version}) (Available for 14 days)`
+            });


### PR DESCRIPTION
Just made a copy of the publish-docs action for prod that is filtered on main/release branches and checks for push. Then the preview action which just checks it's triggered by a pull request.