### PR TITLE
build: Add provenance info to simple-pivot plugin

### DIFF
--- a/plugins/simple-pivot/src/js/package.json
+++ b/plugins/simple-pivot/src/js/package.json
@@ -9,6 +9,10 @@
   "author": "Deephaven Data Labs",
   "license": "Apache-2.0",
   "main": "dist/index.js",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/deephaven/deephaven-plugins"
+  },
   "scripts": {
     "start": "vite build --watch",
     "build": "vite build"
@@ -46,6 +50,5 @@
   },
   "files": [
     "dist/index.js"
-  ],
-  "gitHead": "ffd65b91d87e2bc7064c8e448d1307a8f9c3d559"
+  ]
 }


### PR DESCRIPTION
- Will allow us to publish versions in the future if necessary
- Was currently causing issues when releasing other plugins, as it would also try and publish simple-pivot and fail, e.g. https://github.com/deephaven/deephaven-plugins/actions/runs/16222307802/job/45805843680
> Found 1 package to publish:
> - @deephaven/js-plugin-simple-pivot => 0.0.3-dev.2
> lerna info auto-confirmed 
> lerna info publish Publishing packages to npm...
> lerna ERR! E422 Error verifying sigstore provenance bundle: Failed to validate repos
