### PR TITLE
feat: DH-10205: Enforce text alignment priority hierarchy in UI table

### DIFF
--- a/plugins/ui/src/js/src/elements/UITable/UITableModel.ts
+++ b/plugins/ui/src/js/src/elements/UITable/UITableModel.ts
@@ -553,14 +553,18 @@ class UITableModel extends IrisGridModel {
     // 1. Alignment from context menu
     // 2. UI table formatting
     // 3. Data type based alignment
-    const customAlignment = isIrisGridTableModelTemplate(this.model)
-      ? this.model.columnAlignmentMap.get(
-          this.model.sourceColumn(column, row).name
-        )
-      : undefined;
+    if (isIrisGridTableModelTemplate(this.model)) {
+      const sourceColumn = this.model.sourceColumn(column, row);
+      const customAlignment = this.model.columnAlignmentMap.get(
+        sourceColumn.name
+      );
+
+      if (customAlignment) {
+        return customAlignment;
+      }
+    }
 
     return (
-      customAlignment ??
       this.getFormatOptionForCell(column, row, 'alignment') ??
       this.model.textAlignForCell(column, row)
     );

--- a/plugins/ui/src/js/src/elements/UITable/UITableModel.ts
+++ b/plugins/ui/src/js/src/elements/UITable/UITableModel.ts
@@ -548,7 +548,19 @@ class UITableModel extends IrisGridModel {
     column: ModelIndex,
     row: ModelIndex
   ): CanvasTextAlign {
+    // Check if the base model has a custom alignment. If so, don't override with UI table formatting.
+    // Text alignment priority hierarchy (from highest to lowest):
+    // 1. Alignment from context menu
+    // 2. UI table formatting
+    // 3. Data type based alignment
+    const customAlignment = isIrisGridTableModelTemplate(this.model)
+      ? this.model.columnAlignmentMap.get(
+          this.model.sourceColumn(column, row).name
+        )
+      : undefined;
+
     return (
+      customAlignment ??
       this.getFormatOptionForCell(column, row, 'alignment') ??
       this.model.textAlignForCell(column, row)
     );


### PR DESCRIPTION
For DH-10205 related to [#2513](https://github.com/deephaven/web-client-ui/pull/2513). Users can now set column text alignment via a context menu, but ui.table was ignoring those preferences.

Text alignment is now determined with the following priority order: 1. context menu, 2.ui.table, 3. column type.

TODO:
 - [ ] Bump package version in ui plugins
 - [ ] Update UITableModel to use custom text alignment from the base model