### PR TITLE
fix: DH-19428: Make ui.image use crossorigin="anonymous"

### DIFF
--- a/plugins/ui/src/js/src/elements/Image.tsx
+++ b/plugins/ui/src/js/src/elements/Image.tsx
@@ -12,8 +12,22 @@ type SerializedImageProps = Omit<DHCImageProps, 'onLoad' | 'onError'> & {
 };
 
 export function Image({ ...props }: SerializedImageProps): JSX.Element {
-  // eslint-disable-next-line react/jsx-props-no-spreading
-  return <DHCImage {...props} />;
+  return (
+    <DHCImage
+      // eslint-disable-next-line react/jsx-props-no-spreading
+      {...props}
+      // React Spectrum doesn't allow us to directly set the crossorigin attribute in this version
+      // so we use a ref to set it on the underlying img element.
+      // Spectrum will support once this PR is released: https://github.com/adobe/react-spectrum/pull/8532
+      // For now, just assume we want everything to be anonymous, as images are often loaded from a different origin.
+      ref={imageNode =>
+        imageNode
+          ?.UNSAFE_getDOMNode()
+          ?.querySelector('img')
+          ?.setAttribute('crossorigin', 'anonymous')
+      }
+    />
+  );
 }
 
 export default Image;


### PR DESCRIPTION
- Fixes images not loading correctly
