### PR TITLE
feat: DH-19818: Nested dashboards, complex homepage layout

### DIFF
--- a/plugins/ui/src/deephaven/ui/components/dashboard.py
+++ b/plugins/ui/src/deephaven/ui/components/dashboard.py
@@ -1,10 +1,14 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Union
 from ..elements import BaseElement, FunctionElement
 
 
-def dashboard(element: FunctionElement) -> BaseElement:
+def dashboard(
+    element: FunctionElement,
+    show_close_icon: Union[bool, None] = None,
+    show_headers: Union[bool, None] = None,
+) -> BaseElement:
     """
     A dashboard is the container for an entire layout.
 
@@ -12,8 +16,11 @@ def dashboard(element: FunctionElement) -> BaseElement:
         element: Element to render as the dashboard.
                  The element should render a layout that contains 1 root column or row.
 
+        show_close_icon: Whether to show the close icon in the top right corner of the dashboard. Defaults to False.
+        show_headers: Whether to show headers for the dashboard. Defaults to True.
+
     Returns:
         The rendered dashboard.
     """
     # return DashboardElement(element)
-    return BaseElement("deephaven.ui.components.Dashboard", element)  # type: ignore[return-value]
+    return BaseElement("deephaven.ui.components.Dashboard", element, show_close_icon=show_close_icon, show_headers=show_headers)  # type: ignore[return-value]

--- a/plugins/ui/src/deephaven/ui/components/dashboard.py
+++ b/plugins/ui/src/deephaven/ui/components/dashboard.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
 from typing import Any
-from ..elements import DashboardElement, FunctionElement
+from ..elements import BaseElement, FunctionElement
 
 
-def dashboard(element: FunctionElement) -> DashboardElement:
+def dashboard(element: FunctionElement) -> BaseElement:
     """
     A dashboard is the container for an entire layout.
 
@@ -15,4 +15,5 @@ def dashboard(element: FunctionElement) -> DashboardElement:
     Returns:
         The rendered dashboard.
     """
-    return DashboardElement(element)
+    # return DashboardElement(element)
+    return BaseElement("deephaven.ui.components.Dashboard", element)  # type: ignore[return-value]

--- a/plugins/ui/src/js/src/DashboardPlugin.tsx
+++ b/plugins/ui/src/js/src/DashboardPlugin.tsx
@@ -70,7 +70,9 @@ export function DashboardPlugin(
     id,
     PLUGIN_NAME
   ) as unknown as [DashboardPluginData, (data: DashboardPluginData) => void];
-  const [initialPluginData] = useState(pluginData);
+  const [initialPluginData] = useState({
+    openWidgets: {},
+  } as DashboardPluginData);
 
   // Keep track of the widgets we've got opened.
   const [widgetMap, setWidgetMap] = useState<
@@ -147,20 +149,21 @@ export function DashboardPlugin(
       log.debug('loadInitialPluginData', initialPluginData);
 
       setWidgetMap(prevWidgetMap => {
-        const newWidgetMap = new Map(prevWidgetMap);
-        const { openWidgets } = initialPluginData;
-        if (openWidgets != null) {
-          Object.entries(openWidgets).forEach(
-            ([widgetId, { descriptor, data }]) => {
-              newWidgetMap.set(widgetId, {
-                id: widgetId,
-                widget: descriptor,
-                data,
-              });
-            }
-          );
-        }
-        return newWidgetMap;
+        return new Map();
+        // const newWidgetMap = new Map(prevWidgetMap);
+        // const { openWidgets } = initialPluginData;
+        // if (openWidgets != null) {
+        //   Object.entries(openWidgets).forEach(
+        //     ([widgetId, { descriptor, data }]) => {
+        //       newWidgetMap.set(widgetId, {
+        //         id: widgetId,
+        //         widget: descriptor,
+        //         data,
+        //       });
+        //     }
+        //   );
+        // }
+        // return newWidgetMap;
       });
     },
     [initialPluginData, id]
