### PR TITLE
fix: incorrect table type in ag grid plugin

### DIFF
--- a/plugins/ag-grid/src/js/src/AgGridWidget.tsx
+++ b/plugins/ag-grid/src/js/src/AgGridWidget.tsx
@@ -25,7 +25,8 @@ export function AgGridWidget(
     async function init() {
       log.debug('Fetching widget');
       const widget: DhType.Widget = await fetch();
-      const newTable = (await widget.exportedObjects[0].fetch()) as Table;
+      const newTable =
+        (await widget.exportedObjects[0].fetch()) as DhType.Table;
       if (!cancelled) {
         log.info('AgGridView loaded table', newTable);
         setTable(newTable);


### PR DESCRIPTION
Fixed type that was failing https://github.com/deephaven/deephaven-plugins/actions/runs/14093526373/job/39475806319?pr=1126