### PR TITLE
chore: DOC-714 Add local docs preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,6 +340,23 @@ This example reinstalls the `ui` plugin with js, starts the server, and watches 
 python tools/plugin_builder.py -jrsw ui
 ```
 
+### Previewing Docs
+
+To preview the docs, run the following command from the root directory of this repo:
+
+```shell
+npm run docs
+```
+
+This will use the source directories and serve the preview docs at `http://localhost:3001`. Note that this will not include the API reference docs which are only part of the fully built docs with `plugin_builder.py`.
+
+To build and preview docs from the `build` directory, run the following commands:
+
+```shell
+python tools/plugin_builder.py -d ui plotly-express
+BUILT=true npm run docs
+```
+
 ## Release Management
 
 In order to manage changelogs, version bumps and github releases, we use [cocogitto](https://github.com/cocogitto/cocogitto), or `cog` for short. Follow the [Installation instructions](https://github.com/cocogitto/cocogitto?tab=readme-ov-file#installation) to install `cog`. For Linux and Windows, we recommend using [cargo](https://doc.rust-lang.org/cargo/getting-started/installation.html) to install. For MacOS, we recommend using [brew](https://brew.sh/).

--- a/docker-compose.docs.yml
+++ b/docker-compose.docs.yml
@@ -1,0 +1,11 @@
+services:
+  docs:
+    image: ghcr.io/deephaven/salmon
+    pull_policy: always
+    ports:
+      - '${PORT:-3001}:${PORT:-3001}'
+    environment:
+      - PORT=${PORT:-3001}
+    volumes:
+      - ./plugins/ui/docs${BUILT+/build/markdown}:/salmon/core/ui/docs
+      - ./plugins/plotly-express/docs${BUILT+/build/markdown}:/salmon/core/plotly/docs

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "watch:types": "tsc --watch",
     "serve:plugins": "vite",
     "start:packages": "lerna run start --stream",
+    "docs": "docker compose --file docker-compose.docs.yml up",
     "test": "jest --watch --changedSince origin/main",
     "test:unit": "jest --config jest.config.unit.cjs",
     "test:lint": "jest --config jest.config.lint.cjs",

--- a/plugins/plotly-express/Makefile
+++ b/plugins/plotly-express/Makefile
@@ -14,6 +14,12 @@ help:
 
 .PHONY: help Makefile
 
+# Clean target: remove all files in BUILDDIR but keep directories
+# Salmon preview tool uses docker volume mounts to share the markdown directory
+# If the markdown directory is removed, the volume mount will break
+clean:
+	rm -rf $(BUILDDIR)/**/*
+
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile

--- a/plugins/ui/Makefile
+++ b/plugins/ui/Makefile
@@ -14,6 +14,12 @@ help:
 
 .PHONY: help Makefile
 
+# Clean target: remove all files in BUILDDIR but keep directories
+# Salmon preview tool uses docker volume mounts to share the markdown directory
+# If the markdown directory is removed, the volume mount will break
+clean:
+	rm -rf $(BUILDDIR)/**/*
+
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile

--- a/plugins/ui/docs/docker-compose.yml
+++ b/plugins/ui/docs/docker-compose.yml
@@ -1,0 +1,9 @@
+services:
+  docs:
+    image: ghcr.io/deephaven/salmon
+    ports:
+      - '${PORT:-3001}:${PORT:-3001}'
+    environment:
+      - PORT=${PORT:-3001}
+    volumes:
+      - ./build/markdown:/core/ui/docs

--- a/plugins/ui/docs/docker-compose.yml
+++ b/plugins/ui/docs/docker-compose.yml
@@ -1,9 +1,0 @@
-services:
-  docs:
-    image: ghcr.io/deephaven/salmon
-    ports:
-      - '${PORT:-3001}:${PORT:-3001}'
-    environment:
-      - PORT=${PORT:-3001}
-    volumes:
-      - ./build/markdown:/core/ui/docs


### PR DESCRIPTION
Adds `npm run docs` which will run docs from source code. This does not generate the API param tables, but shows the placeholder value that the sphinx plugin replaces.

I initially had something to run `plugin_builder.py` in watch mode and the docs docker image, but `run-p` would cause this to prevent shutdown with `ctrl+c` for some reason. And it was significantly slower because it would need to rebuild the Python plugin