### PR TITLE
docs: DOC-754: silence non-consecutive header warning

### DIFF
--- a/plugins/plotly-express/docs/area.md
+++ b/plugins/plotly-express/docs/area.md
@@ -4,7 +4,7 @@ An area plot, also known as a stacked area chart, is a data visualization that u
 
 Area plots are appropriate when the data contain a continuous response variable that directly depends on a continuous explanatory variable, such as time. Further, the response variable can be broken down into contributions from each of several independent categories, and those categories are represented by an additional categorical variable.
 
-### What are area plots useful for?
+## What are area plots useful for?
 
 - **Visualizing trends over time**: Area plots are great for displaying the trend of a single continuous variable. The filled areas can make it easier to see the magnitude of changes and trends compared to line plots.
 - **Displaying cumulative totals**: Area plots are effective in showing cumulative totals over a period. They can help in understanding the contribution of different categories to the total amount and how these contributions evolve.

--- a/plugins/plotly-express/docs/bar.md
+++ b/plugins/plotly-express/docs/bar.md
@@ -4,7 +4,7 @@ A bar plot is a graphical representation of data that uses rectangular bars to d
 
 Bar plots are appropriate when the data contain a continuous response variable that is directly related to a categorical explanatory variable. Additionally, if the response variable is a cumulative total of contributions from different subcategories, each bar can be broken up to demonstrate those contributions.
 
-### What are bar plots useful for?
+## What are bar plots useful for?
 
 - **Comparing categorical data**: Bar plots are ideal for comparing the quantities or frequencies of different categories. The height of each bar represents the value of each category, making it easy to compare them at a glance.
 - **Decomposing data by category**: When the data belong to several independent categories, bar plots make it easy to visualize the relative contributions of each category to the overall total. The bar segments are colored by category, making it easy to identify the contribution of each.

--- a/plugins/plotly-express/docs/box.md
+++ b/plugins/plotly-express/docs/box.md
@@ -4,7 +4,7 @@ A box plot, also known as a box-and-whisker plot, is a data visualization that p
 
 Box plots are appropriate when the data have a continuous variable of interest. If there is an additional categorical variable that the variable of interest depends on, side-by-side box plots may be appropriate using the `by` argument.
 
-### What are box plots useful for?
+## What are box plots useful for?
 
 - **Visualizing overall distribution**: Box plots reveal the distribution of the variable of interest. They are good first-line tools for assessing whether a variable's distribution is symmetric, right-skewed, or left-skewed.
 - **Assessing center and spread**: A box plot displays the center (median) of a dataset using the middle line, and displays the spread (IQR) using the width of the box.

--- a/plugins/plotly-express/docs/candlestick.md
+++ b/plugins/plotly-express/docs/candlestick.md
@@ -6,7 +6,7 @@ Interpreting a candlestick chart involves understanding the visual representatio
 
 In a bullish (upward, typically shown as green) candlestick, the open is typically at the bottom of the body, and the close is at the top, indicating a price increase. In a bearish (downward, typically shown as red) candlestick, the open is at the top of the body, and the close is at the bottom, suggesting a price decrease. One can use these patterns, along with the length of the wicks and the context of adjacent candlesticks, to analyze trends.
 
-### What are candlestick plots useful for?
+## What are candlestick plots useful for?
 
 - **Analyzing financial markets**: Candlestick plots are a standard tool in technical analysis for understanding price movements, identifying trends, and potential reversal points in financial instruments, such as stocks, forex, and cryptocurrencies.
 - **Short to medium-term trading**: Candlestick patterns are well-suited for short to medium-term trading strategies, where timely decisions are based on price patterns and trends over a specific time frame.

--- a/plugins/plotly-express/docs/density_heatmap.md
+++ b/plugins/plotly-express/docs/density_heatmap.md
@@ -4,7 +4,7 @@ A density heatmap plot is a data visualization that uses a colored grid to repre
 
 Density heatmaps are appropriate when the data contain two continuous variables of interest. An additional quantitative variable may be incorporated into the visualization using shapes or colors.
 
-#### What are density heatmap plots useful for?
+## What are density heatmap plots useful for?
 
 - **Scatter Plot Replacement**: When dealing with a large number of data points, density heatmaps provide a more concise, informative and performant visualization than a [scatter plot](scatter.md).
 - **2D Density Estimation**: Density heatmaps can serve as the basis for 2D density estimation methods, helping to model and understand underlying data distributions, which is crucial in statistical analysis and machine learning.

