### PR TITLE
docs: Fix deephaven.ui code blocks that have errors

### DIFF
--- a/plugins/ui/conf.py
+++ b/plugins/ui/conf.py
@@ -46,5 +46,8 @@ from deephaven_server import Server
 
 myst_all_links_external = True
 
+# myst_fence_as_directive = set(["py", "python"])
+# myst_number_code_blocks = ["py", "python"]
+
 # need a server instance to pull types from the autodocs
 Server(port=10075)

--- a/plugins/ui/conf.py
+++ b/plugins/ui/conf.py
@@ -46,8 +46,5 @@ from deephaven_server import Server
 
 myst_all_links_external = True
 
-# myst_fence_as_directive = set(["py", "python"])
-# myst_number_code_blocks = ["py", "python"]
-
 # need a server instance to pull types from the autodocs
 Server(port=10075)

--- a/plugins/ui/docs/README.md
+++ b/plugins/ui/docs/README.md
@@ -34,8 +34,6 @@ Get started by importing the `deephaven.ui` package as `ui`:
 
 ```python test-set=0
 from deephaven import ui
-
-print("XXXXXXX TODO FAIL")
 ```
 
 The `ui` package contains many _components_, which you can display in the UI:

--- a/plugins/ui/docs/README.md
+++ b/plugins/ui/docs/README.md
@@ -32,13 +32,15 @@ You'll need to find the link to open the UI in the Docker logs:
 
 Get started by importing the `deephaven.ui` package as `ui`:
 
-```python
+```python test-set=0
 from deephaven import ui
+
+print("XXXXXXX TODO FAIL")
 ```
 
 The `ui` package contains many _components_, which you can display in the UI:
 
-```python
+```python test-set=0
 hello_world = ui.heading("Hello World!")
 ```
 
@@ -50,7 +52,7 @@ By assigning the component to the `hello_world` variable, it displays in the UI 
 
 Write functions to handle events. To write a button that will print event details to the console when clicked:
 
-```python
+```python test-set=0
 my_button = ui.button("Click Me!", on_press=lambda e: print(f"Button was clicked! {e}"))
 ```
 
@@ -62,7 +64,7 @@ Use the `@ui.component` decorator to create your own custom components. This dec
 
 We can display a heading above a button as our custom component:
 
-```python
+```python test-set=0
 @ui.component
 def ui_foo_bar():
     return [
@@ -80,7 +82,7 @@ foo_bar = ui_foo_bar()
 
 Often, you'll want to react to the button presses and update the display. For example, to count the number of times a button has been pressed, use `ui.use_state` to introduce a _state variable_ in your custom component:
 
-```python
+```python skip-test
 @ui.component
 def ui_counter():
     count, set_count = ui.use_state(0)
@@ -91,7 +93,7 @@ Returned from `ui.use_state` is a tuple with two values: the current state (`cou
 
 The first time the button is displayed, the count will be `0` because that is the initial value passed into `ui.use_state`. Call `set_count` to update the state:
 
-```python
+```python skip-test
 @ui.component
 def ui_counter():
     count, set_count = ui.use_state(0)
@@ -102,7 +104,7 @@ When state is updated, deephaven.ui will call your component again to re-render 
 
 Each individual component has its own state:
 
-```python
+```python test-set=0
 @ui.component
 def ui_counter():
     count, set_count = ui.use_state(0)

--- a/plugins/ui/docs/add-interactivity/queueing-updates.md
+++ b/plugins/ui/docs/add-interactivity/queueing-updates.md
@@ -27,7 +27,7 @@ example_counter = counter()
 
 However, as mentioned in the previous section, the state values for each render are fixed. This means that the value of `number` within the event handler of the first render is always 0, regardless of how many times you call `set_number(number + 1)`:
 
-```python
+```python skip-test
 def handle_press():
     set_number(0 + 1)
     set_number(0 + 1)
@@ -72,7 +72,7 @@ Here, `lambda n: n + 1` is called an updater function. When you pass it to a sta
 1. `deephaven.ui` queues this function to be processed after all the other code in the event handler has run.
 2. During the next render, `deephaven.ui` goes through the queue and gives you the final updated state.
 
-```python
+```python skip-test
 set_number(lambda n: n + 1)
 set_number(lambda n: n + 1)
 set_number(lambda n: n + 1)
@@ -176,7 +176,7 @@ After the event handler completes, `deephaven.ui` will trigger a re-render. Duri
 
 It is common to name the updater function argument by the first letters of the corresponding state variable:
 
-```python
+```python skip-test
 set_enabled(lambda e: not e)
 set_last_name(lambda ln: ln.upper())
 set_friend_count(lambda fc: fc * 2)

--- a/plugins/ui/docs/add-interactivity/state-a-components-memory.md
+++ b/plugins/ui/docs/add-interactivity/state-a-components-memory.md
@@ -51,13 +51,13 @@ The [`use_state`](../hooks/use_state.md) hook provides those two things:
 
 To add a state variable, replace this line:
 
-```python
+```python skip-test
 index = 0
 ```
 
 with
 
-```python
+```python skip-test
 index, set_index = ui.use_state(0)
 ```
 
@@ -65,7 +65,7 @@ index, set_index = ui.use_state(0)
 
 This is how they work together in `handle_press`:
 
-```python
+```python skip-test
 set_index(index + 1)
 ```
 
@@ -110,7 +110,7 @@ Hooks can only be called at the top level of your components or your own hooks. 
 
 When you call `use_state`, you are telling `deephaven.ui` that you want this component to remember something:
 
-```python
+```python skip-test
 index, set_index = ui.use_state(0)
 ```
 
@@ -127,7 +127,7 @@ Every time your component renders, `use_state` gives you an array containing two
 
 Here’s how that happens in action:
 
-```python
+```python skip-test
 index, set_index = ui.use_state(0)
 ```
 

--- a/plugins/ui/docs/add-interactivity/update-dictionaries-in-state.md
+++ b/plugins/ui/docs/add-interactivity/update-dictionaries-in-state.md
@@ -6,13 +6,13 @@ State can hold any kind of Python value, including dictionaries. However, you sh
 
 You can store any kind of Python value in state.
 
-```python
+```python skip-test
 x, set_x = ui.use_state(0)
 ```
 
 Python data types like numbers, strings, and booleans are "immutable", meaning unchangeable or "read-only". You can trigger a re-render to replace a value:
 
-```python
+```python skip-test
 set_x(5)
 ```
 
@@ -20,13 +20,13 @@ The `x` state changed from `0` to `5`, but the number `0` itself did not change.
 
 Now consider a dictionary in state:
 
-```python
+```python skip-test
 position, set_position = ui.use_state({"x": 0, "y": 0})
 ```
 
 It is possible to change the contents of the dictionary itself. This is called a mutation:
 
-```python
+```python skip-test
 position["x"] = 5
 ```
 
@@ -60,7 +60,7 @@ my_range_example = range_example()
 
 The problem is with this bit of code.
 
-```python
+```python skip-test
 def handle_press():
     value["end"] = value["end"] + 1
 ```
@@ -69,7 +69,7 @@ This code modifies the dictionary assigned to `value` from the previous render. 
 
 To actually trigger a re-render in this case, create a new dictionary and pass it to the state setting function:
 
-```python
+```python skip-test
 def handle_press():
     set_value({"start": 0, "end": value["end"] + 1})
 ```
@@ -153,13 +153,13 @@ form_example = form()
 
 For example, this line mutates the state from a past render:
 
-```python
+```python skip-test
 person["first_name"] = value
 ```
 
 To achieve the desired behavior, it is best to create a new dictionary and pass it to `set_person`. Since only one of the fields has changed, you'll want to copy the existing data into this new dictionary.
 
