### PR TITLE
fix: fix hovertext logic for hierarchical plots

### DIFF
--- a/plugins/plotly-express/src/deephaven/plot/express/deephaven_figure/generate.py
+++ b/plugins/plotly-express/src/deephaven/plot/express/deephaven_figure/generate.py
@@ -1075,8 +1075,7 @@ def generate_figure(
 
     # types for special hovermap processing
     types = get_list_param_info(data_cols)
-    is_hierarchical = draw in (px.treemap, px.icicle, px.sunburst)
-    if is_hierarchical:
+    if draw in (px.treemap, px.icicle, px.sunburst):
         types.add("hierarchical")
 
     hover_text = create_hover_and_axis_titles(custom_call_args, hover_mapping, types)

--- a/plugins/plotly-express/test/deephaven/plot/express/plots/test_pie.py
+++ b/plugins/plotly-express/test/deephaven/plot/express/plots/test_pie.py
@@ -3,7 +3,7 @@ import unittest
 from ..BaseTest import BaseTestCase
 
 
-class AreaTestCase(BaseTestCase):
+class PieTestCase(BaseTestCase):
     def setUp(self) -> None:
         from deephaven import new_table
         from deephaven.column import int_col, string_col

--- a/plugins/plotly-express/test/deephaven/plot/express/plots/test_pie.py
+++ b/plugins/plotly-express/test/deephaven/plot/express/plots/test_pie.py
@@ -1,0 +1,141 @@
+import unittest
+
+from ..BaseTest import BaseTestCase
+
+
+class AreaTestCase(BaseTestCase):
+    def setUp(self) -> None:
+        from deephaven import new_table
+        from deephaven.column import int_col, string_col
+        import deephaven.pandas as dhpd
+
+        self.source = new_table(
+            [
+                string_col("names", ["A", "B", "C", "D", "E", "F", "G", "H", "I"]),
+                string_col("parents", ["Z", "Z", "Z", "Z", "Z", "Z", "Z", "Z", "Z"]),
+                int_col("values", [1, 2, 2, 3, 3, 3, 4, 4, 5]),
+                int_col("colors", [2, 2, 2, 3, 3, 3, 4, 4, 4]),
+            ]
+        )
+
+        self.pandas_source = dhpd.to_pandas(self.source)
+
+    def test_basic_treemap(self):
+        import src.deephaven.plot.express as dx
+        from deephaven.constants import NULL_INT
+
+        chart = dx.treemap(
+            self.source, names="names", parents="parents", values="values"
+        ).to_dict(self.exporter)
+        plotly, deephaven = chart["plotly"], chart["deephaven"]
+
+        # pop template as we currently do not modify it
+        plotly["layout"].pop("template")
+
+        expected_data = [
+            {
+                "domain": {"x": [0.0, 1.0], "y": [0.0, 1.0]},
+                "hovertemplate": "names=%{label}<br>values=%{value}<br>parents=%{parent}<extra></extra>",
+                "labels": ["None"],
+                "name": "",
+                "parents": ["None"],
+                "type": "treemap",
+                "values": [NULL_INT],
+            }
+        ]
+
+        expected_layout = {"legend": {"tracegroupgap": 0}}
+
+        expected_mappings = [
+            {
+                "data_columns": {
+                    "names": ["/plotly/data/0/labels"],
+                    "parents": ["/plotly/data/0/parents"],
+                    "values": ["/plotly/data/0/values"],
+                },
+                "table": 0,
+            }
+        ]
+
+        self.assert_chart_equals(
+            chart,
+            expected_data=expected_data,
+            expected_layout=expected_layout,
+            expected_mappings=expected_mappings,
+            expected_is_user_set_template=False,
+            expected_is_user_set_color=False,
+        )
+
+    def test_treemap_colors(self):
+        import src.deephaven.plot.express as dx
+        from deephaven.constants import NULL_INT
+
+        chart = dx.treemap(
+            self.source,
+            names="names",
+            parents="parents",
+            values="values",
+            color="colors",
+        ).to_dict(self.exporter)
+        plotly, deephaven = chart["plotly"], chart["deephaven"]
+
+        # pop template as we currently do not modify it
+        plotly["layout"].pop("template")
+
+        expected_data = [
+            {
+                "domain": {"x": [0.0, 1.0], "y": [0.0, 1.0]},
+                "hovertemplate": "names=%{label}<br>values=%{value}<br>parents=%{parent}<br>colors=%{"
+                "color}<extra></extra>",
+                "labels": ["None"],
+                "name": "",
+                "marker": {"coloraxis": "coloraxis", "colors": [NULL_INT]},
+                "parents": ["None"],
+                "type": "treemap",
+                "values": [NULL_INT],
+            }
+        ]
+
+        expected_layout = {
+            "coloraxis": {
+                "colorbar": {"title": {"text": "colors"}},
+                "colorscale": [
+                    [0.0, "#0d0887"],
+                    [0.1111111111111111, "#46039f"],
+                    [0.2222222222222222, "#7201a8"],
+                    [0.3333333333333333, "#9c179e"],
+                    [0.4444444444444444, "#bd3786"],
+                    [0.5555555555555556, "#d8576b"],
+                    [0.6666666666666666, "#ed7953"],
+                    [0.7777777777777778, "#fb9f3a"],
+                    [0.8888888888888888, "#fdca26"],
+                    [1.0, "#f0f921"],
+                ],
+            },
+            "legend": {"tracegroupgap": 0},
+        }
+
+        expected_mappings = [
+            {
+                "data_columns": {
+                    "colors": ["/plotly/data/0/marker/colors"],
+                    "names": ["/plotly/data/0/labels"],
+                    "parents": ["/plotly/data/0/parents"],
+                    "values": ["/plotly/data/0/values"],
+                },
+                "table": 0,
+            }
+        ]
+
+        self.assert_chart_equals(
+            chart,
+            expected_data=expected_data,
+            expected_layout=expected_layout,
+            expected_mappings=expected_mappings,
+            expected_is_user_set_template=False,
+            expected_is_user_set_color=False,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/plugins/plotly-express/test/deephaven/plot/express/plots/test_treemap.py
+++ b/plugins/plotly-express/test/deephaven/plot/express/plots/test_treemap.py
@@ -1,0 +1,118 @@
+import unittest
+
+from ..BaseTest import BaseTestCase
+
+
+class TreemapTestCase(BaseTestCase):
+    def setUp(self) -> None:
+        from deephaven import new_table
+        from deephaven.column import int_col, string_col
+        import deephaven.pandas as dhpd
+
+        self.source = new_table(
+            [
+                string_col("names", ["A", "B", "C", "D", "E", "F", "G", "H", "I"]),
+                int_col("values", [1, 2, 2, 3, 3, 3, 4, 4, 5]),
+                int_col("colors", [2, 2, 2, 3, 3, 3, 4, 4, 4]),
+            ]
+        )
+
+        self.pandas_source = dhpd.to_pandas(self.source)
+
+    def test_basic_pie(self):
+        import src.deephaven.plot.express as dx
+        from deephaven.constants import NULL_INT
+
+        chart = dx.pie(self.source, names="names", values="values").to_dict(
+            self.exporter
+        )
+        plotly, deephaven = chart["plotly"], chart["deephaven"]
+
+        # pop template as we currently do not modify it
+        plotly["layout"].pop("template")
+
+        expected_data = [
+            {
+                "domain": {"x": [0.0, 1.0], "y": [0.0, 1.0]},
+                "hovertemplate": "names=%{label}<br>values=%{value}<extra></extra>",
+                "labels": ["None"],
+                "legendgroup": "",
+                "name": "",
+                "showlegend": True,
+                "type": "pie",
+                "values": [NULL_INT],
+            }
+        ]
+
+        expected_layout = {"legend": {"tracegroupgap": 0}}
+
+        expected_mappings = [
+            {
+                "data_columns": {
+                    "names": ["/plotly/data/0/labels"],
+                    "values": ["/plotly/data/0/values"],
+                },
+                "table": 0,
+            }
+        ]
+
+        self.assert_chart_equals(
+            chart,
+            expected_data=expected_data,
+            expected_layout=expected_layout,
+            expected_mappings=expected_mappings,
+            expected_is_user_set_template=False,
+            expected_is_user_set_color=False,
+        )
+
+    def test_pie_colors(self):
+        import src.deephaven.plot.express as dx
+        from deephaven.constants import NULL_INT
+
+        chart = dx.pie(
+            self.source, names="names", values="values", color="colors"
+        ).to_dict(self.exporter)
+        plotly, deephaven = chart["plotly"], chart["deephaven"]
+
+        # pop template as we currently do not modify it
+        plotly["layout"].pop("template")
+
+        expected_data = [
+            {
+                "domain": {"x": [0.0, 1.0], "y": [0.0, 1.0]},
+                "hovertemplate": "names=%{label}<br>values=%{value}<extra></extra>",
+                "labels": ["None"],
+                "legendgroup": "",
+                "marker": {"colors": []},
+                "name": "",
+                "showlegend": True,
+                "type": "pie",
+                "values": [NULL_INT],
+            }
+        ]
+
+        expected_layout = {"legend": {"tracegroupgap": 0}}
+
+        expected_mappings = [
+            {
+                "data_columns": {
+                    "color": ["/plotly/data/0/marker/colors"],
+                    "names": ["/plotly/data/0/labels"],
+                    "values": ["/plotly/data/0/values"],
+                },
+                "table": 0,
+            }
+        ]
+
+        self.assert_chart_equals(
+            chart,
+            expected_data=expected_data,
+            expected_layout=expected_layout,
+            expected_mappings=expected_mappings,
+            expected_is_user_set_template=False,
+            expected_is_user_set_color=False,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This was found in the process of implementing path, but I pulled it out because it is technically a different issue.
This isn't strictly a blocker for path, but it was making debugging tricky because the color wasn't in the hovertext, and I want to make sure it is updating correctly since it needs to be aggregated.

Example:
```
import deephaven.plot.express as dx
import plotly.express as px
from deephaven import pandas as dhpd

data = dx.data.gapminder(ticking=False).update_view("World=`World`").where("Year = 2007")

df = dhpd.to_pandas(data)
dx_treemap = dx.treemap(df, names="Country", parents="World", values="Pop", color="LifeExp")
px_treemap = px.treemap(df, names="Country", parents="World", values="Pop", color="LifeExp")
```
<img width="707" alt="Screenshot 2025-04-08 at 3 38 14 PM" src="https://github.com/user-attachments/assets/a9fc03c6-c07c-453a-97a5-fcb7eb4a6646" />