--- a/plugins/plotly-express/docs/funnel-area.md
+++ b/plugins/plotly-express/docs/funnel-area.md
@@ -6,7 +6,7 @@ Funnel area plots differ from [funnel plots](funnel.md) in that they display the
 
 Funnel area plots are appropriate when the data contain a categorical variable where the frequencies of each category can be computed, and the categories can be ordered. Additionally, funnel plots assume a particular relationship between levels of the categorical variable, where each category is a proper subset of the previous category. If the data contain an unordered categorical variable, or the categories are better conceptualized as parts of a whole, consider a pie plot instead of a funnel area plot.
 
-### What are funnel area plots useful for?
+## What are funnel area plots useful for?
 
 - **Visualizing sequential data**: Data that are staged or sequential in some way are often visualized with funnel area plots, yielding insight on the rate of change from one stage to the next.
 - **Analyzing data progression**: Funnel area plots may be used for analyzing attrition, conversion rates, or transitions between stages.

--- a/plugins/plotly-express/docs/funnel.md
+++ b/plugins/plotly-express/docs/funnel.md
@@ -6,7 +6,7 @@ Funnel plots differ from [funnel area plots](funnel-area.md) in that they displa
 
 Funnel plots are appropriate when the data contain a categorical variable where the frequencies of each category can be computed, and the categories can be ordered. Additionally, funnel plots assume a particular relationship between levels of the categorical variable, where each category is a proper subset of the previous category. If the data contain an unordered categorical variable, or the categories are better conceptualized as parts of a whole, consider a pie plot instead of a funnel plot.
 
-### What are funnel plots useful for?
+## What are funnel plots useful for?
 
 - **Visualizing sequential data**: Data that are staged or sequential in some way are often visualized with funnel plots, yielding insight on the absolute changes between each stage.
 - **Comparing categories**: Funnel plots can be broken down into categories to produce insights into the distribution of data at each stage within a process. Then

--- a/plugins/plotly-express/docs/histogram.md
+++ b/plugins/plotly-express/docs/histogram.md
@@ -4,7 +4,7 @@ A histogram plot is a data visualization technique commonly used in statistics a
 
 Histograms are appropriate when the data contain a continuous variable of interest. If there is an additional categorical variable that the variable of interest depends on, layered histograms may be appropriate using the `by` argument.
 
-### What are histograms useful for?
+## What are histograms useful for?
 
 - **Data distribution analysis**: Histograms are a valuable tool to gain insights into the distribution of a dataset, making it easier to understand the central tendencies, spread, and skewness of the data.
 - **Identifying outliers**: Histograms help in detecting outliers or anomalies in a dataset by highlighting data points that fall outside the typical distribution.

--- a/plugins/plotly-express/docs/icicle.md
+++ b/plugins/plotly-express/docs/icicle.md
@@ -4,7 +4,7 @@ Icicle plots, a hierarchical data visualization technique, are used to represent
 
 Icicle plots are appropriate when the data have a hierarchical structure. Each level of the hierarchy consists of a categorical variable and an associated numeric variable with a value for each unique category.
 
-### What are icicle plots useful for?
+## What are icicle plots useful for?
 
 - **Representing hierarchical data**: Icicle charts are particularly useful for visualizing hierarchical data, such as organizational structures, file directories, or nested categorical data. They provide a clear and intuitive way to represent multiple levels of hierarchy in a single view.
 - **Space-efficient plotting**: By using a compact rectangular layout, icicle charts make efficient use of space. This allows for the display of large and complex hierarchies without requiring extensive scrolling or panning, making it easier to analyze and interpret the data at a glance.

--- a/plugins/plotly-express/docs/indicator.md
+++ b/plugins/plotly-express/docs/indicator.md
@@ -2,7 +2,7 @@
 
 An indicator plot is a type of plot that highlights a collection of numeric values.
 
-### What are indicator plots useful for?
+## What are indicator plots useful for?
 
 - **Highlight specific metrics**: Indicator plots are useful when you want to highlight specific numeric metrics in a visually appealing way.
 - **Compare metrics to a reference value**: Indicator plots are useful to compare metrics to a reference value, such as a starting value or a target value.
