### PR TITLE
feat: List format options for ui.labeled_value

### DIFF
--- a/plugins/ui/docs/components/labeled_value.md
+++ b/plugins/ui/docs/components/labeled_value.md
@@ -84,6 +84,41 @@ my_number_range = ui.labeled_value(
 )
 ```
 
+## Lists
+
+When passing a list into a labeled value, the `format_options` prop dictates how the value is displayed.
+
+Note that this prop is compatible with the options of [Intl.ListFormat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/ListFormat/ListFormat).
+
+```python
+from deephaven import ui
+
+
+@ui.component
+def labeled_value_list_formatting():
+
+    return [
+        ui.labeled_value(
+            label="Interests",
+            value=["Travel", "Hiking", "Snorkeling", "Camping"],
+            format_options={"type": "conjunction"},
+        ),
+        ui.labeled_value(
+            label="Travel Destination",
+            value=["Paris", "Tokyo", "New York", "Sydney"],
+            format_options={"type": "disjunction"},
+        ),
+        ui.labeled_value(
+            label="Clothing Sizes",
+            value=["XS", "S", "M", "L", "XL"],
+            format_options={"type": "unit", "style": "narrow"},
+        ),
+    ]
+
+
+my_labeled_value_list_formatting = labeled_value_list_formatting()
+```
+
 ## Dates and time
 
 `ui.labeled_value` accepts the following date types as inputs:

--- a/plugins/ui/src/deephaven/ui/components/labeled_value.py
+++ b/plugins/ui/src/deephaven/ui/components/labeled_value.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 from typing import Any, List
 
-from .number_field import NumberFormatOptions
 from .._internal.utils import (
     create_props,
     convert_to_java_date,
@@ -11,6 +10,8 @@ from .types import (
     Alignment,
     AlignSelf,
     CSSProperties,
+    NumberFormatOptions,
+    ListFormatOptions,
     DimensionValue,
     JustifySelf,
     LayoutFlex,
@@ -132,9 +133,11 @@ def _convert_labeled_value_props(
 def labeled_value(
     value: str | List[str] | float | NumberRange | Date | DateRange | None = None,
     label: Element | None = None,
-    format_options: NumberFormatOptions | DateFormatOptions | None = None,
-    # TODO: DH-18854 Implement list format options for ui.labeled_value
-    # format_options: NumberFormatOptions | DateFormatOptions | ListFormatOptions | None = None,
+    format_options: NumberFormatOptions
+    | DateFormatOptions
+    | ListFormatOptions
+    | None = None,
+    timezone: str | None = None,
     label_position: LabelPosition | None = "top",
     label_align: Alignment | None = None,
     contextual_help: Any | None = None,

--- a/plugins/ui/src/deephaven/ui/components/labeled_value.py
+++ b/plugins/ui/src/deephaven/ui/components/labeled_value.py
@@ -137,7 +137,6 @@ def labeled_value(
     | DateFormatOptions
     | ListFormatOptions
     | None = None,
-    timezone: str | None = None,
     label_position: LabelPosition | None = "top",
     label_align: Alignment | None = None,
     contextual_help: Any | None = None,

--- a/plugins/ui/src/deephaven/ui/components/types/Intl/list_format.py
+++ b/plugins/ui/src/deephaven/ui/components/types/Intl/list_format.py
@@ -1,4 +1,11 @@
-from typing import Literal, TypedDict, NotRequired
+from typing import Literal
+
+import sys
+
+if sys.version_info < (3, 11):
+    from typing_extensions import TypedDict, NotRequired
+else:
+    from typing import TypedDict, NotRequired
 
 
 class ListFormatOptions(TypedDict):

--- a/plugins/ui/src/deephaven/ui/components/types/Intl/list_format.py
+++ b/plugins/ui/src/deephaven/ui/components/types/Intl/list_format.py
@@ -22,12 +22,12 @@ class ListFormatOptions(TypedDict):
 
     type: NotRequired[Literal["conjunction", "disjunction", "unit"]]
     """
-    The formatting style to use. 
+    The type of grouping to use. 
     Possible values are "conjunction" for "and"-based grouping of list items, "disjunction" for "or"-based grouping, and "unit" for grouping the list items as a compound unit (neither conjunction or disjunction).
     """
 
     style: NotRequired[Literal["long", "short", "narrow"]]
     """
-    The formatting style to use. 
+    The grouping style to use. 
     Possible values are "long" for a typical list, or "short" to reduce the length of the output, or "narrow" to further abbreviate the output.
     """

--- a/plugins/ui/src/deephaven/ui/components/types/Intl/list_format.py
+++ b/plugins/ui/src/deephaven/ui/components/types/Intl/list_format.py
@@ -1,0 +1,26 @@
+from typing import Literal, TypedDict, NotRequired
+
+
+class ListFormatOptions(TypedDict):
+    """
+    Options for formatting lists of values.
+    """
+
+    locale_matcher: NotRequired[Literal["lookup", "best fit"]]
+    """
+    The locale matching algorithm to use.
+    Possible values are "lookup" to use the runtime's locale matching algorithm, or "best fit" to use the CLDR locale matching algorithm.
+    The default is "best fit".
+    """
+
+    type: NotRequired[Literal["conjunction", "disjunction", "unit"]]
+    """
+    The formatting style to use. 
+    Possible values are "conjunction" for "and"-based grouping of list items, "disjunction" for "or"-based grouping, and "unit" for grouping the list items as a compound unit (neither conjunction or disjunction).
+    """
+
+    style: NotRequired[Literal["long", "short", "narrow"]]
+    """
+    The formatting style to use. 
+    Possible values are "long" for a typical list, or "short" to reduce the length of the output, or "narrow" to further abbreviate the output.
+    """

--- a/plugins/ui/src/deephaven/ui/components/types/__init__.py
+++ b/plugins/ui/src/deephaven/ui/components/types/__init__.py
@@ -7,3 +7,4 @@ from .progress import *
 from .validate import *
 from .icon_types import *
 from .Intl.number_format import *
+from .Intl.list_format import *


### PR DESCRIPTION
- Implements [Intl.ListFormat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/ListFormat/ListFormat) for use in ui.labeled_value. Currently it is only supported in [LabeledValue](https://react-spectrum.adobe.com/react-spectrum/LabeledValue.html), but it could be used in components that might support it in the future.

Test Snippet
```python
from deephaven import ui


@ui.component
def labeled_value_list_formatting():

    return [
        ui.labeled_value(
            label="Interests",
            value=["Travel", "Hiking", "Snorkeling", "Camping"],
            format_options={"type": "conjunction"},
        ),
        ui.labeled_value(
            label="Travel Destination",
            value=["Paris", "Tokyo", "New York", "Sydney"],
            format_options={"type": "disjunction"},
        ),
        ui.labeled_value(
            label="Clothing Sizes",
            value=["XS", "S", "M", "L", "XL"],
            format_options={"type": "unit", "style": "narrow"},
        ),
    ]


my_labeled_value_list_formatting = labeled_value_list_formatting()
```