### PR TITLE
docs: Fix tutorial doc to not display error

### DIFF
--- a/plugins/ui/docs/tutorial.md
+++ b/plugins/ui/docs/tutorial.md
@@ -404,7 +404,12 @@ iris_species_dashboard = ui.dashboard(
 The top row contains lots of empty space. Resize the height of the top row to 1 and the bottom row to 2 for a ratio of 1:2, so the bottom row is twice the height of the top row.
 
 ```py test-set=0
-iris_species_dashboard_resized = ui.dashboard(ui.column(ui.row(about_panel, ui.stack(ui_iris_avg, ui_iris_max, ui_iris_min), height=1), ui.row(sepal_panel, species_picker_panel, height=2)))
+iris_species_dashboard_resized = ui.dashboard(
+    ui.column(
+        ui.row(about_panel, ui.stack(ui_iris_avg, ui_iris_max, ui_iris_min), height=1),
+        ui.row(sepal_panel, species_picker_panel, height=2),
+    )
+)
 ```
 
 ![img](_assets/deephaven-ui-crash-course/iris_species_dashboard_resized.png)

--- a/plugins/ui/docs/tutorial.md
+++ b/plugins/ui/docs/tutorial.md
@@ -241,9 +241,7 @@ ui_iris_avg = ui.panel(iris_avg, title="Average")
 ui_iris_max = ui.panel(iris_max, title="Max")
 ui_iris_min = ui.panel(iris_min, title="Min")
 
-_iris_agg_stack = ui.stack(ui_iris_avg, ui_iris_max, ui_iris_min)
-
-iris_dashboard_stack = ui.dashboard(_iris_agg_stack)
+iris_dashboard_stack = ui.dashboard(ui.stack(ui_iris_avg, ui_iris_max, ui_iris_min))
 ```
 
 ![img](_assets/deephaven-ui-crash-course/iris_dashboard_stack.png)
@@ -396,7 +394,7 @@ Next, embed your custom component in your dashboard.
 ```python test-set=0
 iris_species_dashboard = ui.dashboard(
     ui.column(
-        ui.row(about_panel, _iris_agg_stack), ui.row(sepal_panel, species_picker_panel)
+        ui.row(about_panel, ui.stack(ui_iris_avg, ui_iris_max, ui_iris_min)), ui.row(sepal_panel, species_picker_panel)
     )
 )
 ```
@@ -406,7 +404,7 @@ iris_species_dashboard = ui.dashboard(
 The top row contains lots of empty space. Resize the height of the top row to 1 and the bottom row to 2 for a ratio of 1:2, so the bottom row is twice the height of the top row.
 
 ```py test-set=0
-iris_species_dashboard_resized = ui.dashboard(ui.column(ui.row(about_panel, _iris_agg_stack, height=1), ui.row(sepal_panel, species_picker_panel, height=2)))
+iris_species_dashboard_resized = ui.dashboard(ui.column(ui.row(about_panel, ui.stack(ui_iris_avg, ui_iris_max, ui_iris_min), height=1), ui.row(sepal_panel, species_picker_panel, height=2)))
 ```
 
 ![img](_assets/deephaven-ui-crash-course/iris_species_dashboard_resized.png)
@@ -475,7 +473,7 @@ def create_species_dashboard():
     sepal_panel = create_sepal_panel(set_species)
 
     return ui.column(
-        ui.row(about_panel, _iris_agg_stack, height=1),
+        ui.row(about_panel, ui.stack(ui_iris_avg, ui_iris_max, ui_iris_min), height=1),
         ui.row(sepal_panel, species_panel, height=2),
     )
 
@@ -567,7 +565,7 @@ def create_species_dashboard():
     sepal_panel = create_sepal_panel(set_species)
 
     return ui.column(
-        ui.row(about_panel, _iris_agg_stack, height=1),
+        ui.row(about_panel, ui.stack(ui_iris_avg, ui_iris_max, ui_iris_min), height=1),
         ui.row(sepal_panel, species_panel, height=2),
     )
 
@@ -621,7 +619,7 @@ def create_species_dashboard():
     sepal_panel = create_sepal_panel(set_species)
 
     return ui.column(
-        ui.row(about_panel, _iris_agg_stack, height=1),
+        ui.row(about_panel, ui.stack(ui_iris_avg, ui_iris_max, ui_iris_min), height=1),
         ui.row(sepal_panel, species_panel, height=2),
     )
 
@@ -688,7 +686,7 @@ ui_iris_avg = ui.panel(iris_avg, title="Average")
 ui_iris_max = ui.panel(iris_max, title="Max")
 ui_iris_min = ui.panel(iris_min, title="Min")
 
-_iris_agg_stack = ui.stack(ui_iris_avg, ui_iris_max, ui_iris_min)
+ui.stack(ui_iris_avg, ui_iris_max, ui_iris_min) = ui.stack(ui_iris_avg, ui_iris_max, ui_iris_min)
 
 species_table = iris.view("Species").select_distinct()
 
@@ -777,7 +775,7 @@ def create_species_dashboard():
     sepal_panel = create_sepal_panel(set_species)
 
     return ui.column(
-        ui.row(about_panel, _iris_agg_stack, height=1),
+        ui.row(about_panel, ui.stack(ui_iris_avg, ui_iris_max, ui_iris_min), height=1),
         ui.row(sepal_panel, species_panel, height=2),
     )
 

--- a/plugins/ui/docs/tutorial.md
+++ b/plugins/ui/docs/tutorial.md
@@ -241,9 +241,9 @@ ui_iris_avg = ui.panel(iris_avg, title="Average")
 ui_iris_max = ui.panel(iris_max, title="Max")
 ui_iris_min = ui.panel(iris_min, title="Min")
 
-iris_agg_stack = ui.stack(ui_iris_avg, ui_iris_max, ui_iris_min)
+_iris_agg_stack = ui.stack(ui_iris_avg, ui_iris_max, ui_iris_min)
 
-iris_dashboard_stack = ui.dashboard(iris_agg_stack)
+iris_dashboard_stack = ui.dashboard(_iris_agg_stack)
 ```
 
 ![img](_assets/deephaven-ui-crash-course/iris_dashboard_stack.png)
@@ -396,7 +396,7 @@ Next, embed your custom component in your dashboard.
 ```python test-set=0
 iris_species_dashboard = ui.dashboard(
     ui.column(
-        ui.row(about_panel, iris_agg_stack), ui.row(sepal_panel, species_picker_panel)
+        ui.row(about_panel, _iris_agg_stack), ui.row(sepal_panel, species_picker_panel)
     )
 )
 ```
@@ -406,7 +406,7 @@ iris_species_dashboard = ui.dashboard(
 The top row contains lots of empty space. Resize the height of the top row to 1 and the bottom row to 2 for a ratio of 1:2, so the bottom row is twice the height of the top row.
 
 ```py test-set=0
-iris_species_dashboard_resized = ui.dashboard(ui.column(ui.row(about_panel, iris_agg_stack, height=1), ui.row(sepal_panel, species_picker_panel, height=2)))
+iris_species_dashboard_resized = ui.dashboard(ui.column(ui.row(about_panel, _iris_agg_stack, height=1), ui.row(sepal_panel, species_picker_panel, height=2)))
 ```
 
 ![img](_assets/deephaven-ui-crash-course/iris_species_dashboard_resized.png)
@@ -475,7 +475,7 @@ def create_species_dashboard():
     sepal_panel = create_sepal_panel(set_species)
 
     return ui.column(
-        ui.row(about_panel, iris_agg_stack, height=1),
+        ui.row(about_panel, _iris_agg_stack, height=1),
         ui.row(sepal_panel, species_panel, height=2),
     )
 
@@ -567,7 +567,7 @@ def create_species_dashboard():
     sepal_panel = create_sepal_panel(set_species)
 
     return ui.column(
-        ui.row(about_panel, iris_agg_stack, height=1),
+        ui.row(about_panel, _iris_agg_stack, height=1),
         ui.row(sepal_panel, species_panel, height=2),
     )
 
@@ -621,7 +621,7 @@ def create_species_dashboard():
     sepal_panel = create_sepal_panel(set_species)
 
     return ui.column(
-        ui.row(about_panel, iris_agg_stack, height=1),
+        ui.row(about_panel, _iris_agg_stack, height=1),
         ui.row(sepal_panel, species_panel, height=2),
     )
 
@@ -688,7 +688,7 @@ ui_iris_avg = ui.panel(iris_avg, title="Average")
 ui_iris_max = ui.panel(iris_max, title="Max")
 ui_iris_min = ui.panel(iris_min, title="Min")
 
-iris_agg_stack = ui.stack(ui_iris_avg, ui_iris_max, ui_iris_min)
+_iris_agg_stack = ui.stack(ui_iris_avg, ui_iris_max, ui_iris_min)
 
 species_table = iris.view("Species").select_distinct()
 
@@ -777,7 +777,7 @@ def create_species_dashboard():
     sepal_panel = create_sepal_panel(set_species)
 
     return ui.column(
-        ui.row(about_panel, iris_agg_stack, height=1),
+        ui.row(about_panel, _iris_agg_stack, height=1),
         ui.row(sepal_panel, species_panel, height=2),
     )
 


### PR DESCRIPTION
- There's an issue when you open just a `ui.stack` inside a dashboard it throws an error (DH-19319)
  - Fixing that issue is non-trivial.
- Instead of assigning a variable to the `ui.stack`, just inline it to avoid that error.
- Fixed DOC-395