### PR TITLE
fix: DH-19988: Render error superceding document error on reinitialize (#1222)

### DIFF
--- a/plugins/ui/src/js/src/widget/WidgetHandler.tsx
+++ b/plugins/ui/src/js/src/widget/WidgetHandler.tsx
@@ -251,8 +251,13 @@ function WidgetHandler({
             const objectKey = value[OBJECT_KEY];
             const exportedObject = exportedObjectMap.current.get(objectKey);
             if (exportedObject === undefined) {
-              // The map should always have the exported object for a key, otherwise the protocol is broken
-              throw new Error(`Invalid exported object key ${objectKey}`);
+              // The map should always have the exported object for a key, otherwise the protocol is broken.
+              // However, we could be rendering the document for its panels after receiving a document error.
+              // In this case, we should not throw an error because we may not have the exported objects.
+              // This is possible in a PQ which saves some state that it can't properly hydrate when the PQ restarts
+              if (!error) {
+                throw new Error(`Invalid exported object key ${objectKey}`);
+              }
             }
             deadObjectMap.delete(objectKey);
             return exportedObject;
@@ -302,6 +307,7 @@ function WidgetHandler({
       jsonClient,
       renderEmptyDocument,
       id,
+      error,
     ]
   );
 
@@ -422,6 +428,7 @@ function WidgetHandler({
         number,
         dh.WidgetExportedObject
       >();
+      setIsLoading(true);
       exportedObjectMap.current = widgetExportedObjectMap;
       exportedObjectCount.current = 0;
       renderedCallableMap.current.clear();


### PR DESCRIPTION
DH-19988 for Grizzly

Same test plan as before, but you don't need `start-community` and should be running `rc/grizzly` for the DHE UI. Make sure to `npm install` both plugins and DHE. The PQ is already on `dev-grizzly2` and the dashboard it creates is `dh_19988`