### PR TITLE
fix: Fix type version for plotly-express

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31989,7 +31989,7 @@
         "react-redux": "^7.2.9"
       },
       "devDependencies": {
-        "@deephaven/jsapi-types": "1.0.0-dev0.36.1",
+        "@deephaven/jsapi-types": "1.0.0-dev0.37.6",
         "@deephaven/test-utils": "0.97.0",
         "@types/deep-equal": "^1.0.1",
         "@types/plotly.js": "^2.12.18",
@@ -32374,8 +32374,9 @@
       }
     },
     "plugins/plotly-express/src/js/node_modules/@deephaven/jsapi-types": {
-      "version": "1.0.0-dev0.36.1",
-      "license": "Apache-2.0"
+      "version": "1.0.0-dev0.37.6",
+      "resolved": "https://registry.npmjs.org/@deephaven/jsapi-types/-/jsapi-types-1.0.0-dev0.37.6.tgz",
+      "integrity": "sha512-CWBzP2xpxT0VYsUyEk1+6dcJZyZLbC3GvCs0ikIM87e7Kk54NmcpCCbfz6NtFDcSpJWedEL+iPozdzyv65fT7Q=="
     },
     "plugins/plotly-express/src/js/node_modules/@deephaven/jsapi-utils": {
       "version": "0.97.0",

--- a/plugins/plotly-express/src/js/package.json
+++ b/plugins/plotly-express/src/js/package.json
@@ -36,7 +36,7 @@
     "update-dh-packages": "node ../../../../tools/update-dh-packages.mjs"
   },
   "devDependencies": {
-    "@deephaven/jsapi-types": "1.0.0-dev0.36.1",
+    "@deephaven/jsapi-types": "1.0.0-dev0.37.6",
     "@deephaven/test-utils": "0.97.0",
     "@types/deep-equal": "^1.0.1",
     "@types/plotly.js": "^2.12.18",

--- a/plugins/plotly-express/src/js/src/PlotlyExpressChartModel.ts
+++ b/plugins/plotly-express/src/js/src/PlotlyExpressChartModel.ts
@@ -311,7 +311,7 @@ export class PlotlyExpressChartModel extends ChartModel {
   }
 
   handleFigureUpdated(
-    event: CustomEvent<DhType.SubscriptionTableData>,
+    event: DhType.Event<DhType.SubscriptionTableData>,
     tableId: number
   ): void {
     const chartData = this.chartDataMap.get(tableId);


### PR DESCRIPTION
Probably need to make this more robust, but this gets the type check to pass.

Looks like `@deephaven/chart` depends on `^1.0.0-0.37.6` or something like that while plotly-express was depending on a pinned version of the jsapi-types causing some conflict.