@@ -78,7 +78,7 @@ dog_agg = my_table.where("Sym = `DOG`").agg_by([agg.avg(cols="Price"), agg.first
 indicator_plot = dx.indicator(dog_agg, value="Price", reference="StartingPrice", number=False)
 ```
 
-### An angular indicator plot
+## An angular indicator plot
 
 Visualize a single numeric value with an angular gauge by passing `gauge="angular"`.
 
@@ -94,7 +94,7 @@ dog_avg = my_table.where("Sym = `DOG`").agg_by([agg.avg(cols="Price")])
 indicator_plot = dx.indicator(dog_avg, value="Price", gauge="angular")
 ```
 
-### A hidden axis bullet indicator plot
+## A hidden axis bullet indicator plot
 
 Visualize a single numeric value with a bullet gauge by passing `gauge="bullet"`. Hide the axis by passing `axis=False`.
 
@@ -110,7 +110,7 @@ dog_avg = my_table.where("Sym = `DOG`").agg_by([agg.avg(cols="Price")])
 indicator_plot = dx.indicator(dog_avg, value="Price", gauge="bullet", axis=False)
 ```
 
-### Prefixes and suffixes
+## Prefixes and suffixes
 
 Add a prefix and suffix to the numeric value by passing `prefix` and `suffix`.
 

--- a/plugins/plotly-express/docs/line-3d.md
+++ b/plugins/plotly-express/docs/line-3d.md
@@ -4,7 +4,7 @@
 
 3D line plots are appropriate when a continuous response variable depends on two continuous explanatory variables. If there is an additional categorical variable that the response variable depends on, shapes or colors can be used in the scatter plot to distinguish the categories. Further, line plots are preferable to scatter plots when the explanatory variables are ordered.
 
-### What are 3D line plots useful for?
+## What are 3D line plots useful for?
 
 - **Multidimensional data visualization**: 3D line plots allow for the representation of data in a 3D space, providing a more comprehensive view of complex relationships.
 - **Trend exploration**: 3D line plots are useful for exploring and understanding trends, patterns, and variations in data within a 3D space, making them valuable in scientific and engineering fields.

--- a/plugins/plotly-express/docs/line-polar.md
+++ b/plugins/plotly-express/docs/line-polar.md
@@ -4,7 +4,7 @@ Polar line plots are a type of data visualization that represents data points on
 
 Polar line plots are appropriate when the data contain a continuous variable represented in polar coordinates, with a radial and an angular component instead of the typical x and y components. Further, polar line plots are preferable to [polar scatter plots](scatter-polar.md) when the explanatory variables are ordered.
 
-### What are polar line plots useful for?
+## What are polar line plots useful for?
 
 - **Cyclical data analysis**: They are ideal for analyzing cyclical or periodic data, such as daily temperature fluctuations, seasonal patterns, or circular processes in physics and engineering.
 - **Representing directional data**: Polar line plots are valuable for representing directional data, such as wind direction, compass bearings, or circular measurements, offering a clear way to visualize and analyze these kinds of patterns.

--- a/plugins/plotly-express/docs/line-ternary.md
+++ b/plugins/plotly-express/docs/line-ternary.md
@@ -4,7 +4,7 @@ Ternary line plots are a data visualization technique that represents data in a 
 
 Ternary line plots are appropriate when the data contain three interrelated mutually exclusive categories whose relationships can be quantified with a continuous variable. Further, ternary line plots are preferable to [ternary scatter plots](scatter-ternary.md) when the explanatory variables are ordered.
 
-### What are ternary line plots useful for?
+## What are ternary line plots useful for?
 
 - **Compositional data representation**: Ternary line plots are suitable for representing compositional data where the total proportion remains constant, allowing for the visualization of how components change relative to one another.
 - **Multivariate data analysis**: They are useful in multivariate data analysis to visualize relationships and trends among three variables or components that are interrelated.

--- a/plugins/plotly-express/docs/line.md
+++ b/plugins/plotly-express/docs/line.md
@@ -4,7 +4,7 @@ A line plot is a graphical representation that displays data points connected by
 
 Line plots are appropriate when the data contain a continuous response variable that directly depends on a continuous explanatory variable. Further, line plots are preferable to [scatter plots](scatter.md) when the explanatory variables are ordered.
 
-### What are line plots useful for?
+## What are line plots useful for?
 
 - **Visualizing trends:** Line plots excel at revealing trends and patterns in data, making them ideal for time series analysis and showcasing changes over a continuous range.
 - **Simplicity and clarity:** Line plots offer a straightforward and uncluttered representation, enhancing readability and allowing developers to focus on the data's inherent structure.

--- a/plugins/plotly-express/docs/ohlc.md
+++ b/plugins/plotly-express/docs/ohlc.md
@@ -4,7 +4,7 @@ OHLC (Open-High-Low-Close) plots are a common data visualization tool used in fi
 
 In OHLC plots, each bar consists of a vertical line with small horizontal lines on both ends. The top of the vertical line represents the high price, the bottom represents the low price, the horizontal line on the left indicates the opening price, and the horizontal line on the right signifies the closing price. Additionally, the color of the bar is often used to indicate whether the closing price was higher (bullish, often green) or lower (bearish, often red) than the opening price, aiding in the quick assessment of price trends and market sentiment. Analyzing the shape, color, and position of these bars helps traders and analysts assess the price movement, trends, and market sentiment within a given time frame.
 
-### What are OHLC plots useful for?
+## What are OHLC plots useful for?
 
 - **Price trend analysis**: OHLC charts provide a clear visual representation of price trends and movements over specific time periods, helping traders and analysts assess market direction.
 - **Identifying support and resistance**: They aid in identifying support and resistance levels, key price points that can inform trading decisions and risk management.

--- a/plugins/plotly-express/docs/pie.md
+++ b/plugins/plotly-express/docs/pie.md
@@ -4,7 +4,7 @@ A pie plot is a circular data visualization that illustrates the relative propor
 
 Pie plots are appropriate when the data contain a categorical variable where the frequencies of each category can be computed.
 
-### What are pie plots useful for?
+## What are pie plots useful for?
 
 - **Proportional representation**: Pie plots effectively convey the proportional distribution of categories, making them useful when you want to highlight the relative size of discrete components within a whole.
 - **Simplicity**: Pie plots are straightforward to interpret and can be especially valuable when communicating data to non-technical audiences, as they provide an easily digestible overview of data composition.

--- a/plugins/plotly-express/docs/scatter-3d.md
+++ b/plugins/plotly-express/docs/scatter-3d.md
@@ -4,7 +4,7 @@ A 3D scatter plot is a type of data visualization that displays data points in t
 
 3D scatter plots are appropriate when a continuous response variable depends on two continuous explanatory variables. If there is an additional categorical variable that the response variable depends on, shapes or colors can be used in the scatter plot to distinguish the categories.
 
-### What are 3D scatter plots useful for?
+## What are 3D scatter plots useful for?
 
 - **Visualizing multivariate data**: When you have three variables of interest, a 3D scatter plot allows you to visualize and explore their relationships in a single plot. It enables you to see how changes in one variable affect the other two, providing a more comprehensive understanding of the data.
 - **Identifying clusters and patterns**: In some datasets, 3D scatter plots can reveal clusters or patterns that might not be evident in 2D scatter plots. The added dimensionality can help identify complex structures and relationships that exist in the data.

--- a/plugins/plotly-express/docs/scatter-polar.md
+++ b/plugins/plotly-express/docs/scatter-polar.md
@@ -4,7 +4,7 @@ Polar scatter plots are a data visualization method that represents data points 
 
 Polar scatter plots are appropriate when the data contain a continuous variable represented in polar coordinates, with a radial and an angular component instead of the typical x and y components.
 
-### What are polar scatter plots useful for?
+## What are polar scatter plots useful for?
 
 - **Analyzing cyclical data**: Polar scatter plots are valuable for analyzing data with cyclical or periodic patterns, as they enable the visualization of cyclic trends and periodic variations within the data.
 - **Representing directional data**: They are used to represent directional data, such as wind directions, compass bearings, or angular measurements, providing a visual means to explore data with specific orientations.

--- a/plugins/plotly-express/docs/scatter-ternary.md
+++ b/plugins/plotly-express/docs/scatter-ternary.md
@@ -4,7 +4,7 @@ Ternary scatter plots are a data visualization method used to represent data wit
 
 Ternary scatter plots are appropriate when the data contain three interrelated mutually exclusive categories whose relationships can be quantified with a continuous variable.
 
-### What are ternary scatter plots useful for?
+## What are ternary scatter plots useful for?
 
 - **Compositional data analysis**: Ternary scatter plots are useful for analyzing data where proportions of three components add up to a constant total. They help visualize the distribution of these components and their relationships within the composition.
 - **Exploring multivariate data**: They can be applied in multivariate data analysis to visualize relationships, patterns, and trends among three variables or components, particularly when these components are interrelated.

--- a/plugins/plotly-express/docs/scatter.md
+++ b/plugins/plotly-express/docs/scatter.md
@@ -4,7 +4,7 @@ A scatter plot is a type of data visualization that uses Cartesian coordinates t
 
 Scatter plots are appropriate when the data contain a continuous response variable that directly depends on a continuous explanatory variable. If there is an additional categorical variable that the response variable depends on, shapes or colors can be used in the scatter plot to distinguish the categories. For large datasets (> 1 million points), consider using a [density heatmap](density_heatmap.md) instead of a scatter plot.
 
-### What are scatter plots useful for?
+## What are scatter plots useful for?
 
 - **Exploring relationships**: Scatter plots are useful for exploring and visualizing the relationship between two continuous variables. By plotting the data points, you can quickly identify patterns, trends, or correlations between the variables. It helps in understanding how changes in one variable affect the other.
 - **Outlier detection**: Scatter plots are effective in identifying outliers or extreme values in a dataset. Outliers appear as points that deviate significantly from the general pattern of the data. By visualizing the data in a scatter plot, you can easily spot these outliers, which may be important in certain analyses.

--- a/plugins/plotly-express/docs/strip.md
+++ b/plugins/plotly-express/docs/strip.md
@@ -4,7 +4,7 @@ In a strip plot, individual data points are displayed along a single axis, provi
 
 Strip plots are appropriate when the data contain a continuous variable of interest. If there is an additional categorical variable that the variable of interest depends on, stacked strip plots may be appropriate. The data should be relatively sparse, as strip plots can get crowded quickly with large datasets. This may make it difficult to spot multimodal distributions, heavy-tailed distributions, or outliers. In such cases, [box plots](box.md) or [violin plots](violin.md) may be more appropriate.
 
-### What are strip plots useful for?
+## What are strip plots useful for?
 
 - **Comparing data categories**: Strip plots effectively present the distribution of a dataset, and make it easy to compare the distributions of different categories of data.
 - **Identifying outliers**: Because strip plots are made up of individual points, they are well-suited for identifying potential outliers in datasets.

--- a/plugins/plotly-express/docs/sunburst.md
+++ b/plugins/plotly-express/docs/sunburst.md
@@ -4,7 +4,7 @@ Sunburst plots are a data visualization technique used to represent hierarchical
 
 Sunburst plots are appropriate when the data have a hierarchical structure. Each level of the hierarchy consists of a categorical variable and an associated numeric variable with a value for each unique category.
 
-### What are sunburst plots useful for?
+## What are sunburst plots useful for?
 
 - **Hierarchical Data Visualization**: Sunburst plots are valuable for visualizing hierarchical data structures, making them suitable for applications where data has multiple levels of nested categories or relationships. Developers can use sunburst plots to represent data in a manner that clearly illustrates the hierarchical organization of information.
 - **Tree Maps Replacement**: Sunburst plots can be an alternative to tree maps for visualizing hierarchical data. Developers can use sunburst plots to present hierarchical data in a space-efficient and visually appealing manner. This can be particularly beneficial in applications where screen real estate is limited, and users need to view hierarchical data with an interactive and intuitive interface.

--- a/plugins/plotly-express/docs/treemap.md
+++ b/plugins/plotly-express/docs/treemap.md
@@ -4,7 +4,7 @@ Treemap plots are a data visualization technique used to represent hierarchical 
 
 Treemap plots are appropriate when the data have a hierarchical structure. Each level of the hierarchy consists of a categorical variable and an associated numeric variable with a value for each unique category.
 
-### What are treemap plots useful for?
+## What are treemap plots useful for?
 
 - **Visualizing hierarchical data**: Treemap plots are valuable for visualizing hierarchical data structures with multiple levels of nested categories or relationships. Developers can use treemaps to represent data in a space-efficient manner, making them suitable for applications where data has complex hierarchical organizations.
 - **Hierarchical data comparison**: Treemaps can be used to compare data within hierarchical structures, allowing users to understand the distribution of categories and their relative sizes. Developers can implement features that enable users to compare data across multiple hierarchies or time periods.

--- a/plugins/plotly-express/docs/violin.md
+++ b/plugins/plotly-express/docs/violin.md
@@ -4,7 +4,7 @@ A violin plot is a data visualization that combines a box plot with a rotated ke
 
 Violin plots are appropriate when the data contain a continuous variable of interest. If there is an additional categorical variable that the variable of interest depends on, side-by-side violin plots may be appropriate using the `by` argument.
 
-### What are violin plots useful for?
+## What are violin plots useful for?
 
 - **Comparing distributions**: Violin plots are effective for visually comparing and contrasting the distribution of multiple datasets or categories, allowing for quick identification of differences in data patterns.
 - **Assessing central tendency and spread**: Violin plots provide insights into the central tendencies and variability of data, including the median, quartiles, and potential outliers.


### PR DESCRIPTION
DOC-754: modifies the Sphinx configuration specifically when building plotly-express docs to silence `myst.header` warnings that occur when there are non-consecutive heading levels. (This seems to be intentional in some docs where heading levels are skipped for layout reasons)

If you wish to suppress specific warnings for plotly-express build logs, add the warning to the `suppress_warnings` configuration option in the `conf.py` file.

