### PR TITLE
fix: DH-19685: Auto-size AG Grid to fit cell content

### DIFF
--- a/plugins/ag-grid/src/js/src/AgGridView.tsx
+++ b/plugins/ag-grid/src/js/src/AgGridView.tsx
@@ -44,7 +44,7 @@ export function AgGridView({
 
   const [isVisible, setIsVisible] = useState(false);
   const [isFirstDataRendered, setIsFirstDataRendered] = useState(false);
-  const [isAutoSized, setIsAutoSized] = useState(false);
+  const [isColumnsSized, setIsColumnsSized] = useState(false);
 
   log.debug('AgGridView rendering', table, table?.columns);
 
@@ -133,11 +133,11 @@ export function AgGridView({
   };
 
   useEffect(() => {
-    if (isVisible && isFirstDataRendered && !isAutoSized) {
-      setIsAutoSized(true);
+    if (isVisible && isFirstDataRendered && !isColumnsSized) {
+      setIsColumnsSized(true);
       autoSizeAllColumns();
     }
-  }, [isVisible, isFirstDataRendered, isAutoSized]);
+  }, [isVisible, isFirstDataRendered, isColumnsSized]);
 
   return (
     <AgGridReact

--- a/plugins/ag-grid/src/js/src/AgGridView.tsx
+++ b/plugins/ag-grid/src/js/src/AgGridView.tsx
@@ -120,6 +120,7 @@ export function AgGridView({
 
   const [isVisible, setIsVisible] = useState(false);
   const [isFirstDataRendered, setIsFirstDataRendered] = useState(false);
+  const [isAutoSized, setIsAutoSized] = useState(false);
 
   const handleFirstDataRendered = (event: FirstDataRenderedEvent) => {
     log.debug('handleFirstDataRendered data', datasource);
@@ -140,11 +141,13 @@ export function AgGridView({
   };
 
   useEffect(() => {
-    if (isVisible && isFirstDataRendered) {
+    if (isVisible && isFirstDataRendered && !isAutoSized) {
       log.debug('isVisible & isFirstDataRendered');
+      log.debug('USEEFFECT AUTOSIZED', isAutoSized);
+      setIsAutoSized(true);
       autoSizeAllColumns();
     }
-  }, [isVisible, isFirstDataRendered]);
+  }, [isVisible, isFirstDataRendered, isAutoSized]);
 
   return (
     <>

--- a/plugins/ag-grid/src/js/src/AgGridWidget.tsx
+++ b/plugins/ag-grid/src/js/src/AgGridWidget.tsx
@@ -30,9 +30,15 @@ export function AgGridWidget(
   const [table, setTable] = useState<DhType.Table>();
 
   const gridDensity = settings?.gridDensity;
-  const theme = useMemo(
-    () => themeQuartz.withParams(AgGridDhTheme.getThemeParams(gridDensity)),
+
+  const themeParams = useMemo(
+    () => AgGridDhTheme.getThemeParams(gridDensity),
     [gridDensity]
+  );
+
+  const theme = useMemo(
+    () => themeQuartz.withParams(themeParams),
+    [themeParams]
   );
 
   const agGridProps: AgGridReactProps = useMemo(
@@ -55,8 +61,9 @@ export function AgGridWidget(
       },
       suppressCellFocus: true,
       theme,
+      rowHeight: themeParams.rowHeight as number,
     }),
-    [theme]
+    [theme, themeParams]
   );
 
   /** First we load the widget object. This is the object that is sent from the server in AgGridMessageStream. */

--- a/plugins/ag-grid/src/js/src/datasources/DeephavenViewportDatasource.ts
+++ b/plugins/ag-grid/src/js/src/datasources/DeephavenViewportDatasource.ts
@@ -234,11 +234,9 @@ export class DeephavenViewportDatasource implements IViewportDatasource {
     log.debug('Refreshing viewport');
     if (this.currentViewport == null) {
       log.debug('Setting default viewport');
-      log.debug('Viewport is null');
-      // return;
       this.currentViewport = {
         firstRow: this.gridApi.getFirstDisplayedRowIndex(),
-        lastRow: this.gridApi.getLastDisplayedRowIndex(), // Default to the first 100 rows
+        lastRow: this.gridApi.getLastDisplayedRowIndex(),
       };
     }
     const { firstRow, lastRow } = this.currentViewport;

--- a/plugins/ag-grid/src/js/src/datasources/DeephavenViewportDatasource.ts
+++ b/plugins/ag-grid/src/js/src/datasources/DeephavenViewportDatasource.ts
@@ -234,9 +234,11 @@ export class DeephavenViewportDatasource implements IViewportDatasource {
     log.debug('Refreshing viewport');
     if (this.currentViewport == null) {
       log.debug('Setting default viewport');
+      log.debug('Viewport is null');
+      // return;
       this.currentViewport = {
-        firstRow: 0,
-        lastRow: 100, // Default to the first 100 rows
+        firstRow: this.gridApi.getFirstDisplayedRowIndex(),
+        lastRow: this.gridApi.getLastDisplayedRowIndex(), // Default to the first 100 rows
       };
     }
     const { firstRow, lastRow } = this.currentViewport;


### PR DESCRIPTION
For DH-19685. Implements column and row auto-sizing for AG Grid tables. When the grid is initialized and data is loaded in, columns are auto-sized to fit their largest cell content, while row heights are set based on theme parameters