### PR TITLE
docs: DOC-759: warnings when building deephaven UI docs

### DIFF
--- a/plugins/ui/docs/components/dialog.md
+++ b/plugins/ui/docs/components/dialog.md
@@ -320,9 +320,9 @@ my_large_example = large_example()
 
 ## API Reference
 
+
 ```{eval-rst}
 .. dhautofunction:: deephaven.ui.dialog
-    :no-index:
 
 .. dhautofunction:: deephaven.ui.content
 

--- a/plugins/ui/docs/components/dialog.md
+++ b/plugins/ui/docs/components/dialog.md
@@ -322,6 +322,9 @@ my_large_example = large_example()
 
 ```{eval-rst}
 .. dhautofunction:: deephaven.ui.dialog
+    :no-index:
+
 .. dhautofunction:: deephaven.ui.content
+
 .. dhautofunction:: deephaven.ui.footer
 ```

--- a/plugins/ui/docs/components/dialog_trigger.md
+++ b/plugins/ui/docs/components/dialog_trigger.md
@@ -364,5 +364,14 @@ my_event_example = event_example()
 ## API Reference
 
 ```{eval-rst}
+.. dhautofunction:: deephaven.ui.dialog_trigger
+
 .. dhautofunction:: deephaven.ui.dialog
+    :no-index:
+
+.. dhautofunction:: deephaven.ui.content
+    :no-index:
+
+.. dhautofunction:: deephaven.ui.footer
+    :no-index:
 ```

--- a/plugins/ui/docs/components/html.md
+++ b/plugins/ui/docs/components/html.md
@@ -108,6 +108,8 @@ html = ui.html.div(ui.html.h1("Component inside html"), ui.text("this is a compo
 
 .. dhautofunction:: deephaven.ui.html.pre
 
+.. dhautofunction:: deephaven.ui.html.select
+
 .. dhautofunction:: deephaven.ui.html.span
 
 .. dhautofunction:: deephaven.ui.html.table
@@ -120,11 +122,9 @@ html = ui.html.div(ui.html.h1("Component inside html"), ui.text("this is a compo
 
 .. dhautofunction:: deephaven.ui.html.th
 
+.. dhautofunction:: deephaven.ui.html.thead
+
 .. dhautofunction:: deephaven.ui.html.tr
 
 .. dhautofunction:: deephaven.ui.html.ul
-
-.. dhautofunction:: deephaven.ui.html.thead
-
-.. dhautofunction:: deephaven.ui.html.select
 ```