@@ -278,7 +281,7 @@ export function DashboardPlugin(
             <DashboardWidgetHandler
               widgetDescriptor={wrapper.widget}
               id={wrapper.id}
-              initialData={wrapper.data}
+              // initialData={wrapper.data}
               onDataChange={handleWidgetDataChange}
               onClose={handleWidgetClose}
             />

--- a/plugins/ui/src/js/src/layout/Column.tsx
+++ b/plugins/ui/src/js/src/layout/Column.tsx
@@ -13,6 +13,7 @@ function LayoutColumn({
   children,
   width,
 }: ColumnElementProps): JSX.Element | null {
+  console.log('xxx doing a LayoutColumn');
   const layoutManager = useLayoutManager();
   const parent = useParentItem();
 

--- a/plugins/ui/src/js/src/layout/Dashboard.tsx
+++ b/plugins/ui/src/js/src/layout/Dashboard.tsx
@@ -1,20 +1,136 @@
-import React from 'react';
+import React, { useCallback, useMemo, useRef, useState } from 'react';
+import { nanoid } from 'nanoid';
+import {
+  Dashboard as DHCDasbhoard,
+  LayoutManagerContext,
+} from '@deephaven/dashboard';
+import GoldenLayout from '@deephaven/golden-layout';
+import { useDashboardPlugins } from '@deephaven/plugin';
+import Log from '@deephaven/log';
 import {
   normalizeDashboardChildren,
   type DashboardElementProps,
 } from './LayoutUtils';
 import { ParentItemContext, useParentItem } from './ParentItemContext';
+import ReactPanel from './ReactPanel';
+import { ReactPanelContext } from './ReactPanelContext';
+import useWidgetStatus from './useWidgetStatus';
+import { ReactPanelManagerContext } from './ReactPanelManager';
+
+const log = Log.module('@deephaven/js-plugin-ui/DocumentHandler');
 
 function Dashboard({ children }: DashboardElementProps): JSX.Element | null {
-  const parent = useParentItem();
+  const [childLayout, setChildLayout] = useState<GoldenLayout>();
+  // const parent = useParentItem();
+  const plugins = useDashboardPlugins();
 
   const normalizedChildren = normalizeDashboardChildren(children);
+  console.log('xxx doing a dashboard with layout', childLayout);
+
+  const panelIdIndex = useRef(0);
+  // panelIds that are currently opened within this document. This list is tracked by the `onOpen`/`onClose` call on the `ReactPanelManager` from a child component.
+  // Note that the initial widget data provided will be the `panelIds` for this document to use; this array is what is actually opened currently.
+  const panelIds = useRef<string[]>([]);
+
+  // Flag to signal the panel counts have changed in the last render
+  // We may need to check if we need to close this widget if all panels are closed
+  const [isPanelsDirty, setPanelsDirty] = useState(false);
+
+  const handleOpen = useCallback(
+    (panelId: string) => {
+      if (panelIds.current.includes(panelId)) {
+        throw new Error('Duplicate panel opens received');
+      }
+
+      panelIds.current.push(panelId);
+      log.debug('Panel opened, open count', panelIds.current.length);
+
+      setPanelsDirty(true);
+    },
+    [panelIds]
+  );
+
+  const handleClose = useCallback(
+    (panelId: string) => {
+      const panelIndex = panelIds.current.indexOf(panelId);
+      if (panelIndex === -1) {
+        throw new Error('Panel close received for unknown panel');
+      }
+
+      panelIds.current.splice(panelIndex, 1);
+      log.debug('Panel closed, open count', panelIds.current.length);
+
+      setPanelsDirty(true);
+    },
+    [panelIds]
+  );
+
+  const getPanelId = useCallback(() => {
+    // On rehydration, yield known IDs first
+    // If there are no more known IDs, generate a new one.
+    // This can happen if the document hasn't been opened before, or if it's rehydrated and a new panel is added.
+    // Note that if the order of panels changes, the worst case scenario is that panels appear in the wrong location in the layout.
+    const panelId = nanoid();
+    panelIdIndex.current += 1;
+    return panelId;
+  }, []);
+
+  const widgetStatus = useWidgetStatus();
+  const panelManager = useMemo(
+    () => ({
+      metadata: widgetStatus.descriptor,
+      onOpen: handleOpen,
+      onClose: handleClose,
+      onDataChange: () => log.debug('xxx Panel data changed'),
+      getPanelId,
+      getInitialData: () => [],
+    }),
+    [
+      widgetStatus,
+      getPanelId,
+      handleClose,
+      handleOpen,
+      // handleDataChange,
+      // getInitialData,
+    ]
+  );
+  const [isLayoutInitialized, setLayoutInitialized] = useState(false);
 
   return (
-    <ParentItemContext.Provider value={parent}>
-      {normalizedChildren}
-    </ParentItemContext.Provider>
+    // <>
+    <ReactPanel>
+      <ParentItemContext.Provider value={null}>
+        <ReactPanelContext.Provider value={null}>
+          <ReactPanelManagerContext.Provider value={panelManager}>
+            <DHCDasbhoard
+              onGoldenLayoutChange={setChildLayout}
+              onLayoutInitialized={() => setLayoutInitialized(true)}
+            >
+              {plugins}
+              {isLayoutInitialized && <>{normalizedChildren}</>}
+            </DHCDasbhoard>
+          </ReactPanelManagerContext.Provider>
+        </ReactPanelContext.Provider>
+      </ParentItemContext.Provider>
+      {/* Resetting the panel ID so the children don't get confused */}
+      {/* <ReactPanelContext.Provider value={null}>
+        <ReactPanelManagerContext.Provider value={panelManager}>
+          {childLayout != null && (
+            <LayoutManagerContext.Provider value={childLayout}>
+              <ParentItemContext.Provider value={childLayout.root}>
+                {normalizedChildren}
+              </ParentItemContext.Provider>
+            </LayoutManagerContext.Provider>
+          )}
+        </ReactPanelManagerContext.Provider>
+      </ReactPanelContext.Provider> */}
+    </ReactPanel>
+    // </>
   );
+  // <ParentItemContext.Provider value={parent}>
+  //       {normalizedChildren}
+  //     </ParentItemContext.Provider>
+  // </DashboardLayout>
 }
 
 export default Dashboard;

--- a/plugins/ui/src/js/src/layout/Dashboard.tsx
+++ b/plugins/ui/src/js/src/layout/Dashboard.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useMemo, useRef, useState } from 'react';
 import { nanoid } from 'nanoid';
 import {
-  Dashboard as DHCDasbhoard,
+  Dashboard as DHCDashboard,
   LayoutManagerContext,
 } from '@deephaven/dashboard';
 import GoldenLayout from '@deephaven/golden-layout';
@@ -13,9 +13,10 @@ import {
 } from './LayoutUtils';
 import { ParentItemContext, useParentItem } from './ParentItemContext';
 import ReactPanel from './ReactPanel';
-import { ReactPanelContext } from './ReactPanelContext';
+import { ReactPanelContext, usePanelId } from './ReactPanelContext';
 import useWidgetStatus from './useWidgetStatus';
 import { ReactPanelManagerContext } from './ReactPanelManager';
+import PortalPanelManager from './PortalPanelManager';
 
 const log = Log.module('@deephaven/js-plugin-ui/DocumentHandler');
 
@@ -98,20 +99,24 @@ function Dashboard({ children }: DashboardElementProps): JSX.Element | null {
 
   return (
     // <>
-    <ReactPanel>
-      <ParentItemContext.Provider value={null}>
-        <ReactPanelContext.Provider value={null}>
+    <>
+      {/* <ReactPanelManagerContext.Provider value={panelManager}> */}
+      <DHCDashboard
+        onGoldenLayoutChange={setChildLayout}
+        onLayoutInitialized={() => setLayoutInitialized(true)}
+      >
+        {plugins}
+        <PortalPanelManager>
           <ReactPanelManagerContext.Provider value={panelManager}>
-            <DHCDasbhoard
-              onGoldenLayoutChange={setChildLayout}
-              onLayoutInitialized={() => setLayoutInitialized(true)}
-            >
-              {plugins}
-              {isLayoutInitialized && <>{normalizedChildren}</>}
-            </DHCDasbhoard>
+            <ParentItemContext.Provider value={null}>
+              <ReactPanelContext.Provider value={null}>
+                {isLayoutInitialized && normalizedChildren}
+              </ReactPanelContext.Provider>
+            </ParentItemContext.Provider>
           </ReactPanelManagerContext.Provider>
-        </ReactPanelContext.Provider>
-      </ParentItemContext.Provider>
+        </PortalPanelManager>
+      </DHCDashboard>
+      {/* </ReactPanelManagerContext.Provider> */}
       {/* Resetting the panel ID so the children don't get confused */}
       {/* <ReactPanelContext.Provider value={null}>
         <ReactPanelManagerContext.Provider value={panelManager}>
@@ -124,7 +129,7 @@ function Dashboard({ children }: DashboardElementProps): JSX.Element | null {
           )}
         </ReactPanelManagerContext.Provider>
       </ReactPanelContext.Provider> */}
-    </ReactPanel>
+    </>
     // </>
   );
   // <ParentItemContext.Provider value={parent}>

--- a/plugins/ui/src/js/src/layout/LayoutUtils.tsx
+++ b/plugins/ui/src/js/src/layout/LayoutUtils.tsx
@@ -153,6 +153,7 @@ export function isDashboardElementNode(
 export function normalizeDashboardChildren(
   children: React.ReactNode
 ): React.ReactNode {
+  console.log('xxx normalizeDashboardChildren', children);
   const needsWrapper = Children.count(children) > 1;
   const hasRows = Children.toArray(children).some(
     child => isValidElement(child) && child.type === Row

--- a/plugins/ui/src/js/src/layout/LayoutUtils.tsx
+++ b/plugins/ui/src/js/src/layout/LayoutUtils.tsx
@@ -113,9 +113,12 @@ export function isStackElementNode(obj: unknown): obj is StackElementNode {
   );
 }
 
-export type DashboardElementProps = React.PropsWithChildren<
-  Record<string, unknown>
->;
+export type DashboardElementProps = React.PropsWithChildren<{
+  /** Whether to show the close icon in the top right corner of the dashboard */
+  showCloseIcon?: boolean;
+  /** Whether to show headers for the dashboard */
+  showHeaders?: boolean;
+}>;
 
 /**
  * Describes a dashboard element that can be rendered in the UI.

--- a/plugins/ui/src/js/src/layout/Row.tsx
+++ b/plugins/ui/src/js/src/layout/Row.tsx
@@ -7,6 +7,7 @@ import { ParentItemContext, useParentItem } from './ParentItemContext';
 import { usePanelId } from './ReactPanelContext';
 
 function LayoutRow({ children, height }: RowElementProps): JSX.Element | null {
+  console.log('xxx doing a LayoutRow');
   const layoutManager = useLayoutManager();
   const parent = useParentItem();
   const row = useMemo(() => {
@@ -45,6 +46,7 @@ function Row({ children, height }: RowElementProps): JSX.Element {
     return <LayoutRow height={height}>{children}</LayoutRow>;
   }
 
+  console.log('xxx doing a flexRow with panelId', panelId);
   return (
     <Flex height={`${height}%`} direction="row">
       {children}

--- a/plugins/ui/src/js/src/styles.scss
+++ b/plugins/ui/src/js/src/styles.scss
@@ -103,11 +103,45 @@
   padding: 0;
 }
 
+$lm-header-nested-height: 18px;
+$lm-header-double-nested-height: 14px;
+$lm-header-nested-font-size: 11px;
+$lm-header-double-nested-font-size: 10px;
+$lm-header-nested-color: var(--dh-color-gray-600);
+$lm-header-double-nested-color: var(--dh-color-gray-500);
+$lm-header-nested-bg: var(--dh-color-gray-50);
+$lm-header-double-nested-bg: var(--dh-color-true-black);
+
 .dashboard-container {
   .dashboard-container {
-    border: 5px solid red;
+    // border: 5px solid red;
+    .lm_tab {
+      height: $lm-header-nested-height;
+      font-size: $lm-header-nested-font-size;
+      // color: $lm-header-nested-color;
+    }
+    .lm_tabs {
+      background: $lm-header-nested-bg;
+    }
+    .lm_header {
+      height: $lm-header-nested-height;
+    }
+    .lm_close_tab {
+      display: none; // hide close icon for nested tabs
+    }
     .dashboard-container {
-      border: 5px solid blue;
+      // border: 5px solid blue;
+      .lm_tab {
+        height: $lm-header-double-nested-height;
+        font-size: $lm-header-double-nested-font-size;
+        // color: $lm-header-double-nested-color;
+      }
+      .lm_tabs {
+        background: $lm-header-double-nested-bg;
+      }
+      .lm_header {
+        height: $lm-header-double-nested-height;
+      }
     }
   }
 }

--- a/plugins/ui/src/js/src/styles.scss
+++ b/plugins/ui/src/js/src/styles.scss
@@ -102,3 +102,12 @@
 .ui-markdown {
   padding: 0;
 }
+
+.dashboard-container {
+  .dashboard-container {
+    border: 5px solid red;
+    .dashboard-container {
+      border: 5px solid blue;
+    }
+  }
+}

--- a/plugins/ui/src/js/src/widget/DocumentHandler.tsx
+++ b/plugins/ui/src/js/src/widget/DocumentHandler.tsx
@@ -130,6 +130,7 @@ function DocumentHandler({
         panelIds.current.length
       );
       if (panelIds.current.length === 0) {
+        // Let's just ignore this for now ...
         log.debug('Widget', widget.id, 'closed all panels, triggering onClose');
         onClose?.();
       } else {

--- a/plugins/ui/src/js/src/widget/DocumentUtils.tsx
+++ b/plugins/ui/src/js/src/widget/DocumentUtils.tsx
@@ -45,7 +45,7 @@ export function getRootChildren(
     throw new MixedPanelsError('Cannot mix Panel and Dashboard elements');
   }
 
-  if (nonLayoutCount === childrenArray.length) {
+  if (nonLayoutCount === childrenArray.length || dashboardCount > 0) {
     // Just wrap it in a panel
     return (
       <ReactPanel title={widget.name ?? widget.id ?? widget.type}>

--- a/plugins/ui/src/js/src/widget/WidgetHandler.tsx
+++ b/plugins/ui/src/js/src/widget/WidgetHandler.tsx
@@ -98,12 +98,12 @@ function WidgetHandler({
 
   if (widget !== prevWidget) {
     setPrevWidget(widget);
-    if (widget != null && widget.type === DASHBOARD_ELEMENT) {
-      log.info(
-        'Dashboard widget has changed, removing previous elements from layout'
-      );
-      layoutManager.root.contentItems.forEach(item => item.remove());
-    }
+    // if (widget != null && widget.type === DASHBOARD_ELEMENT) {
+    //   log.info(
+    //     'Dashboard widget has changed, removing previous elements from layout'
+    //   );
+    //   layoutManager.root.contentItems.forEach(item => item.remove());
+    // }
   }
 
   if (widgetError != null && isLoading) {


### PR DESCRIPTION
- Prototype for now to play around with styling and what not, to see what feels right. Styles are in `styles.scss` in the deephaven.ui plugin, just did some extra styling for dashboards nested in a dashboard
- Dragging panels around is limited to within that dashboard
- Updated to the latest packages (`pip instsall --upgrade deephaven-core deephaven-server`), then ran `python tools/plugin_builder.py --js --reinstall --server --server-arg --port=10000 --server-arg --jvm-args="-DAuthHandlers=io.deephaven.auth.AnonymousAuthenticationHandler" ui`
- Tested by running the code snippet below, and then navigating to http://localhost:10000/iframe/widget/?name=home to see what the "home" page would look like
```python
# This example creates a bunch of dashboards, then creates a "home page" that displays a menu of the dashboards on the left, and the embedded dashboard on the right.
# Simply run this code snippet, then navigate to http://localhost:10000/iframe/widget/?name=home
# Creating example dashboards
from deephaven.time import dh_now
from deephaven import time_table, ui
import deephaven.plot.express as dx


# The control panel contain UI elements to set filtering
@ui.component
def control_panel(filter_type, set_filter_type, dates, set_dates, value, set_value):
    return ui.panel(
        ui.radio_group(
            ui.radio("Date"),
            ui.radio("Value"),
            value=filter_type,
            on_change=set_filter_type,
            label="Filter type",
        ),
        ui.date_range_picker(label="Date filter", value=dates, on_change=set_dates),
        ui.picker(
            "A", "B", selected_key=value, on_change=set_value, label="Value filter"
        ),
        title="Controls",
    )


# The create dashboard component contains the state variables and returns the ui.row
@ui.component
def create_dashboard(start_date, end_date, table):
    # State to choose the filter type
    filter_type, set_filter_type = ui.use_state("Date")

    # State variable to filter by Value column
    value, set_value = ui.use_state("A")

    # State variable to filter by Date column
    dates, set_dates = ui.use_state({"start": start_date, "end": end_date})
    start = dates["start"]
    end = dates["end"]

    # handler to filter the table
    def handle_filter(filter_type, start, end, value, table):
        if filter_type == "Date":
            return table.where("Date >= start && Date < end")
        else:
            return table.where("Value=value")

    # memoize table operations and plots
    filtered_table = ui.use_memo(
        lambda start=start, end=end: handle_filter(
            filter_type, start, end, value, table
        ),
        [filter_type, start, end, value, table],
    )
    plot = ui.use_memo(
        lambda: dx.line(filtered_table, x="Date", y="Row"), [filtered_table]
    )

    # This row will be the root layout for the dashboard
    return ui.row(
        control_panel(filter_type, set_filter_type, dates, set_dates, value, set_value),
        ui.column(
            ui.stack(
                ui.panel(filtered_table, title="Filter table"),
                ui.panel(table, title="Original table"),
                active_item_index=0,
            ),
            ui.panel(plot, title="Plot"),
        ),
    )


SECONDS_IN_DAY = 86400
today = dh_now()
_table = time_table("PT1s").update_view([
    "Date=today.plusSeconds(SECONDS_IN_DAY*i)",
    "Value=i%2==0 ? `A` : `B`",
    "Row=i",
])
_example_dashboard = ui.dashboard(
    create_dashboard(today, today.plusSeconds(SECONDS_IN_DAY * 10), _table)
)

_stocks = dx.data.stocks()
_dash_2x1 = ui.dashboard(ui.row(ui.panel("A", title="A"), ui.panel("B", title="B")))
_dash_1x2 = ui.dashboard(ui.column(ui.panel("A", title="A"), ui.panel("B", title="B")))
_dash_2x2 = ui.dashboard(
    ui.row(
        ui.column(ui.panel("A", title="A"), ui.panel("C", title="C")),
        ui.column(ui.panel("B", title="B"), ui.panel("D", title="D")),
    )
)
_dash_3x1 = ui.dashboard(
    ui.row(ui.panel("A", title="A"), ui.panel("B", title="B"), ui.panel("C", title="C"))
)
_dash_stack = ui.dashboard(
    ui.stack(
        ui.panel("A", title="A"), ui.panel("B", title="B"), ui.panel("C", title="C")
    )
)
_dash_stack_nested = ui.dashboard(
    ui.stack(
        ui.panel(
            ui.tabs(ui.tab("A1 content", title="A1"), ui.tab("A2 content", title="A2")),
            title="A",
        ),
        ui.panel(
            ui.tabs(ui.tab("B1 content", title="B1"), ui.tab("B2 content", title="B2")),
            title="B",
        ),
    )
)
_dash_layout_stack = ui.dashboard(
    ui.row(
        ui.stack(
            ui.panel("A", title="A"), ui.panel("B", title="B"), ui.panel("C", title="C")
        ),
        ui.panel("D", title="D"),
        ui.panel("E", title="E"),
    )
)
_double_dash = ui.dashboard(
    ui.row(
        ui.panel(
            "In this example dashboard, we show how one can make a dashboard with no headers, display UI panel on the left and display another dashboard in a panel on the right. This could be another home screen."
        ),
        ui.panel(_example_dashboard),
    ),
    show_close_icon=False,
    show_headers=False,
)
# End of creating dashboards


from deephaven import ui
from typing import Callable

simple_dashboards = {}
for i in range(0, 10):
    simple_dashboards[f"Dashboard {i}"] = ui.dashboard(
        ui.panel(ui.heading(f"Dashboard {i}"))
    )

layout_dashboards = {
    "Row split (2x1)": _dash_2x1,
    "Column split (1x2)": _dash_1x2,
    "2x2": _dash_2x2,
    "3x1": _dash_3x1,
    "Basic stack": _dash_stack,
    "Nested stack": _dash_stack_nested,
    "Stack in a layout": _dash_layout_stack,
}

complex_dashboards = {
    "Example Dashboard": _example_dashboard,
    "Nested Dashboard": _double_dash,
}


@ui.component
def dashboard_list(dashboards, on_select: Callable[[any], None]):
    return ui.flex(
        map(
            lambda k: ui.button(
                k, on_press=lambda: on_select(dashboards[k]), variant="ghost"
            ),
            dashboards,
        ),
        direction="Column",
    )


@ui.component
def dashboard_menu(on_select: Callable[[any], None]):
    return ui.accordion(
        ui.disclosure(
            "Simple dashboards", dashboard_list(simple_dashboards, on_select=on_select)
        ),
        ui.disclosure(
            "Layout dashboards", dashboard_list(layout_dashboards, on_select=on_select)
        ),
        ui.disclosure(
            "Complex dashboards",
            dashboard_list(complex_dashboards, on_select=on_select),
        ),
    )


@ui.component
def home_screen():
    active_dashboard, set_active_dashboard = ui.use_state(None)

    return ui.dashboard(
        ui.row(
            ui.column(
                ui.panel(dashboard_menu(on_select=set_active_dashboard)), width=20
            ),
            ui.panel(
                ui.view(
                    active_dashboard,
                    key=None if active_dashboard is None else id(active_dashboard),
                    width="100%",
                    height="100%",
                )
            ),
        ),
        show_close_icon=False,
        show_headers=False,
    )


# Show the home screen nested within itself for funsies
complex_dashboards["Nested Homescreen"] = home_screen()

home = home_screen()
```