### PR TITLE
build(ag-grid): Allow peer dependency of React to be 17, 18, or 19

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31086,8 +31086,8 @@
         "typescript": "^4.5.4"
       },
       "peerDependencies": {
-        "react": "^17.0.2 || ^18.0.0",
-        "react-dom": "^17.0.2 || ^18.0.0"
+        "react": "^17.0.2 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^17.0.2 || ^18.0.0 || ^19.0.0"
       }
     },
     "plugins/ag-grid/src/js/node_modules/@ag-grid-community/react": {

--- a/plugins/ag-grid/src/js/package.json
+++ b/plugins/ag-grid/src/js/package.json
@@ -44,8 +44,8 @@
     "typescript": "^4.5.4"
   },
   "peerDependencies": {
-    "react": "^17.0.2 || ^18.0.0 || ^19.0.0",
-    "react-dom": "^17.0.2 || ^18.0.0 || ^19.0.0"
+    "react": ">=17.0.2",
+    "react-dom": ">=17.0.2"
   },
   "dependencies": {
     "@ag-grid-community/core": "32.3.4",

--- a/plugins/ag-grid/src/js/package.json
+++ b/plugins/ag-grid/src/js/package.json
@@ -44,8 +44,8 @@
     "typescript": "^4.5.4"
   },
   "peerDependencies": {
-    "react": "^17.0.2 || ^18.0.0",
-    "react-dom": "^17.0.2 || ^18.0.0"
+    "react": "^17.0.2 || ^18.0.0 || ^19.0.0",
+    "react-dom": "^17.0.2 || ^18.0.0 || ^19.0.0"
   },
   "dependencies": {
     "@ag-grid-community/core": "32.3.4",

--- a/plugins/ag-grid/src/js/package.json
+++ b/plugins/ag-grid/src/js/package.json
@@ -44,8 +44,8 @@
     "typescript": "^4.5.4"
   },
   "peerDependencies": {
-    "react": ">=17.0.2",
-    "react-dom": ">=17.0.2"
+    "react": "^17.0.2 || ^18.0.0 || ^19.0.0",
+    "react-dom": "^17.0.2 || ^18.0.0 || ^19.0.0"
   },
   "dependencies": {
     "@ag-grid-community/core": "32.3.4",


### PR DESCRIPTION
- Allows for our tools to be used in these packages without overrides
