### PR TITLE
build: Add custom sphinx translator to fix relative image paths in output

### DIFF
--- a/plugins/plotly-express/conf.py
+++ b/plugins/plotly-express/conf.py
@@ -23,6 +23,7 @@ extensions = [
     "myst_parser",
     "sphinx.ext.autodoc",
     "sphinx.ext.napoleon",
+    "deephaven_markdown_translator",
     "sphinx_markdown_builder",
     "sphinx_autodoc_typehints",
     "deephaven_autodoc",

--- a/plugins/ui/conf.py
+++ b/plugins/ui/conf.py
@@ -23,6 +23,7 @@ extensions = [
     "myst_parser",
     "sphinx.ext.autodoc",
     "sphinx.ext.napoleon",
+    "deephaven_markdown_translator",
     "sphinx_markdown_builder",
     "sphinx_autodoc_typehints",
     "deephaven_autodoc",

--- a/sphinx_ext/deephaven_markdown_translator.py
+++ b/sphinx_ext/deephaven_markdown_translator.py
@@ -1,0 +1,31 @@
+from sphinx.application import Sphinx
+from sphinx_markdown_builder.translator import MarkdownTranslator  # type: ignore
+
+
+class DeephavenTranslator(MarkdownTranslator):
+    def visit_image(self, node):  # noqa: ANN001
+        # Change image uri to original_uri if it exists since sphinx-markdown-builder just uses uri
+        # This will give us proper relative image paths
+        # See https://github.com/liran-funaro/sphinx-markdown-builder/issues/33 for more info
+        node["uri"] = node.get("original_uri", node["uri"])
+        super().visit_image(node)
+
+
+def setup(app: Sphinx):
+    """
+    Setup the deephaven autodoc extension
+    Adds the deephaven autodoc directive to the app
+
+    Args:
+        app: The Sphinx application
+
+    Returns:
+        The metadata for the extension
+    """
+    app.set_translator("markdown", DeephavenTranslator)
+
+    return {
+        "version": "0.1",
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }


### PR DESCRIPTION
This is a bit of a hack, but works. Checked the output of UI docs in `components` and ensured they kept the `../` in their image paths.