--- a/plugins/ui/docs/components/html.md
+++ b/plugins/ui/docs/components/html.md
@@ -123,4 +123,8 @@ html = ui.html.div(ui.html.h1("Component inside html"), ui.text("this is a compo
 .. dhautofunction:: deephaven.ui.html.tr
 
 .. dhautofunction:: deephaven.ui.html.ul
+
+.. dhautofunction:: deephaven.ui.html.thead
+
+.. dhautofunction:: deephaven.ui.html.select
 ```

--- a/plugins/ui/docs/components/html.md
+++ b/plugins/ui/docs/components/html.md
@@ -67,34 +67,60 @@ html = ui.html.div(ui.html.h1("Component inside html"), ui.text("this is a compo
 
 ```{eval-rst}
 .. dhautofunction:: deephaven.ui.html.html_element
+
 .. dhautofunction:: deephaven.ui.html.a
+
 .. dhautofunction:: deephaven.ui.html.button
+
 .. dhautofunction:: deephaven.ui.html.code
+
 .. dhautofunction:: deephaven.ui.html.div
+
 .. dhautofunction:: deephaven.ui.html.form
+
 .. dhautofunction:: deephaven.ui.html.h1
+
 .. dhautofunction:: deephaven.ui.html.h2
+
 .. dhautofunction:: deephaven.ui.html.h3
+
 .. dhautofunction:: deephaven.ui.html.h4
+
 .. dhautofunction:: deephaven.ui.html.h5
+
 .. dhautofunction:: deephaven.ui.html.h6
+
 .. dhautofunction:: deephaven.ui.html.i
+
 .. dhautofunction:: deephaven.ui.html.img
+
 .. dhautofunction:: deephaven.ui.html.input
+
 .. dhautofunction:: deephaven.ui.html.label
+
 .. dhautofunction:: deephaven.ui.html.li
+
 .. dhautofunction:: deephaven.ui.html.ol
+
 .. dhautofunction:: deephaven.ui.html.option
+
 .. dhautofunction:: deephaven.ui.html.p
+
 .. dhautofunction:: deephaven.ui.html.pre
-.. dhautofunction:: deephaven.ui.html.selection
+
 .. dhautofunction:: deephaven.ui.html.span
+
 .. dhautofunction:: deephaven.ui.html.table
+
 .. dhautofunction:: deephaven.ui.html.tbody
+
 .. dhautofunction:: deephaven.ui.html.td
+
 .. dhautofunction:: deephaven.ui.html.textarea
+
 .. dhautofunction:: deephaven.ui.html.th
-.. dhautofunction:: deephaven.ui.html.thread
+
 .. dhautofunction:: deephaven.ui.html.tr
+
 .. dhautofunction:: deephaven.ui.html.ul
 ```

--- a/plugins/ui/src/deephaven/ui/components/combo_box.py
+++ b/plugins/ui/src/deephaven/ui/components/combo_box.py
@@ -132,6 +132,7 @@ def combo_box(
 ) -> ComboBoxElement:
     """
     A combo box that can be used to search or select from a list. Children should be one of five types:
+
     1. If children are of type `Item`, they are the dropdown options.
     2. If children are of type `SectionElement`, they are the dropdown sections.
     3. If children are of type `Table`, the values in the table are the dropdown options.

--- a/plugins/ui/src/deephaven/ui/components/dialog_trigger.py
+++ b/plugins/ui/src/deephaven/ui/components/dialog_trigger.py
@@ -29,6 +29,7 @@ def dialog_trigger(
 ) -> Element:
     """
     A dialog_trigger serves as a wrapper around a dialog and its associated trigger.
+
     Args:
         *children: The Dialog and its trigger element.
         type: The type of Dialog that should be rendered.

--- a/plugins/ui/src/deephaven/ui/components/list_view.py
+++ b/plugins/ui/src/deephaven/ui/components/list_view.py
@@ -103,6 +103,7 @@ def list_view(
 ) -> ListViewElement:
     """
     A list view that can be used to create a list of items. Children should be one of three types:
+
     1. If children are of type `Item`, they are the list items.
     2. If children are of type `Table`, the values in the table are the list items.
         There can only be one child, the `Table`.
@@ -120,7 +121,7 @@ def list_view(
         overflow_mode: The behaviour of the text when it overflows the cell.
         render_empty_state: Sets what the `list_view` should render when there is no content to display.
         disabled_behavior: Whether disabled_keys applies to all interactions or just selection.
-        disabled_keys: The keys that should be disabled. These cannot be selected, focused, or interacted with
+        disabled_keys: The keys that should be disabled. These cannot be selected, focused, or interacted with.
         selection_mode: By default `"MULTIPLE"`, which allows multiple selection. May also be `"SINGLE"` to allow only single selection, or `"None"`/`None` to allow no selection.
         disallow_empty_selection: Whether the ListView should disallow empty selection.
         selected_keys: The currently selected keys in the collection (controlled).
@@ -128,13 +129,13 @@ def list_view(
         selection_style: How the selection should be displayed.
         on_action: Handler that is called when the user performs an action on an item. The user event depends on the collection's selection_style and interaction modality.
         on_change: Handler that is called when the selection changes.
-        on_selection_change: Deprecated. Use on_change instead.Handler that is called when the selection changes.
+        on_selection_change: Deprecated. Use on_change instead. Handler that is called when the selection changes.
         flex: When used in a flex layout, specifies how the element will grow or shrink to fit the space available.
         flex_grow: When used in a flex layout, specifies how the element will grow to fit the space available.
         flex_shrink: When used in a flex layout, specifies how the element will shrink to fit the space available.
         flex_basis: When used in a flex layout, specifies the initial main size of the element.
         align_self: Overrides the alignItems property of a flex or grid container.
-        justify_self: Species how the element is justified inside a flex or grid container.
+        justify_self: Specifies how the element is justified inside a flex or grid container.
         order: The layout order for the element within a flex or grid container.
         grid_area: When used in a grid layout, specifies the named grid area that the element should be placed in within the grid.
         grid_row: When used in a grid layout, specifies the row the element should be placed in within the grid.
@@ -163,7 +164,7 @@ def list_view(
         right: The right position of the element.
         start: The logical start position of the element, depending on layout direction.
         end: The logical end position of the element, depending on layout direction.
-        z_index: The stacking order for the element
+        z_index: The stacking order for the element.
         is_hidden: Hides the element.
         id: The unique identifier of the element.
         aria_label: Defines a string value that labels the current element.

--- a/plugins/ui/src/deephaven/ui/components/picker.py
+++ b/plugins/ui/src/deephaven/ui/components/picker.py
@@ -121,31 +121,28 @@ def picker(
 ) -> PickerElement:
     """
     A picker that can be used to select from a list. Children should be one of five types:
+
     1. If children are of type `Item`, they are the dropdown options.
     2. If children are of type `SectionElement`, they are the dropdown sections.
     3. If children are of type `Table`, the values in the table are the dropdown options.
-        There can only be one child, the `Table`.
-        The first column is used as the key and label by default.
+       There can only be one child, the `Table`.
+       The first column is used as the key and label by default.
     4. If children are of type `PartitionedTable`, the values in the table are the dropdown options
-        and the partitions create multiple sections. There can only be one child, the `PartitionedTable`.
-        The first column is used as the key and label by default.
+       and the partitions create multiple sections. There can only be one child, the `PartitionedTable`.
+       The first column is used as the key and label by default.
     5. If children are of type `ItemTableSource`, complex items are created from the source.
-        There can only be one child, the `ItemTableSource`.
-        Supported ItemTableSource arguments are `key_column`, `label_column`, `description_column`,
-        `icon_column`, and `title_column`.
+       There can only be one child, the `ItemTableSource`.
+       Supported ItemTableSource arguments are `key_column`, `label_column`, `description_column`,
+       `icon_column`, and `title_column`.
 
     Args:
         *children: The options to render within the picker.
-        default_selected_key:
-            The initial selected key in the collection (uncontrolled).
-        selected_key:
-            The currently selected key in the collection (controlled).
-        on_selection_change:
-            Handler that is called when the selection changes.
-        on_change:
-            Alias of `on_selection_change`. Handler that is called when the selection changes.
+        default_selected_key: The initial selected key in the collection (uncontrolled).
+        selected_key: The currently selected key in the collection (controlled).
+        on_selection_change: Handler that is called when the selection changes.
+        on_change: Alias of `on_selection_change`. Handler that is called when the selection changes.
 
-        is_quiet: Whether the TextField should be displayed with a quiet style
+        is_quiet: Whether the TextField should be displayed with a quiet style.
         align: Alignment of the menu relative to the input target.
         direction: Direction in which the menu should open relative to the Picker.
         should_flip: Whether the menu should flip when it reaches the viewport boundaries.
@@ -219,7 +216,6 @@ def picker(
         UNSAFE_class_name: A CSS class to apply to the element.
         UNSAFE_style: A CSS style to apply to the element.
         key: A unique identifier used by React to render elements in a list.
-
 
     Returns:
         The rendered Picker.


### PR DESCRIPTION
Fixes Doc-759.

Resolves indentation and block quote formatting issues in the UI docs. Also, removes references to `selection` and `thread` in the API reference to prevent build warnings as modules are not defined.