### PR TITLE
ci: Update images to Ubuntu 24

### DIFF
--- a/.github/workflows/build-python-package.yml
+++ b/.github/workflows/build-python-package.yml
@@ -19,7 +19,7 @@ on:
 
 jobs:
   build-python-package:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/conventional-pr-check.yml
+++ b/.github/workflows/conventional-pr-check.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   pr-check:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: amannn/action-semantic-pull-request@v5
         id: lint_pr_title

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   e2e-test:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
       cancel-in-progress: true
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run tests
-        run: "./tools/run_docker.sh e2e-tests"
+        run: './tools/run_docker.sh e2e-tests'
 
       - name: Upload Playwright report
         uses: actions/upload-artifact@v4
@@ -34,7 +34,7 @@ jobs:
       - name: Dump server logs
         if: failure()
         run: docker logs deephaven-plugins > /tmp/server-log.txt
-  
+
       - name: Upload server logs
         if: failure()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/modified-plugin.yml
+++ b/.github/workflows/modified-plugin.yml
@@ -19,7 +19,7 @@ on:
 
 jobs:
   changes:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     permissions:
       pull-requests: read
     outputs:
@@ -55,7 +55,7 @@ jobs:
   # https://github.com/orgs/community/discussions/26822#discussioncomment-5122101
   test-results:
     if: ${{ always() }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: [test-python, test-js, build-docs]
     steps:
       # Only fail if one of the previous tests failed
@@ -64,7 +64,7 @@ jobs:
 
   filter-release:
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Filter tag
         id: filter-tag

--- a/.github/workflows/publish-alpha.yml
+++ b/.github/workflows/publish-alpha.yml
@@ -12,7 +12,7 @@ on:
         default: ''
 jobs:
   publish-alpha:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -5,7 +5,7 @@ on:
     types: [created]
 jobs:
   publish-packages:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/release-python-package.yml
+++ b/.github/workflows/release-python-package.yml
@@ -22,7 +22,7 @@ jobs:
 
   release:
     needs: build-plugin
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     permissions:
       id-token: write
     outputs:
@@ -60,7 +60,7 @@ jobs:
           attestations: false # TODO: Followup this thread to see if there's a better fix https://github.com/pypa/gh-action-pypi-publish/issues/283
 
   check-make-docs:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     outputs:
       files_exists: ${{ steps.check_files.outputs.files_exists }}
     steps:

--- a/.github/workflows/request-docs-review.yml
+++ b/.github/workflows/request-docs-review.yml
@@ -16,7 +16,7 @@ jobs:
     if: github.event.pull_request.draft == false
     permissions:
       pull-requests: write
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Add docs reviewers

--- a/.github/workflows/test-js-packages.yml
+++ b/.github/workflows/test-js-packages.yml
@@ -7,7 +7,7 @@ on:
   workflow_call:
 jobs:
   unit:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
       cancel-in-progress: true

--- a/.github/workflows/test-python-package.yml
+++ b/.github/workflows/test-python-package.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
- We were still using Ubuntu 22, which uses Java 11 by default
- deephaven-server released 0.39.0, which now requires Java 17 for Jetty 12 support: https://github.com/deephaven/deephaven-core/pull/6037
- Just update to Ubuntu 24, may as well do this anyway. Uses Java 17 by default
