### PR TITLE
ci: Remove python 3.8 from tests and add python 3.13

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -19,6 +19,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.8'
+          python-version: '3.9'
           cache: 'pip'
       - uses: pre-commit/action@v3.0.1

--- a/.github/workflows/test-python-package.yml
+++ b/.github/workflows/test-python-package.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python: ['3.9', '3.10', '3.11', '3.12', '3.13']
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -78,21 +78,12 @@ If you want to run tests locally (which may be easier for debugging or creating 
 
 The [venv setup](#pre-commit-hookspython-formatting) steps will also set up `tox` to run tests for the python plugins that support it.
 Note that `tox` sets up an isolated environment for running tests.  
-Be default, `tox` will run against Python 3.8, which will need to be installed on your system before running tests.
+Be default, `tox` will run against Python 3.9, which will need to be installed on your system before running tests.
 You can run tests with the following command from the `plugins/<plugin>` directory:
 
 ```shell
 tox -e py
 ```
-
-> [!IMPORTANT]
-> Linux, and possibly other setups such as MacOS depending on method, may require additional packages to be installed to run Python 3.8.
->
-> ```shell
-> sudo apt install python3.8 python3.8-distutils libpython3.8
-> # or just full install although it will include more packages than necessary
-> sudo apt install python3.8-full
-> ```
 
 You can also run tests against a specific version of python by appending the version to `py`  
 This assumes that the version of Python you're targeting is installed on your system.  

--- a/plugins/ag-grid/tox.ini
+++ b/plugins/ag-grid/tox.ini
@@ -6,10 +6,7 @@ deps =
     deephaven-server
 commands =
     python -m unittest {posargs}
-basepython = python3.8
-
-[testenv:py3.8]
-basepython = python3.8
+basepython = python3.9
 
 [testenv:py3.9]
 basepython = python3.9
@@ -22,3 +19,6 @@ basepython = python3.11
 
 [testenv:py3.12]
 basepython = python3.12
+
+[testenv:py3.13]
+basepython = python3.13

--- a/plugins/matplotlib/tox.ini
+++ b/plugins/matplotlib/tox.ini
@@ -4,8 +4,6 @@ isolated_build = True
 [testenv]
 deps =
     deephaven-server
-commands =
-    python -m unittest {posargs}
 basepython = python3.9
 
 [testenv:py3.9]

--- a/plugins/matplotlib/tox.ini
+++ b/plugins/matplotlib/tox.ini
@@ -1,0 +1,24 @@
+[tox]
+isolated_build = True
+
+[testenv]
+deps =
+    deephaven-server
+commands =
+    python -m unittest {posargs}
+basepython = python3.9
+
+[testenv:py3.9]
+basepython = python3.9
+
+[testenv:py3.10]
+basepython = python3.10
+
+[testenv:py3.11]
+basepython = python3.11
+
+[testenv:py3.12]
+basepython = python3.12
+
+[testenv:py3.13]
+basepython = python3.13

--- a/plugins/packaging/tox.ini
+++ b/plugins/packaging/tox.ini
@@ -4,8 +4,6 @@ isolated_build = True
 [testenv]
 deps =
     deephaven-server
-commands =
-    python -m unittest {posargs}
 basepython = python3.9
 
 [testenv:py3.9]

--- a/plugins/packaging/tox.ini
+++ b/plugins/packaging/tox.ini
@@ -1,0 +1,24 @@
+[tox]
+isolated_build = True
+
+[testenv]
+deps =
+    deephaven-server
+commands =
+    python -m unittest {posargs}
+basepython = python3.9
+
+[testenv:py3.9]
+basepython = python3.9
+
+[testenv:py3.10]
+basepython = python3.10
+
+[testenv:py3.11]
+basepython = python3.11
+
+[testenv:py3.12]
+basepython = python3.12
+
+[testenv:py3.13]
+basepython = python3.13

--- a/plugins/pivot/tox.ini
+++ b/plugins/pivot/tox.ini
@@ -6,10 +6,7 @@ deps =
     deephaven-server
 commands =
     python -m unittest {posargs}
-basepython = python3.8
-
-[testenv:py3.8]
-basepython = python3.8
+basepython = python3.9
 
 [testenv:py3.9]
 basepython = python3.9
@@ -22,3 +19,6 @@ basepython = python3.11
 
 [testenv:py3.12]
 basepython = python3.12
+
+[testenv:py3.13]
+basepython = python3.13

--- a/plugins/plotly-express/tox.ini
+++ b/plugins/plotly-express/tox.ini
@@ -6,10 +6,7 @@ deps =
     deephaven-server
 commands =
     python -m unittest discover
-basepython = python3.8
-
-[testenv:py3.8]
-basepython = python3.8
+basepython = python3.9
 
 [testenv:py3.9]
 basepython = python3.9
@@ -23,4 +20,5 @@ basepython = python3.11
 [testenv:py3.12]
 basepython = python3.12
 
-
+[testenv:py3.13]
+basepython = python3.13

--- a/plugins/simple-pivot/tox.ini
+++ b/plugins/simple-pivot/tox.ini
@@ -6,10 +6,7 @@ deps =
     deephaven-server
 commands =
     python -m unittest {posargs}
-basepython = python3.8
-
-[testenv:py3.8]
-basepython = python3.8
+basepython = python3.9
 
 [testenv:py3.9]
 basepython = python3.9
@@ -22,3 +19,6 @@ basepython = python3.11
 
 [testenv:py3.12]
 basepython = python3.12
+
+[testenv:py3.13]
+basepython = python3.13

--- a/plugins/theme-pack/tox.ini
+++ b/plugins/theme-pack/tox.ini
@@ -6,10 +6,7 @@ deps =
     deephaven-server
 commands =
     python -m unittest {posargs}
-basepython = python3.8
-
-[testenv:py3.8]
-basepython = python3.8
+basepython = python3.9
 
 [testenv:py3.9]
 basepython = python3.9
@@ -22,3 +19,6 @@ basepython = python3.11
 
 [testenv:py3.12]
 basepython = python3.12
+
+[testenv:py3.13]
+basepython = python3.13

--- a/plugins/ui/test/deephaven/ui/test_ui_table.py
+++ b/plugins/ui/test/deephaven/ui/test_ui_table.py
@@ -19,9 +19,7 @@ class UITableTestCase(BaseTestCase):
         context = RenderContext(on_change, on_queue)
         result = ui_table.render(context)
 
-        # Can replace 2nd param with result | expected_props after dropping Python 3.8
-        # https://stackoverflow.com/questions/20050913/python-unittests-assertdictcontainssubset-recommended-alternative
-        self.assertDictEqual(result, {**result, **expected_props})
+        self.assertDictEqual(result, result | expected_props)
 
     def test_empty_ui_table(self):
         import deephaven.ui as ui

--- a/plugins/ui/tox.ini
+++ b/plugins/ui/tox.ini
@@ -6,10 +6,7 @@ deps =
     deephaven-server
 commands =
     python -m unittest {posargs}
-basepython = python3.8
-
-[testenv:py3.8]
-basepython = python3.8
+basepython = python3.9
 
 [testenv:py3.9]
 basepython = python3.9
@@ -22,3 +19,6 @@ basepython = python3.11
 
 [testenv:py3.12]
 basepython = python3.12
+
+[testenv:py3.13]
+basepython = python3.13

--- a/plugins/utilities/tox.ini
+++ b/plugins/utilities/tox.ini
@@ -4,8 +4,6 @@ isolated_build = True
 [testenv]
 deps =
     deephaven-server
-commands =
-    python -m unittest {posargs}
 basepython = python3.9
 
 [testenv:py3.9]

--- a/plugins/utilities/tox.ini
+++ b/plugins/utilities/tox.ini
@@ -1,0 +1,24 @@
+[tox]
+isolated_build = True
+
+[testenv]
+deps =
+    deephaven-server
+commands =
+    python -m unittest {posargs}
+basepython = python3.9
+
+[testenv:py3.9]
+basepython = python3.9
+
+[testenv:py3.10]
+basepython = python3.10
+
+[testenv:py3.11]
+basepython = python3.11
+
+[testenv:py3.12]
+basepython = python3.12
+
+[testenv:py3.13]
+basepython = python3.13

--- a/templates/widget/{{ cookiecutter.python_project_name }}/tox.ini
+++ b/templates/widget/{{ cookiecutter.python_project_name }}/tox.ini
@@ -6,10 +6,7 @@ deps =
     deephaven-server
 commands =
     python -m unittest {posargs}
-basepython = python3.8
-
-[testenv:py3.8]
-basepython = python3.8
+basepython = python3.9
 
 [testenv:py3.9]
 basepython = python3.9
@@ -22,3 +19,6 @@ basepython = python3.11
 
 [testenv:py3.12]
 basepython = python3.12
+
+[testenv:py3.13]
+basepython = python3.13


### PR DESCRIPTION
- Python 3.8 is past EOL: https://devguide.python.org/versions/
- jpy no longer publishes wheels for Python 3.8: https://github.com/jpy-consortium/jpy/pull/201
- Logged a ticket for deephaven-core to update requirements: https://deephaven.atlassian.net/browse/DH-20615
- For the deephaven-plugins tests, just remove 3.8 and add 3.13 (since it should be supported as well)
