### PR TITLE
fix: DH-19988: Render error superceding document error on reinitialize

### DIFF
--- a/plugins/ui/src/js/src/widget/WidgetHandler.tsx
+++ b/plugins/ui/src/js/src/widget/WidgetHandler.tsx
@@ -395,6 +395,9 @@ function WidgetHandler({
         };
         unstable_batchedUpdates(() => {
           setIsLoading(false);
+          // Need to set an empty document in case there was something there before
+          // Without this we could get render errors superceding the document error
+          setDocument({});
           setInternalError(newError);
         });
       });


### PR DESCRIPTION
DH-19988

Tested with local DHE UI on `rc/grizzly` running w/ `VITE_JS_PLUGINS_DEV_PORT=4100` on `dev-grizzly2` with the `DH-19988-simple` query. Open `t_2` dashboard from the new tab screen as `iris`. Then restart the query. On restart you should get the error `<class 'deephaven.table.Table'> is not convertible to datetime` instead of the reported error that also empties the dashboard.