### PR TITLE
build: Bundle AG Grid plugin so it can be imported in other projects

### DIFF
--- a/plugins/ag-grid/src/js/package.json
+++ b/plugins/ag-grid/src/js/package.json
@@ -10,10 +10,20 @@
   ],
   "author": "Deephaven Data Labs LLC",
   "license": "Apache-2.0",
-  "main": "dist/index.js",
+  "main": "dist/bundle/index.js",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/deephaven/deephaven-plugins"
+  },
+  "type": "module",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "require": "./dist/bundle/index.js",
+      "default": "./dist/bundle/index.js"
+    },
+    "./*.js": "./dist/*.js",
+    "./*": "./dist/*.js"
   },
   "bugs": {
     "url": "https://github.com/deephaven/deephaven-plugins/issues"
@@ -21,7 +31,9 @@
   "homepage": "https://github.com/deephaven/deephaven-plugins",
   "scripts": {
     "start": "vite build --watch",
-    "build": "vite build"
+    "build": "run-s build:*",
+    "build:transpile": "tsc",
+    "build:bundle": "vite build"
   },
   "devDependencies": {
     "@deephaven/jsapi-types": "^1.0.0-dev0.39.1",

--- a/plugins/ag-grid/src/js/src/AgGridView.tsx
+++ b/plugins/ag-grid/src/js/src/AgGridView.tsx
@@ -93,7 +93,6 @@ export function AgGridView({
           toolPanel: 'agColumnsToolPanel',
         },
       ],
-      defaultToolPanel: 'columns',
     }),
     []
   );

--- a/plugins/ag-grid/src/js/src/datasources/DeephavenViewportDatasource.ts
+++ b/plugins/ag-grid/src/js/src/datasources/DeephavenViewportDatasource.ts
@@ -24,7 +24,7 @@ const log = Log.module('@deephaven/js-plugin-ag-grid/ViewportDatasource');
  * Class that takes the input table and provides a viewport data source for AG Grid.
  * Also listens for grouping to change from a table to a tree table and vice versa.
  */
-class DeephavenViewportDatasource implements IViewportDatasource {
+export class DeephavenViewportDatasource implements IViewportDatasource {
   /** The current parameters for the viewport datasource */
   private params!: IViewportDatasourceParams;
 

--- a/plugins/ag-grid/src/js/src/datasources/index.ts
+++ b/plugins/ag-grid/src/js/src/datasources/index.ts
@@ -1,0 +1,1 @@
+export * from './DeephavenViewportDatasource';

--- a/plugins/ag-grid/src/js/src/index.ts
+++ b/plugins/ag-grid/src/js/src/index.ts
@@ -1,3 +1,7 @@
 import { AgGridPlugin } from './AgGridPlugin.js';
 
+export * from './datasources';
+export * from './renderers';
+export * from './utils';
+
 export default AgGridPlugin;

--- a/plugins/ag-grid/src/js/src/renderers/index.ts
+++ b/plugins/ag-grid/src/js/src/renderers/index.ts
@@ -1,0 +1,1 @@
+export * from './TreeCellRenderer';

--- a/plugins/ag-grid/src/js/src/utils/index.ts
+++ b/plugins/ag-grid/src/js/src/utils/index.ts
@@ -1,0 +1,6 @@
+export * from './AgGridAggUtils';
+export * from './AgGridColors';
+export * from './AgGridFilterUtils';
+export * from './AgGridFormatter';
+export * from './AgGridSortUtils';
+export * from './AgGridTableUtils';

--- a/plugins/ag-grid/src/js/src/vite-env.d.ts
+++ b/plugins/ag-grid/src/js/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/plugins/ag-grid/src/js/tsconfig.json
+++ b/plugins/ag-grid/src/js/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "@deephaven/tsconfig",
+  "compilerOptions": {
+    "composite": false,
+    "rootDir": "src/",
+    "outDir": "dist/",
+    "types": [],
+    "emitDeclarationOnly": false,
+    "noEmit": false
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx"],
+  "exclude": ["**/node_modules/**/*", "src/**/*.test.*", "dist/**/*"]
+}

--- a/plugins/ag-grid/src/js/vite.config.ts
+++ b/plugins/ag-grid/src/js/vite.config.ts
@@ -6,6 +6,7 @@ import react from '@vitejs/plugin-react-swc';
 export default defineConfig(({ mode }) => ({
   build: {
     minify: false,
+    outDir: 'dist/bundle',
     lib: {
       entry: './src/index.ts',
       fileName: () => 'index.js',

--- a/plugins/manifest.json
+++ b/plugins/manifest.json
@@ -3,7 +3,7 @@
     {
       "name": "ag-grid",
       "version": "0.0.0",
-      "main": "src/js/dist/index.js"
+      "main": "src/js/dist/bundle/index.js"
     },
     {
       "name": "matplotlib",


### PR DESCRIPTION
- Wire it up similar to the plotly-express plugin, such that it can be imported as a module or installed as a plugin
- Export everything from an index.ts so imports can all be done from the root of the package
- Verified the plugin still worked, and that all the files were output correctly to the `dist` build folder