-```python
+```python skip-test
 set_person(
     {
         "first_name": value,
@@ -171,7 +171,7 @@ set_person(
 
 You can use dictionary `unpacking` so that you do not need to copy every property separately.
 
-```python
+```python skip-test
 set_person({**person, "first_name": value})
 ```
 
@@ -232,7 +232,7 @@ Note that the dictionary `unpacking` is “shallow”. It only copies things one
 
 Consider a nested dictionary structure like this:
 
-```python
+```python skip-test
 person, set_person = ui.use_state(
     {
         "first_name": "John",
@@ -244,13 +244,13 @@ person, set_person = ui.use_state(
 
 If you wanted to update `email`, it’s clear how to do it with mutation:
 
-```python
+```python skip-test
 person["contact"]["email"] = "jdoe@domain.net"
 ```
 
 But in `deephaven.ui`, you should treat state as immutable. In order to change `email`, you first need to produce the new `contact` dictionary (pre-populated with data from the previous one), and then produce the new `person` dictionary, which points at the new artwork:
 
-```python
+```python skip-test
 new_person = {**person, "contact": {**person["contact"], "email": "jdoe@domain.net"}}
 ```
 

--- a/plugins/ui/docs/add-interactivity/update-lists-in-state.md
+++ b/plugins/ui/docs/add-interactivity/update-lists-in-state.md
@@ -64,7 +64,7 @@ artist_list_example = artist_list()
 
 The `concatenation` syntax also lets you prepend by placing it before the original list:
 
-```python
+```python skip-test
 set_artists([name] + artists)
 ```
 
@@ -271,7 +271,7 @@ Here, you use the `copy()` method to create a copy of the original list first. N
 
 However, even if you copy the list, you cannot mutate existing items inside of it directly. This is because copying is shallow and the new list will contain the same items as the original one. So, if you modify a dictionary inside the copied list, you are mutating the existing state. For example, code like this is a problem.
 
-```python
+```python skip-test
 artists_copy = artists.copy()
 artists_copy[0]["name"] = "Splinter"
 set_artists(artists_copy)
@@ -339,7 +339,7 @@ bucket_list_example = bucket_list()
 
 The problem is in code like this:
 
-```python
+```python skip-test
 my_list_copy = my_list.copy()
 artwork = next((a for a in my_list_copy if a["id"] == artworkId), None)
 artwork["seen"] = next_seen  # Problem: mutates an existing item

--- a/plugins/ui/docs/architecture.md
+++ b/plugins/ui/docs/architecture.md
@@ -8,7 +8,7 @@ Components are reusable pieces of UI that can be combined to create complex UIs.
 
 Components are created using the `@ui.component` decorator. This decorator takes a function that returns a list of components, and returns a new function that can be called to render the component. The function returned by the decorator is called a "component function". Calling the function and assigning it to a variable will create an "element" that can be rendered by the client.
 
-```python
+```python test-set=0
 from deephaven import ui
 
 
@@ -22,7 +22,7 @@ btn = my_button()
 
 Once you have declared a component, you can nest it into another component.
 
-```python
+```python test-set=0
 @ui.component
 def my_app():
     return ui.flex(ui.text("Hello, world!"), my_button(), direction="column")

--- a/plugins/ui/docs/components/action_button.md
+++ b/plugins/ui/docs/components/action_button.md
@@ -34,7 +34,7 @@ from deephaven import ui
 
 @ui.component
 def counter():
-    count, set_count = use_state(0)
+    count, set_count = ui.use_state(0)
     return ui.action_button(
         f"Pressed {count} times",
         on_press=lambda: set_count(count + 1),

--- a/plugins/ui/docs/components/button.md
+++ b/plugins/ui/docs/components/button.md
@@ -36,7 +36,7 @@ from deephaven import ui
 
 @ui.component
 def counter():
-    count, set_count = use_state(0)
+    count, set_count = ui.use_state(0)
     return ui.button(
         f"Pressed {count} times",
         on_press=lambda: set_count(count + 1),

--- a/plugins/ui/docs/components/checkbox.md
+++ b/plugins/ui/docs/components/checkbox.md
@@ -95,7 +95,7 @@ def ui_checkbox_event_example():
     selected, set_selected = ui.use_state(False)
     return ui.flex(
         ui.checkbox("Subscribe", is_selected=selected, on_change=set_selected),
-        ui.text(value="Subscribed!" if selected else "Not subscribed!"),
+        ui.text("Subscribed!" if selected else "Not subscribed!"),
         direction="column",
     )
 

--- a/plugins/ui/docs/components/checkbox_group.md
+++ b/plugins/ui/docs/components/checkbox_group.md
@@ -283,7 +283,9 @@ my_checkbox_group_contextual_help_example = ui.checkbox_group(
     "Basketball",
     "Baseball",
     label="Favorite sports",
-    contextual_help=ui.contextual_help(ui.heading("Content tips")),
+    contextual_help=ui.contextual_help(
+        ui.heading("Tips"), ui.content("Select all your favorite sports.")
+    ),
 )
 ```
 

--- a/plugins/ui/docs/components/combo_box.md
+++ b/plugins/ui/docs/components/combo_box.md
@@ -674,7 +674,9 @@ my_combo_box_contextual_help_example = ui.combo_box(
         title="Section 1",
     ),
     label="Sample Label",
-    contextual_help=ui.contextual_help(ui.heading("Content tips")),
+    contextual_help=ui.contextual_help(
+        ui.heading("Content tips"), ui.content("Tips for the content.")
+    ),
 )
 ```
 

--- a/plugins/ui/docs/components/date_field.md
+++ b/plugins/ui/docs/components/date_field.md
@@ -347,7 +347,9 @@ from deephaven import ui
 
 date_field_contextual_help_example = ui.date_field(
     label="Sample Label",
-    contextual_help=ui.contextual_help(ui.heading("Content tips")),
+    contextual_help=ui.contextual_help(
+        ui.heading("Content tips"), ui.content("Help content")
+    ),
 )
 ```
 

--- a/plugins/ui/docs/components/date_range_picker.md
+++ b/plugins/ui/docs/components/date_range_picker.md
@@ -359,7 +359,9 @@ from deephaven import ui
 
 date_range_picker_contextual_help_example = ui.date_range_picker(
     label="Sample Label",
-    contextual_help=ui.contextual_help(ui.heading("Content tips")),
+    contextual_help=ui.contextual_help(
+        ui.heading("Content tips"), ui.content("Select a date range.")
+    ),
 )
 ```
 

--- a/plugins/ui/docs/components/heading.md
+++ b/plugins/ui/docs/components/heading.md
@@ -18,7 +18,6 @@ my_heading_basic = ui.heading("Hello world")
 
 Consider using a [`text`](./text.md) component if the content does not require a specific heading level or semantic importance, such as for paragraphs or inline text.
 
-
 ## Content
 
 The heading component represents a header that inherits styling from its parent container.
@@ -38,14 +37,15 @@ def ui_heading_content_examples():
         ui.heading("Heading 6", level=6),
         ui.time_field(
             label="Sample Label",
-            contextual_help=ui.contextual_help(ui.heading("Content tips")),
+            contextual_help=ui.contextual_help(
+                ui.heading("Content tips"), ui.content("Tips go here")
+            ),
         ),
     ]
 
 
 my_heading_content_examples = ui_heading_content_examples()
 ```
-
 
 ## Color
 

--- a/plugins/ui/docs/components/image.md
+++ b/plugins/ui/docs/components/image.md
@@ -4,7 +4,7 @@
 
 ## Example
 
-```python
+```python test-set=0
 from deephaven import ui
 
 img = ui.image(src="https://i.imgur.com/Z7AzH2c.png", alt="Sky and roof")
@@ -29,7 +29,7 @@ Other options:
 - `none` renders the image in its original dimensions.
 - `scale-down` sizes the image as if `none` or `contain` were specified. Whichever results in a smaller concrete image size is selected.
 
-```python
+```python test-set=0
 def image_variants():
     return ui.flex(
         ui.view(

--- a/plugins/ui/docs/components/list_view.md
+++ b/plugins/ui/docs/components/list_view.md
@@ -101,7 +101,7 @@ my_list_view = ui_list_view()
 
 Set `selection_mode=None` or `selection_mode='NONE'` to disable selection.
 
-```python
+```python test-set=0
 from deephaven import ui
 
 
@@ -120,7 +120,7 @@ my_list_view = ui_list_view()
 
 `selection_mode` can be explicitly set to `MULTIPLE` for cases where it is dynamically defined. For example, a `ui.radio` can be used to change the selection mode.
 
-```python
+```python test-set=0
 @ui.component
 def ui_list_view():
     selection_mode, set_selection_mode = ui.use_state("NONE")

--- a/plugins/ui/docs/components/picker.md
+++ b/plugins/ui/docs/components/picker.md
@@ -39,7 +39,6 @@ Recommendations for creating pickers:
 6. When an error occurs, the help text specified in a picker should be replaced by error text.
 7. Write error messages in a concise and helpful manner, guiding users to resolve the issue. Error text should be 1-2 short, complete sentences ending with a period.
 
-
 ## Data sources
 
 We can use a Deephaven table as a data source to populate the options for pickers. A table automatically uses the first column as both the key and label. If there are duplicate keys, an error will be thrown; to avoid this, a `select_distinct` can be used on the table before using it as a picker data source.
@@ -53,8 +52,7 @@ stocks = dx.data.stocks().select_distinct("Sym")
 my_picker_table_source_example = ui.picker(stocks, label="Stock Symbol Picker")
 ```
 
-
-If you wish to specify the keys and labels manually, you can use a  `ui.item_table_source` to dynamically derive the options from a table. 
+If you wish to specify the keys and labels manually, you can use a `ui.item_table_source` to dynamically derive the options from a table.
 
 ```python
 from deephaven import ui, empty_table
@@ -76,7 +74,6 @@ item_table_source = ui.item_table_source(
 
 my_picker_item_table_source_example = ui.picker(item_table_source, label="User Picker")
 ```
-
 
 ## Labeling
 
@@ -149,7 +146,6 @@ def ui_picker_required_examples():
 my_picker_required_examples = ui_picker_required_examples()
 ```
 
-
 ## Selection
 
 In a picker, the `default_selected_key` or `selected_key` props set a selected option.
@@ -214,7 +210,6 @@ def ui_picker_key_variations():
 my_picker_key_variations = ui_picker_key_variations()
 ```
 
-
 ## HTML Forms
 
 Pickers can support a `name` prop for integration with HTML forms, allowing for easy identification of a value on form submission.
@@ -227,7 +222,6 @@ my_picker_name_example = ui.form(
     ui.flex(ui.picker(ui.item("Option 1"), ui.item("Option 2"), name="Sample Name"))
 )
 ```
-
 
 ## Sections
 
@@ -309,7 +303,6 @@ def ui_picker_loading_example():
 my_picker_loading_example = ui_picker_loading_example()
 ```
 
-
 ## Validation
 
 The `is_required` prop ensures that the user selects an option. The related `validation_behaviour` prop allows the user to specify aria or native verification.
@@ -337,7 +330,6 @@ my_picker_validation_behaviour_example = ui_picker_validation_behaviour_example(
 ## Label position
 
 By default, the position of a picker's label is above the picker, but it can be moved to the side using the `label_position` prop.
-
 
 ```python
 from deephaven import ui
@@ -442,7 +434,7 @@ picker_contextual_help_example = ui.picker(
 
 ## Custom width
 
-The `width` prop adjusts the width of a picker, and the `max_width` prop enforces a maximum width. 
+The `width` prop adjusts the width of a picker, and the `max_width` prop enforces a maximum width.
 
 ```python
 from deephaven import ui
@@ -490,7 +482,6 @@ def ui_picker_alignment_direction_examples():
         ),
         gap="size-150",
         direction="column",
-        padding=40,
     )
 
 

--- a/plugins/ui/docs/components/picker.md
+++ b/plugins/ui/docs/components/picker.md
@@ -428,7 +428,9 @@ from deephaven import ui
 picker_contextual_help_example = ui.picker(
     ui.section(ui.item("Option 1"), ui.item("Option 2"), title="Section 1"),
     label="Sample Label",
-    contextual_help=ui.contextual_help(ui.heading("Content tips")),
+    contextual_help=ui.contextual_help(
+        ui.heading("Content tips"), ui.content("Select an option.")
+    ),
 )
 ```
 

--- a/plugins/ui/docs/components/radio_group.md
+++ b/plugins/ui/docs/components/radio_group.md
@@ -1,6 +1,6 @@
 # Radio Group
 
-A radio group is a UI component that groups multiple radio buttons together, allowing users to select one option from a set of mutually exclusive choices. 
+A radio group is a UI component that groups multiple radio buttons together, allowing users to select one option from a set of mutually exclusive choices.
 
 Note that the radio component can only be used within a radio group.
 
@@ -69,7 +69,6 @@ def radio_group_value_examples():
 my_radio_group_value_examples = radio_group_value_examples()
 ```
 
-
 ## HTML Forms
 
 Radio groups can support a `name` prop for integration with HTML forms, allowing for easy identification of a value on form submission.
@@ -86,7 +85,6 @@ my_radio_group_name_example = ui.form(
     ),
 )
 ```
-
 
 ## Labeling
 
@@ -114,7 +112,6 @@ def ui_radio_group_label_examples():
 
 my_radio_group_label_examples = ui_radio_group_label_examples()
 ```
-
 
 The `is_required` prop and the `necessity_indicator` props can be used to show whether selecting an option in the radio group is required or optional.
 
@@ -152,7 +149,6 @@ def ui_radio_group_required_examples():
 my_radio_group_required_examples = ui_radio_group_required_examples()
 ```
 
-
 ## Events
 
 The `on_change` property is triggered whenever the value in the radio group selection is changed.
@@ -178,7 +174,6 @@ def ui_radio_group_on_change_example():
 
 my_radio_group_on_change_example = ui_radio_group_on_change_example()
 ```
-
 
 ## Validation
 
@@ -208,7 +203,6 @@ my_radio_group_validation_behaviour_example = (
 )
 ```
 
-
 ## Orientation
 
 While aligned vertically by default, the axis the radio buttons align with can be changed via the `orientation` prop.
@@ -225,10 +219,9 @@ my_radio_group_orientation_example = ui.radio_group(
 )
 ```
 
-
 ## Label position
 
-By default, the position of a radio group's label is above the radio group, but it can be changed to the side using the `label_position` prop. 
+By default, the position of a radio group's label is above the radio group, but it can be changed to the side using the `label_position` prop.
 
 ```python
 from deephaven import ui
@@ -241,7 +234,6 @@ my_radio_group_label_position_example = ui.radio_group(
     label_position="side",
 )
 ```
-
 
 ## Help text
 
@@ -276,7 +268,6 @@ def ui_radio_group_help_text_examples():
 my_radio_group_help_text_examples = ui_radio_group_help_text_examples()
 ```
 
-
 ## Contextual Help
 
 Using the `contextual_help` prop, a `ui.contextual_help` can be placed next to the label to provide additional information about the radio group.
@@ -289,10 +280,11 @@ my_radio_group_contextual_help_example = ui.radio_group(
     ui.radio("Wizard", value="wizard"),
     ui.radio("Dragon", value="dragon"),
     label="Favorite avatar",
-    contextual_help=ui.contextual_help(ui.heading("Content tips")),
+    contextual_help=ui.contextual_help(
+        ui.heading("Content tips"), ui.content("Select an avatar.")
+    ),
 )
 ```
-
 
 ## Disabled state
 
@@ -331,7 +323,6 @@ my_radio_group_is_read_only_example = ui.radio_group(
 
 The `is_emphasized` prop makes the selected radio button the user's accent color, adding a visual prominence to the selection.
 
-
 ```python
 from deephaven import ui
 
@@ -344,8 +335,6 @@ my_radio_group_is_emphasized_example = ui.radio_group(
     is_emphasized=True,
 )
 ```
-
-
 
 ## API Reference
 

--- a/plugins/ui/docs/components/table.md
+++ b/plugins/ui/docs/components/table.md
@@ -73,7 +73,7 @@ t = ui.table(
 Any string value for a formatting rule can be read from a column by specifying the column name as the value. Note that if a value matches a column name, it will always be used (i.e., the theme color `positive` can not be used as a direct value if there is also a column called `positive`). The following example sets the `background_color` of column `x` using the value of the `bg_color` column.
 
 ```py
-from deephaven import ui
+from deephaven import empty_table, ui
 
 _t = empty_table(100).update(["x = i", "y = sin(i)", "bg_color = x % 2 == 0 ? `positive` : `negative`"])
 

--- a/plugins/ui/docs/components/text_area.md
+++ b/plugins/ui/docs/components/text_area.md
@@ -19,13 +19,12 @@ ta = ui.text_area(
 Recommendations for creating text areas:
 
 1. Text area should include a label, or else, the text area is ambiguous and not accessible.
-2. Text area labels and placeholder text should follow sentence casing. 
+2. Text area labels and placeholder text should follow sentence casing.
 3. A text area should not use `is_quiet` styling if it has a fixed height, given that the field underline may be too far from the text to be considered part of the component.
 4. Use help text to provide instructions on input format, content, and requirements; the help text should not restate the same information as the label, or prompt a user to interact with the text area.
 5. Dynamically switch between help text and error messages based on input, ensuring both convey essential input requirements.
 
 Consider using [`text_field`](./text_field.md) for cases where concise, single-line input is required.
-
 
 ## Value
 
@@ -48,7 +47,7 @@ text_area_value_example = text_area_value_prop()
 
 ## Labeling
 
-To provide a visual label for the text area, use the `label` prop. To indicate that the text area is mandatory, use the `is_required` prop. 
+To provide a visual label for the text area, use the `label` prop. To indicate that the text area is mandatory, use the `is_required` prop.
 
 ```python
 from deephaven import ui
@@ -111,6 +110,7 @@ from deephaven import ui
 
 text_area_name_example = ui.form(ui.flex(ui.text_area(label="Comment", name="comment")))
 ```
+
 ## Quiet State
 
 The `is_quiet` prop makes text areas "quiet". This can be useful when the text area and its corresponding styling should not distract users from surrounding content.
@@ -146,10 +146,9 @@ text_area_is_read_only_example = ui.text_area(label="Sample", is_read_only=True)
 
 ## Label position
 
-By default, the position of a text area's label is above the text area, but it can be changed to the side using the `label_position` prop. 
+By default, the position of a text area's label is above the text area, but it can be changed to the side using the `label_position` prop.
 
 While labels can be placed either on top or on the side of the text area, top labels are the default recommendation. Top labels work better with longer copy, localization, and responsive layouts. Side labels are more useful when vertical space is limited.
-
 
 ```python
 from deephaven import ui
@@ -203,13 +202,16 @@ from deephaven import ui
 
 
 text_area_contextual_help_example = ui.text_area(
-    label="Comment", contextual_help=ui.contextual_help(ui.heading("Sample tips"))
+    label="Comment",
+    contextual_help=ui.contextual_help(
+        ui.heading("Sample tips"), ui.content("Enter a comment.")
+    ),
 )
 ```
 
 ## Custom width
 
-The `width` prop adjusts the width of a text area, and the `max_width` prop enforces a maximum width. 
+The `width` prop adjusts the width of a text area, and the `max_width` prop enforces a maximum width.
 
 ```python
 from deephaven import ui

--- a/plugins/ui/docs/components/time_field.md
+++ b/plugins/ui/docs/components/time_field.md
@@ -344,7 +344,9 @@ from deephaven import ui
 
 time_field_contextual_help_example = ui.time_field(
     label="Sample Label",
-    contextual_help=ui.contextual_help(ui.heading("Content tips")),
+    contextual_help=ui.contextual_help(
+        ui.heading("Content tips"), ui.content("Enter a time.")
+    ),
 )
 ```
 

--- a/plugins/ui/docs/describing/component_rules.md
+++ b/plugins/ui/docs/describing/component_rules.md
@@ -33,7 +33,7 @@ For developers familiar with React JSX, this example shows how `prop` and `child
 
 Here is the same component written in `deephaven.ui`.
 
-```python
+```python skip-test
 my_component("Hello World", prop1="value1")
 ```
 

--- a/plugins/ui/docs/describing/importing_and_exporting_components.md
+++ b/plugins/ui/docs/describing/importing_and_exporting_components.md
@@ -26,7 +26,7 @@ def table_of_contents():
 
 ### Example Import in Deephaven Core
 
-```python
+```python skip-test
 # file2.py
 # Tell the Python interpreter where the data directory is located
 import sys
@@ -75,7 +75,7 @@ def table_of_contents():
 
 ### Example Import in Deephaven Enterprise
 
-```python
+```python skip-test
 # file2.py
 # Use the notebook module to meta_import file1.py
 from deephaven_enterprise.notebook import meta_import

--- a/plugins/ui/docs/describing/ui_with_tables.md
+++ b/plugins/ui/docs/describing/ui_with_tables.md
@@ -169,7 +169,7 @@ from deephaven import time_table, ui
 @ui.component
 def ui_table_first_cell(table):
     cell_value = ui.use_cell_data(table)
-    is_even = (cell_value % 2 == 0) if not cell_value is None else False
+    is_even = (cell_value % 2 == 0) if cell_value is not None else False
     return [
         ui.heading(f"The first cell value is {cell_value}"),
         ui.text(f"Is {cell_value} even?", " ✅" if is_even else " ❌"),

--- a/plugins/ui/docs/describing/ui_with_tables.md
+++ b/plugins/ui/docs/describing/ui_with_tables.md
@@ -122,11 +122,13 @@ def ui_table_data(table):
     return ui.flex(
         table,
         ui.list_view(
-            [ui.item(str(timestamp)) for timestamp in table_data["Timestamp"]],
+            [ui.item(str(timestamp)) for timestamp in table_data["Timestamp"]]
+            if table_data
+            else None,
             selection_mode=None,
         ),
         ui.list_view(
-            [ui.item(x) for x in table_data["x"]],
+            [ui.item(x) for x in table_data["x"]] if table_data else None,
             selection_mode=None,
         ),
     )
@@ -144,11 +146,15 @@ from deephaven import time_table, ui
 @ui.component
 def ui_table_first_cell(table):
     row_data = ui.use_row_data(table)
-    return [
-        ui.heading("Latest data"),
-        ui.text(f"Timestamp: {row_data['Timestamp']}"),
-        ui.text(f"x: {row_data['x']}"),
-    ]
+    return (
+        [
+            ui.heading("Latest data"),
+            ui.text(f"Timestamp: {row_data['Timestamp']}"),
+            ui.text(f"x: {row_data['x']}"),
+        ]
+        if row_data
+        else ui.heading("Waiting for data...")
+    )
 
 
 table_first_cell2 = ui_table_first_cell(time_table("PT1s").update("x=i").reverse())
@@ -163,7 +169,7 @@ from deephaven import time_table, ui
 @ui.component
 def ui_table_first_cell(table):
     cell_value = ui.use_cell_data(table)
-    is_even = cell_value % 2 == 0
+    is_even = (cell_value % 2 == 0) if not cell_value is None else False
     return [
         ui.heading(f"The first cell value is {cell_value}"),
         ui.text(f"Is {cell_value} even?", " ✅" if is_even else " ❌"),

--- a/plugins/ui/docs/hooks/use_boolean.md
+++ b/plugins/ui/docs/hooks/use_boolean.md
@@ -38,19 +38,19 @@ my_boolean_example = ui_boolean_example()
 
 `use_boolean` takes an optional parameter that intializes the value to an initial value:
 
-```python
+```python skip-test
 value, set_value = ui.use_boolean(True)
 ```
 
 If the parameter is omitted, the value will initalize to `False`:
 
-```python
+```python skip-test
 value, set_value = ui.use_boolean()
 ```
 
 If you pass a function into the initializer, it will be called on the first initialization. This is useful if you have an expensive computation to determine the value:
 
-```python
+```python skip-test
 value, set_value = ui.use_boolean(lambda: complex_function())
 ```
 

--- a/plugins/ui/docs/hooks/use_effect.md
+++ b/plugins/ui/docs/hooks/use_effect.md
@@ -194,7 +194,7 @@ An effect will run after the initial render (mount) and any subsequent render wh
 
 In this example below, we connect to a server when the host or scheme changes. The effect will run when the component is mounted, and when the host or scheme is changed:
 
-```python
+```python skip-test
 @ui.component
 def ui_server(scheme: str):  # `scheme` is a reactive prop passed in
     host, set_host = ui.use_state("localhost")  # `host` is a reactive state variable
@@ -215,7 +215,7 @@ def ui_server(scheme: str):  # `scheme` is a reactive prop passed in
 
 However, if we specify an empty dependency list, the effect will only run once when the component is mounted, which is probably not what we want:
 
-```python
+```python skip-test
 @ui.component
 def ui_server(scheme: str):
     host, set_host = ui.use_state("localhost")
@@ -236,7 +236,7 @@ def ui_server(scheme: str):
 
 If you use constant values in your effect, you can omit them from the dependency list. If the `host` was instead a constant outside of the component and not reactive, you can omit it from the dependency list:
 
-```python
+```python skip-test
 host = "localhost"
 
 
@@ -257,7 +257,7 @@ def ui_server(scheme: str):
 
 If your effect doesn't use any reactive values, its dependency list should be empty:
 
-```python
+```python skip-test
 scheme = "https"
 host = "localhost"
 
@@ -283,7 +283,7 @@ def ui_server():
 
 If you specify dependencies, the effect will run on initial render and on subsequent re-renders when the dependencies change.
 
-```python
+```python skip-test
 ui.use_effect(..., [scheme, host])  # Runs again when host or scheme changes
 ```
 
@@ -331,7 +331,7 @@ app = ui_app()
 
 If you specify an empty dependency list, the effect will only run once when the component is mounted, and cleanup on unmount. It will not re-run when any reactive values change.
 
-```python
+```python skip-test
 ui.use_effect(..., [])  # Does not run again
 ```
 
@@ -375,7 +375,7 @@ app = ui_app()
 
 If you specify no dependency list, the effect will run after every single render.
 
-```python
+```python skip-test
 ui.use_effect(...)  # Runs after every render
 ```
 
@@ -423,7 +423,7 @@ app = ui_app()
 
 If your effect depends on an object or function that is recreated on every render, you may want to memoize it to avoid unnecessary re-renders.
 
-```python
+```python skip-test
 class ServerDetails:
     scheme: str
     host: str
@@ -458,7 +458,7 @@ def ui_server():
 
 To avoid this, declare the object inside the effect:
 
-```python
+```python skip-test
 @ui.component
 def ui_server():
     message, set_message = ui.use_state("")
@@ -526,7 +526,7 @@ server = ui_server()
 
 Similarly, if your effect depends on a function declared within the component, you may want to memoize it to avoid unnecessary re-renders.
 
-```python
+```python skip-test
 @ui.component
 def ui_server():
     message, set_message = ui.use_state("")
@@ -551,7 +551,7 @@ def ui_server():
 
 To avoid this, move the function inside the effect:
 
-```python
+```python skip-test
 @ui.component
 def ui_server():
     message, set_message = ui.use_state("")

--- a/plugins/ui/docs/hooks/use_effect.md
+++ b/plugins/ui/docs/hooks/use_effect.md
@@ -440,7 +440,7 @@ class ServerDetails:
 def ui_server():
     message, set_message = ui.use_state("")
 
-    # 🚩 this creates a new object on every re-render
+    # ❌ this creates a new object on every re-render
     details = ServerDetails("https", "localhost")
 
     def disconnect():
@@ -450,7 +450,7 @@ def ui_server():
         print(f"Connected to {details}")
         return disconnect
 
-    # 🚩 As a result, these dependencies are different on every re-render and the effect will always run again
+    # ❌ As a result, these dependencies are different on every re-render and the effect will always run again
     ui.use_effect(connect, [details])
 
     # ...
@@ -531,7 +531,7 @@ Similarly, if your effect depends on a function declared within the component, y
 def ui_server():
     message, set_message = ui.use_state("")
 
-    # 🚩 this function is a new function on every re-render
+    # ❌ this function is a new function on every re-render
     def create_details():
         return ServerDetails("https", "localhost")
 
@@ -543,7 +543,7 @@ def ui_server():
         print(f"Connected to {details}")
         return lambda: disconnect(details)
 
-    # 🚩 As a result, these dependencies are different on every re-render and the effect will always run again
+    # ❌ As a result, these dependencies are different on every re-render and the effect will always run again
     ui.use_effect(connect, [create_details])
 
     # ...

--- a/plugins/ui/docs/hooks/use_row_data.md
+++ b/plugins/ui/docs/hooks/use_row_data.md
@@ -11,7 +11,7 @@ from deephaven import time_table, ui
 @ui.component
 def ui_table_row(table):
     row_data = ui.use_row_data(table)
-    if row_data == None:
+    if row_data is None:
         return ui.heading("No data yet.")
     return ui.heading(f"Row data is {row_data}. Value of X is {row_data['x']}")
 

--- a/plugins/ui/docs/hooks/use_row_data.md
+++ b/plugins/ui/docs/hooks/use_row_data.md
@@ -59,7 +59,7 @@ import datetime as dt
 
 @ui.component
 def ui_table_row(table):
-    row_data = ui.use_row_data(table, sentinel={"Timestamp": "No data yet."})
+    row_data = ui.use_row_data(table, sentinel={"x": "No data yet."})
     return ui.heading(f"Row data: {row_data}. Value of 'x' is {row_data['x']}")
 
 

--- a/plugins/ui/docs/hooks/use_row_data.md
+++ b/plugins/ui/docs/hooks/use_row_data.md
@@ -11,7 +11,7 @@ from deephaven import time_table, ui
 @ui.component
 def ui_table_row(table):
     row_data = ui.use_row_data(table)
-    if row_data == ():
+    if row_data == None:
         return ui.heading("No data yet.")
     return ui.heading(f"Row data is {row_data}. Value of X is {row_data['x']}")
 

--- a/plugins/ui/docs/hooks/use_row_list.md
+++ b/plugins/ui/docs/hooks/use_row_list.md
@@ -11,7 +11,7 @@ from deephaven import time_table, ui
 @ui.component
 def ui_table_row_list(table):
     row_list = ui.use_row_list(table)
-    if row_list == None:
+    if row_list is None:
         return ui.heading("No data yet.")
     return ui.heading(f"The row list is {row_list}. Value of X is {row_list[1]}.")
 

--- a/plugins/ui/docs/hooks/use_row_list.md
+++ b/plugins/ui/docs/hooks/use_row_list.md
@@ -11,7 +11,7 @@ from deephaven import time_table, ui
 @ui.component
 def ui_table_row_list(table):
     row_list = ui.use_row_list(table)
-    if row_list == ():
+    if row_list == None:
         return ui.heading("No data yet.")
     return ui.heading(f"The row list is {row_list}. Value of X is {row_list[1]}.")
 

--- a/plugins/ui/docs/hooks/use_state.md
+++ b/plugins/ui/docs/hooks/use_state.md
@@ -30,19 +30,19 @@ Recommendations for using state and creating state variables:
 
 `use_state` takes a parameter that intializes the state to an initial value:
 
-```python
+```python skip-test
 answer, set_answer = ui.use_state(42)
 ```
 
 In the example above, `set_answer` initializes to the value `42`. If you pass a function into the initializer, it will be called on the first initialization. This is useful if you have an expensive computation you want to set as your state:
 
-```python
+```python skip-test
 complex_item, set_complex_item = ui.use_state(lambda: complex_function())
 ```
 
 Note the initializer function does not take any parameters, and should be deterministic. If you wish to store a function in your state, return that function as a result of a function:
 
-```python
+```python skip-test
 operation, set_operation = ui.use_state(lambda: math.sin)
 ```
 
@@ -94,7 +94,7 @@ result = my_component()
 
 You can update the state using the previous value. However, let's say you have a function to update the count by three:
 
-```python
+```python skip-test
 def handle_press():
     set_count(count + 1)  # set_age(0 + 1)
     set_count(count + 1)  # set_age(0 + 1)
@@ -103,7 +103,7 @@ def handle_press():
 
 You can instead pass in an updater function that will allow you to use the previous value:
 
-```python
+```python skip-test
 def handle_press():
     set_count(lambda c: c + 1)  # set_age(0 + 1)
     set_count(lambda c: c + 1)  # set_age(1 + 1)

--- a/plugins/ui/docs/managing-state/choose-the-state-structure.md
+++ b/plugins/ui/docs/managing-state/choose-the-state-structure.md
@@ -20,14 +20,14 @@ At times, you may be uncertain whether to use a single state variable or multipl
 
 Should you use this?
 
-```python
+```python skip-test
 start_date, set_start_date = ui.use_state("2020-02-03")
 end_date, set_end_date = ui.use_state("2020-02-08")
 ```
 
 Or should you use this?
 
-```python
+```python skip-test
 date_range, set_date_range = ui.use_state({"start": "2020-02-03", "end": "2020-02-08"})
 ```
 
@@ -133,7 +133,7 @@ feedback_form_example = feedback_form()
 
 You can still declare some constants for readability:
 
-```python
+```python skip-test
 is_sending = status == "sending"
 is_sent = status == "sent"
 ```
@@ -217,7 +217,7 @@ name_input_example = name_input()
 
 Here, `full_name` is not a state variable. Instead, it is calculated during render:
 
-```python
+```python skip-test
 full_name = f"{first_name} {last_name}"
 ```
 

--- a/plugins/ui/docs/managing-state/preserving-and-resetting-state.md
+++ b/plugins/ui/docs/managing-state/preserving-and-resetting-state.md
@@ -335,7 +335,7 @@ scoreboard_example = scoreboard()
 
 Switching between John and Jill does not preserve the state. This is because they have different keys:
 
-```python
+```python skip-test
 counter("John", key="John") if is_player1 else counter("Jill", key="Jill")
 ```
 

--- a/plugins/ui/docs/managing-state/react-to-input-with-state.md
+++ b/plugins/ui/docs/managing-state/react-to-input-with-state.md
@@ -133,14 +133,14 @@ Next you’ll need to represent the visual states of your component in memory wi
 
 Start with the state that absolutely must be there. For example, you’ll need to store the answer for the input, and the error (if it exists) to store the last error:
 
-```python
+```python skip-test
 answer, set_answer = ui.use_state("")
 error, set_error = ui.use_state(None)
 ```
 
 Then, you’ll need a state variable representing which one of the visual states that you want to display. Naively, you can represent each state as a boolean value. There are issues with this which we will cover later.
 
-```python
+```python skip-test
 is_empty, set_is_empty = ui.use_state(True)
 is_typing, set_is_typing = ui.use_state(False)
 is_submitting, set_is_submitting = ui.use_state(False)
@@ -160,7 +160,7 @@ Here are some questions to consider about your state variables:
 
 After this clean-up, you’re left with three essential state variables, down from seven.
 
-```python
+```python skip-test
 answer, set_answer = ui.use_state("")
 error, set_error = ui.use_state(None)
 status, set_status = ui.use_state("typing")  # "typing", "submitting", or "success"

--- a/plugins/ui/docs/managing-state/share-state-between-components.md
+++ b/plugins/ui/docs/managing-state/share-state-between-components.md
@@ -60,7 +60,7 @@ This approach will enable the `accordion` component to manage both `info` panels
 
 You will delegate control of the `info` panel’s `is_active` state to its parent component. This means the parent component will pass `is_active` to the `info` panel as a prop. Start by removing this line from the `info` component:
 
-```python
+```python skip-test
 is_active, set_is_active = ui.use_state(False)
 ```
 
@@ -118,7 +118,7 @@ Lifting state up often changes the nature of the state you are managing.
 
 In this scenario, only one `info` panel should be active at any given time. Therefore, the parent component must track which `info` is currently active. Instead of using a boolean value, it can use a number representing the index of the active `info` for the state variable:
 
-```python
+```python skip-test
 active, set_active = ui.use_state(0)
 ```
 
@@ -126,7 +126,7 @@ When `active` is `0`, the first `info` is active. When it is `1`, the second `in
 
 Clicking the “Show” button in any panel should change `active` in the `accordion`. An `info` cannot directly set the `active` state because it is defined within the `accordion`. The `accordion` component must explicitly allow the `info` component to change its state by passing an event handler as a prop:
 
-```python
+```python skip-test
 info(
     "Apple", "Red and delicious", is_active=active == 0, on_show=lambda: set_active(0)
 ),

--- a/plugins/ui/docs/tutorial.md
+++ b/plugins/ui/docs/tutorial.md
@@ -8,11 +8,11 @@ This guide shows you how to build a dashboard with [`deephaven.ui`](https://gith
 - Finally, you'll embed your custom component into your dashboard.
 
 ![img](_assets/deephaven-ui-crash-course/iris_species_dashboard_final.png)
-To follow along, you need the [`deephaven.ui`](https://pypi.org/project/deephaven-plugin-ui/) package and simulated data and charts from [`deephaven.plot.express`](https://pypi.org/project/deephaven-plugin-ui/). Both of these packages are included in the default setup. 
+To follow along, you need the [`deephaven.ui`](https://pypi.org/project/deephaven-plugin-ui/) package and simulated data and charts from [`deephaven.plot.express`](https://pypi.org/project/deephaven-plugin-ui/). Both of these packages are included in the default setup.
 
 Import the simulated `iris` data with this script:
 
-```py
+```py test-set=0
 from deephaven import ui
 import deephaven.plot.express as dx
 
@@ -21,7 +21,7 @@ iris = dx.data.iris()
 
 ![img](_assets/deephaven-ui-crash-course/iris.png)
 
-In this dataset, the `Species` column is a categorical column with three values: `setosa`, `Versicolor`, and `Virginia`. The `SepalLength`, `SepalWidth`, `PetalLength`, and `PetalWidth` columns are continuous numerical columns that contain measurements of the sepal and petal of an iris flower. The `Timestamp` column is also useful for ordering the data. 
+In this dataset, the `Species` column is a categorical column with three values: `setosa`, `Versicolor`, and `Virginia`. The `SepalLength`, `SepalWidth`, `PetalLength`, and `PetalWidth` columns are continuous numerical columns that contain measurements of the sepal and petal of an iris flower. The `Timestamp` column is also useful for ordering the data.
 
 You'll mostly focus on `SepalLength` and `SepalWidth` in this guide.
 
@@ -40,7 +40,7 @@ With `iris`, create a `ui.table` that:
 3. Hides the `PetalLength`, `PetalWidth`, and `SpeciesID` columns.
 4. Uses the compact table density so you can see as many rows as possible.
 
-```py
+```py test-set=0
 ui_iris = ui.table(
   iris,
   reverse=True,
@@ -56,7 +56,7 @@ ui_iris = ui.table(
 
 Charts from Deephaven Plotly Express (`dx`) have no `deephaven.ui` specific wrapping and are added directly. Create a [`dx.scatter`](/core/plotly/docs/scatter) chart that compares `SepalLength` and `SepalWidth` by `Species`.
 
-```py
+```py test-set=0
 scatter_by_species = dx.scatter(iris, x = "SepalLength", y = "SepalWidth", by="Species")
 ```
 
@@ -66,7 +66,7 @@ scatter_by_species = dx.scatter(iris, x = "SepalLength", y = "SepalWidth", by="S
 
 The [`ui.text`](components/text.md) component adds basic text. Create text to accompany the chart and table.
 
-```py
+```py test-set=0
 sepal_text = ui.text("SepalLength vs. SepalWidth By Species")
 ```
 
@@ -77,7 +77,7 @@ sepal_text = ui.text("SepalLength vs. SepalWidth By Species")
 Wrap your chart and `ui.table` in a [`ui.flex`](components/flex.md) component. `ui.flex` is an implementation of [Flexbox](https://developer.mozilla.org/en-US/docs/Learn/CSS/CSS_layout/Flexbox) that enables responsive layouts that adjust as you resize panels.
 Items within a `ui.flex` component stretch and shrink based on available space.
 
-```py
+```py test-set=0
 sepal_flex = ui.flex(ui_iris, scatter_by_species)
 ```
 
@@ -85,7 +85,7 @@ sepal_flex = ui.flex(ui_iris, scatter_by_species)
 
 The `direction` of `sepal_flex` is `"row"`. Add `sepal_text` and `sepal_flex` to another panel, with a `direction` of `"column"`.
 
-```py
+```py test-set=0
 sepal_flex_column = ui.flex(sepal_text, sepal_flex, direction="column")
 ```
 
@@ -97,7 +97,7 @@ The [`ui.tabs`](components/tabs.md) component enables tabs within a panel. Creat
 Histograms are useful to display comparisons of data distributions, so create [`dx.histogram`](/core/plotly/docs/histogram) charts of the columns of interest, `SepalLength` and `SepalWidth`, by `Species`.
 Create `ui.tab` elements for `sepal_flex`, `sepal_length_hist`, and `sepal_width_hist`, then pass them to `ui.tabs` to switch between different views.
 
-```py
+```py test-set=0
 sepal_length_hist = dx.histogram(iris, x="SepalLength", by="Species")
 sepal_width_hist = dx.histogram(iris, x="SepalWidth", by="Species")
 
@@ -115,7 +115,7 @@ sepal_flex_tabs = ui.flex(sepal_text, sepal_tabs, direction="column")
 
 [`ui.markdown`](components/markdown.md) components allow you to provide text in a markdown format. Create an informational panel with markdown text.
 
-```py
+```py test-set=0
 about_markdown = ui.markdown(r"""
 ### Iris Dashboard
 
@@ -186,7 +186,7 @@ Explore the Iris dataset with **deephaven.ui**
 
 Before that, create a `ui.panel` manually to provide a `title`.
 
-```py
+```py test-set=0
 sepal_panel = ui.panel(sepal_flex_tabs, title="Sepal Panel")
 iris_dashboard = ui.dashboard(sepal_panel)
 ```
@@ -197,7 +197,7 @@ You now have a one-panel dashboard.
 
 You can create a default layout with multiple panels. Create a panel for `about_markdown` so you can give it a `title`.
 
-```py
+```py test-set=0
 about_panel = ui.panel(about_markdown, title="About")
 ```
 
@@ -207,7 +207,7 @@ about_panel = ui.panel(about_markdown, title="About")
 
 One way to create a default layout is by wrapping your panels in a [`ui.row`](components/dashboard.md) component.
 
-```py
+```py test-set=0
 iris_dashboard_row = ui.dashboard(ui.row(about_panel, sepal_panel))
 ```
 
@@ -217,7 +217,7 @@ iris_dashboard_row = ui.dashboard(ui.row(about_panel, sepal_panel))
 
 Another way to create a default layout is with [`ui.column`](components/dashboard.md).
 
-```py
+```py test-set=0
 iris_dashboard_column = ui.dashboard(ui.column(about_panel, sepal_panel))
 ```
 
@@ -230,7 +230,7 @@ One more way to create a default layout is with [`ui.stack`](components/dashboar
 Create tabs that show the average, max, and min values of `SepalLength`, `SepalWidth`, `PetalLength`, and `PetalWidth` by `Species`.
 You can compare a specific statistic across the different `Species` within the same panel or move between panels to compare different statistics across `Species`.
 
-```py
+```py test-set=0
 from deephaven import agg
 
 iris_avg = iris.agg_by([agg.avg(cols=["SepalLength", "SepalWidth", "PetalLength", "PetalWidth"])], by=["Species"])
@@ -242,7 +242,7 @@ ui_iris_max = ui.panel(iris_max, title="Max")
 ui_iris_min = ui.panel(iris_min, title="Min")
 
 iris_agg_stack = ui.stack(ui_iris_avg, ui_iris_max, ui_iris_min)
-  
+
 iris_dashboard_stack = ui.dashboard(iris_agg_stack)
 ```
 
@@ -257,7 +257,7 @@ Since this walkthrough investigates `SepalLength` and `SepalWidth`, this section
 
 A custom component uses the `ui.component` decorator. The decorator signals to the `deephaven.ui` rendering engine that this component needs to be rendered. Create a function with the `ui.component` decorator that returns `"Hello, World!"`.
 
-```py
+```py test-set=0
 @ui.component
 def custom_component():
   return "Hello, World!"
@@ -269,9 +269,9 @@ custom_panel = custom_component()
 
 ### Picker
 
-A [`ui.picker`](components/picker.md) allows you to select options from a list. 
+A [`ui.picker`](components/picker.md) allows you to select options from a list.
 
-```py
+```py test-set=0
 @ui.component
 def species_panel():
   species_picker = ui.picker("setosa", "versicolor", "virginica")
@@ -290,7 +290,7 @@ picker_panel = species_panel()
 > [!NOTE]
 > It’s important to filter your table down to the distinct values you want. The `ui.picker` does not do this for you.
 
-```py
+```py test-set=0
 species_table = iris.view("Species").select_distinct()
 
 @ui.component
@@ -310,10 +310,10 @@ The [`ui.use_state`](hooks/use_state.md) hook is how you’ll enable interactivi
 Next, modify your picker to take the `species` and `set_species` from the hook you just defined using `on_change` and `selected_key`. `on_change` is called whenever an option is selected. `selected_key` is the currently selected option. Using these makes the component controlled, meaning that the `selected_key` is controlled outside of the `ui.picker` itself. This allows you to use the `selected_key` in other ways such as filtering a table.
 
 > [!WARNING]
-> Hooks like `ui.use_state` are only available in components decorated with `ui.component`. 
+> Hooks like `ui.use_state` are only available in components decorated with `ui.component`.
 > Additionally, hooks should not be called conditionally within a component. Create a new component if conditional rendering is needed.
 
-```py
+```py test-set=0
 @ui.component
 def species_panel():
   species, set_species = ui.use_state()
@@ -333,7 +333,7 @@ Now, your picker is controlled by the rendering engine and updates as you pick v
 Now, add a table filtered on this value and a chart that uses this filtered table. Return them with the picker.
 You'll create a `dx.heatmap`, which shows the joint density of `SepalLength` and `SepalWidth` (the variables of interest) filtered by `Species`.
 
-```py
+```py test-set=0
 @ui.component
 def species_panel():
   species, set_species = ui.use_state()
@@ -347,7 +347,7 @@ def species_panel():
   filtered_table = iris.where("Species = species")
 
   heatmap = dx.density_heatmap(filtered_table, x="SepalLength", y="SepalWidth")
-  
+
   return ui.panel(ui.flex(species_picker, heatmap, direction="column"), title="Investigate Species")
 
 species_picker_panel = species_panel()
@@ -359,7 +359,7 @@ species_picker_panel = species_panel()
 
 Currently, an empty table and chart appear if no species is selected. For a more user-friendly experience, add a [`ui.illustrated_message`](components/illustrated_message.md) component to display instead if no `species` is selected.
 
-```py
+```py test-set=0
 @ui.component
 def species_panel():
   species, set_species = ui.use_state()
@@ -389,23 +389,23 @@ species_picker_panel = species_panel()
 
 ![img](_assets/deephaven-ui-crash-course/species_picker_panel_illustrated.png)
 
-
 ### Utilizing custom components
 
 Next, embed your custom component in your dashboard.
 
-```python
+```python test-set=0
 iris_species_dashboard = ui.dashboard(
     ui.column(
         ui.row(about_panel, iris_agg_stack), ui.row(sepal_panel, species_picker_panel)
     )
 )
 ```
+
 ![img](_assets/deephaven-ui-crash-course/iris_species_dashboard.png)
 
 The top row contains lots of empty space. Resize the height of the top row to 1 and the bottom row to 2 for a ratio of 1:2, so the bottom row is twice the height of the top row.
 
-```py
+```py test-set=0
 iris_species_dashboard_resized = ui.dashboard(ui.column(ui.row(about_panel, iris_agg_stack, height=1), ui.row(sepal_panel, species_picker_panel, height=2)))
 ```
 
@@ -421,7 +421,7 @@ Recreate the `sepal_flex_tabs` panel within the `create_sepal_panel` function, w
 - Pull the `Species` value from the row data and set it with `set_species`.
 - Then, create `sepal_panel` with `create_sepal_panel`, passing `set_species` to it.
 
-```python
+```python test-set=0
 def create_sepal_panel(set_species):
     ui_iris = ui.table(
         iris,
@@ -491,6 +491,7 @@ You've got a density heatmap that shows the density of `SepalLength` and `SepalW
 
 `deephaven.ui` provides hooks to access table data. Each hook provides access to a specific part of the table and is updated when the table changes.
 The hooks are:
+
 - [`ui.use_cell_data`](hooks/use_cell_data.md) - Accesses a single cell value.
 - [`ui.use_row_data`](hooks/use_row_data.md) - Accesses a row of data.
 - [`ui.use_row_list`](hooks/use_row_list.md) - Accesses a row as a list.
@@ -503,7 +504,7 @@ The hooks are:
 Create a custom component that pulls the min, max, and average values for `SepalLength` and `SepalWidth` for the selected `Species`.
 To display the values, wrap them in [`ui.badge`](components/badge.md) components, which draw attention to specific values.
 
-```python
+```python test-set=0
 @ui.component
 def summary_badges(species):
     # Filter the tables to the selected species
@@ -582,7 +583,7 @@ iris_species_dashboard_badge = ui.dashboard(create_species_dashboard())
 Since you've added badges to the dashboard, the `dx.heatmap` is recreated every time any of the badges change, but only needs to be recreated when the `Species` changes.
 Heatmap is a fairly expensive chart to create (it requires a filtered table in this case) and changes rarely, so pull the heatmap creation into a separate function and use `ui.use_memo` to cache the heatmap creation.
 
-```python
+```python test-set=0
 def create_heatmap(species):
     heatmap = ui.illustrated_message(
         ui.icon("vsFilter"),
@@ -710,16 +711,16 @@ def create_sepal_panel(set_species):
   )
 
   sepal_flex_tabs = ui.flex(sepal_text, sepal_tabs, direction="column")
-  
+
   return ui.panel(sepal_flex_tabs, title="Sepal Panel")
-  
+
 @ui.component
 def summary_badges(species):
   # Filter the tables to the selected species
   species_min = iris_min.where("Species=species")
   species_max = iris_max.where("Species=species")
   species_avg = iris_avg.where("Species=species")
-  
+
   # Pull the desired columns from the tables before using the hooks
   sepal_length_min = ui.use_cell_data(species_min.view(["SepalLength"]))
   sepal_width_min = ui.use_cell_data(species_min.view(["SepalWidth"]))
@@ -729,12 +730,12 @@ def summary_badges(species):
   sepal_width_avg = ui.use_cell_data(species_avg.view(["SepalWidth"]))
 
   # format the values to 3 decimal places
-  # set flex_grow to 0 to prevent the badges from growing 
+  # set flex_grow to 0 to prevent the badges from growing
   return ui.flex(
-    ui.badge(f"SepalLength Min: {sepal_length_min:.3f}", variant="info"), 
+    ui.badge(f"SepalLength Min: {sepal_length_min:.3f}", variant="info"),
     ui.badge(f"SepalLength Max: {sepal_length_max:.3f}", variant="info"),
     ui.badge(f"SepalLength Avg: {sepal_length_avg:.3f}", variant="info"),
-    ui.badge(f"SepalWidth Min: {sepal_width_min:.3f}", variant="info"), 
+    ui.badge(f"SepalWidth Min: {sepal_width_min:.3f}", variant="info"),
     ui.badge(f"SepalWidth Max: {sepal_width_max:.3f}", variant="info"),
     ui.badge(f"SepalWidth Avg: {sepal_width_avg:.3f}", variant="info"),
     flex_grow=0
@@ -747,13 +748,13 @@ def create_heatmap(species):
         ui.content("Select a species to display filtered table and chart."),
         width="100%",
     )
-  
+
     if species:
         filtered_table = iris.where("Species = species")
         heatmap = dx.density_heatmap(filtered_table, x="SepalLength", y="SepalWidth")
-      
+
     return heatmap
-  
+
 @ui.component
 def create_species_dashboard():
     species, set_species = ui.use_state()
@@ -763,7 +764,7 @@ def create_species_dashboard():
         selected_key=species,
         label="Current Species",
     )
-  
+
     heatmap = ui.use_memo(lambda: create_heatmap(species), [species])
 
     badges = summary_badges(species) if species else None


### PR DESCRIPTION
- Found errors by running the salmon snapshotter tool against the deephaven.ui docs
- Some of the common errors:
  - Add `test-set` for blocks that should run together
  - Add `skip-test` for tests that should be skipped
  - Some missing imports in a couple
  - Using `use_state` without prefixing with `ui.`
  - Widgets accessing table data when None
  - Unicode character that isn't UTF-8 compatible that we probably shouldn't use in our examples