### PR TITLE
fix: Re-opening widget would break interactivity (DH-18090)

### DIFF
--- a/plugins/ui/src/js/src/widget/WidgetHandler.tsx
+++ b/plugins/ui/src/js/src/widget/WidgetHandler.tsx
@@ -399,6 +399,7 @@ function WidgetHandler({
       >();
       exportedObjectMap.current = widgetExportedObjectMap;
       exportedObjectCount.current = 0;
+      renderedCallableMap.current.clear();
 
       // Set a var to the client that we know will not be null in the closure below
       const activeClient = jsonClient;


### PR DESCRIPTION
- Issue caused by #1113
- Re-opening the widget would call an old version of the callback
- Reset the rendered callable map when re-initializing the widget
- Tested with component, ran snippet, pressed button, then re-ran snippet and pressed button. It continued to print text:
```
from deephaven import ui
b = ui.button("Print something", on_press=print)
```
