### PR TITLE
build: Fix docs code fence plugin not registering py or groovy

### DIFF
--- a/plugins/plotly-express/conf.py
+++ b/plugins/plotly-express/conf.py
@@ -42,7 +42,6 @@ exclude_patterns = ["build", "Thumbs.db", ".DS_Store"]
 always_use_bars_union = True
 
 myst_all_links_external = True
-myst_fence_as_directive = ("python", "groovy")
 
 from deephaven_server import Server
 

--- a/plugins/ui/conf.py
+++ b/plugins/ui/conf.py
@@ -46,7 +46,6 @@ strip_signature_backslash = True
 from deephaven_server import Server
 
 myst_all_links_external = True
-myst_fence_as_directive = ("python", "groovy")
 
 # need a server instance to pull types from the autodocs
 Server(port=10075)

--- a/sphinx_ext/deephaven_code_block.py
+++ b/sphinx_ext/deephaven_code_block.py
@@ -44,7 +44,10 @@ def setup(app: Sphinx):
     Returns:
         The metadata for the extension
     """
-    app.add_directive("python", CodeBlockDirective)
+    languages = ["python", "py", "groovy"]
+    for lang in languages:
+        app.add_directive(lang, CodeBlockDirective)
+        app.config.myst_fence_as_directive.add(lang)
 
     return {
         "version": "0.1",


### PR DESCRIPTION
Previously was only preserving `python` as the language, not `py` or `groovy` (we don't have any groovy in these docs right now)

Also modifies the myst global config value from the plugin setup to augment it instead of setting in each `conf.py`. It's an empty set by default.