### PR TITLE
fix: DH-19839: Subplot row_heights reversed in place

### DIFF
--- a/plugins/plotly-express/src/deephaven/plot/express/plots/subplots.py
+++ b/plugins/plotly-express/src/deephaven/plot/express/plots/subplots.py
@@ -188,6 +188,9 @@ def get_domains(values: list[float], spacing: float) -> tuple[list[float], list[
     for i in range(1, len(scaled)):
         ends.append(ends[-1] + scaled[i] + spacing)
 
+    # the last end value is always 1.0, and sometimes it ends up off due to rounding errors
+    ends[-1] = 1.0
+
     return starts, ends
 
 

--- a/plugins/plotly-express/test/deephaven/plot/express/plots/test_indicator.py
+++ b/plugins/plotly-express/test/deephaven/plot/express/plots/test_indicator.py
@@ -364,7 +364,7 @@ class IndicatorTestCase(BaseTestCase):
                     "increasing": {"symbol": "▲"},
                 },
                 "domain": {
-                    "x": [0.711111111111111, 0.9999999999999999],
+                    "x": [0.711111111111111, 1.0],
                     "y": [0.0, 1.0],
                 },
                 "mode": "number",
@@ -432,7 +432,7 @@ class IndicatorTestCase(BaseTestCase):
                 },
                 "domain": {
                     "x": [0.0, 1.0],
-                    "y": [0.7333333333333333, 0.9999999999999999],
+                    "y": [0.7333333333333333, 1.0],
                 },
                 "mode": "number",
                 "type": "indicator",

--- a/plugins/plotly-express/test/deephaven/plot/express/plots/test_make_subplots.py
+++ b/plugins/plotly-express/test/deephaven/plot/express/plots/test_make_subplots.py
@@ -541,6 +541,37 @@ class MakeSubplotsTestCase(BaseTestCase):
             expected_is_user_set_color=False,
         )
 
+    def test_make_subplots_shared_variables(self):
+        import src.deephaven.plot.express as dx
+
+        chart = dx.scatter(self.source, x="X", y="Y")
+
+        row_heights = [0.8, 0.2]
+        column_widths = [0.8, 0.2]
+        vertical_grid = [[chart], [chart]]
+        horizontal_grid = [[chart, chart]]
+        specs_grid = [[{"l": 0.1}], [{"r": 0.15}]]
+
+        vertical_chart_one = dx.make_subplots(
+            grid=vertical_grid, rows=2, row_heights=row_heights, specs=specs_grid
+        )
+
+        vertical_chart_two = dx.make_subplots(
+            grid=vertical_grid, rows=2, row_heights=row_heights, specs=specs_grid
+        )
+
+        self.assert_chart_equals(vertical_chart_one, vertical_chart_two)
+
+        horizontal_chart_one = dx.make_subplots(
+            grid=horizontal_grid, cols=2, column_widths=column_widths
+        )
+
+        horizontal_chart_two = dx.make_subplots(
+            grid=horizontal_grid, cols=2, column_widths=column_widths
+        )
+
+        self.assert_chart_equals(horizontal_chart_one, horizontal_chart_two)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Just swapping out reverse so that it is not in place when passed in 