### PR TITLE
docs: Update our instructions for installing kaleido

### DIFF
--- a/plugins/plotly-express/docs/static-image-export.md
+++ b/plugins/plotly-express/docs/static-image-export.md
@@ -7,9 +7,11 @@ Either install will `all` extras or install `kaleido` separately.
 ```sh
 pip install 'deephaven-plugin-plotly-express[all]'
 ```
+
 or
+
 ```sh
-pip install kaleido
+pip install "kaleido<1.0.0"
 ```
 
 > [!WARNING]
@@ -37,7 +39,7 @@ line_plot_image = ui.image(src=line_plot_bytes)
 
 ## Theme Template
 
-Customize the theme with the `template` argument. 
+Customize the theme with the `template` argument.
 Default options are `"plotly"`, `"plotly_white"`, `"plotly_dark"`, `"ggplot2"`, `"seaborn"`, and `"simple_white"`.
 
 ```python order=line_plot_image
@@ -57,7 +59,7 @@ line_plot_image = ui.image(src=line_plot_bytes)
 
 ## Image Format
 
-Customize the format with the `format` argument. 
+Customize the format with the `format` argument.
 Options are `"png"`, `"jpg"`, `"jpeg"`, `"webp"`, `"svg"`, and `"pdf"`.
 
 ```python order=line_plot_image

--- a/plugins/plotly-express/setup.cfg
+++ b/plugins/plotly-express/setup.cfg
@@ -34,7 +34,7 @@ install_requires =
 include_package_data = True
 
 [options.extras_require]
-all = kaleido
+all = kaleido<1.0.0
 
 [options.packages.find]
 where=src


### PR DESCRIPTION
- Kaleido just released v1.0.0 yesterday (June 19, 2025), which contains breaking changes and is only compatible with plotly>=6.1.1
- We use plotly <6.0.0 (until we finish updating to the latest)
- Fix up our docs and setup.cfg to be more explicit about which version of kaleido to install.
