### PR TITLE
fix: DH-21498: Hook up the disconnect/reconnect events

### DIFF
--- a/plugins/pivot/setup.cfg
+++ b/plugins/pivot/setup.cfg
@@ -16,7 +16,8 @@ packages=find_namespace:
 install_requires =
     deephaven-core>=0.37.0
     deephaven-plugin>=0.6.0
-    deephaven-plugin-utilities
+    deephaven-plugin-utilities>=0.0.2
+    typing_extensions;python_version<'3.11'
 include_package_data = True
 
 [options.packages.find]

--- a/plugins/pivot/setup.cfg
+++ b/plugins/pivot/setup.cfg
@@ -18,6 +18,7 @@ install_requires =
     deephaven-plugin>=0.6.0
     deephaven-plugin-utilities>=0.0.2
     typing_extensions;python_version<'3.11'
+    pytz
 include_package_data = True
 
 [options.packages.find]

--- a/plugins/pivot/setup.cfg
+++ b/plugins/pivot/setup.cfg
@@ -14,7 +14,7 @@ package_dir=
     =src
 packages=find_namespace:
 install_requires =
-    deephaven-core>=0.35.1
+    deephaven-core>=0.37.0
     deephaven-plugin>=0.6.0
     deephaven-plugin-utilities
 include_package_data = True

--- a/plugins/pivot/src/js/src/IrisGridPivotModel.test.ts
+++ b/plugins/pivot/src/js/src/IrisGridPivotModel.test.ts
@@ -333,7 +333,7 @@ describe('IrisGridPivotModel', () => {
 
     model.setViewport(0, 10);
 
-    expect(pivotTable.addEventListener).toHaveBeenCalledTimes(1);
+    expect(pivotTable.addEventListener).toHaveBeenCalledTimes(3);
 
     // Simulate the update event with the data
     asMock(pivotTable.addEventListener).mock.calls[0][1](updateEvent);

--- a/plugins/pivot/src/js/src/IrisGridPivotModel.ts
+++ b/plugins/pivot/src/js/src/IrisGridPivotModel.ts
@@ -930,8 +930,6 @@ class IrisGridPivotModel<R extends UIPivotRow = UIPivotRow>
   startListening(): void {
     super.startListening();
 
-    log.info('Pivot Table start listening');
-
     this.pivotTable.addEventListener(
       this.dh.coreplus.pivot.PivotTable.EVENT_UPDATED,
       this.handlePivotUpdated

--- a/plugins/pivot/src/js/src/IrisGridPivotModel.ts
+++ b/plugins/pivot/src/js/src/IrisGridPivotModel.ts
@@ -174,6 +174,8 @@ class IrisGridPivotModel<R extends UIPivotRow = UIPivotRow>
 
     this.handleModelEvent = this.handleModelEvent.bind(this);
     this.handlePivotUpdated = this.handlePivotUpdated.bind(this);
+    this.handleTableDisconnect = this.handleTableDisconnect.bind(this);
+    this.handleTableReconnect = this.handleTableReconnect.bind(this);
 
     this.pivotTable = pivotTable;
     this.irisFormatter = formatter;
@@ -720,6 +722,18 @@ class IrisGridPivotModel<R extends UIPivotRow = UIPivotRow>
     this.dispatchEvent(new EventShimCustomEvent(type, { detail }));
   }
 
+  handleTableDisconnect(): void {
+    log.info('Pivot table disconnected');
+    this.dispatchEvent(
+      new EventShimCustomEvent(IrisGridModel.EVENT.DISCONNECT)
+    );
+  }
+
+  handleTableReconnect(): void {
+    log.info('Pivot table reconnected');
+    this.dispatchEvent(new EventShimCustomEvent(IrisGridModel.EVENT.RECONNECT));
+  }
+
   handlePivotUpdated(
     event: CorePlusDhType.Event<CorePlusDhType.coreplus.pivot.PivotSnapshot>
   ): void {
@@ -916,9 +930,20 @@ class IrisGridPivotModel<R extends UIPivotRow = UIPivotRow>
   startListening(): void {
     super.startListening();
 
+    log.info('Pivot Table start listening');
+
     this.pivotTable.addEventListener(
       this.dh.coreplus.pivot.PivotTable.EVENT_UPDATED,
       this.handlePivotUpdated
+    );
+
+    this.pivotTable.addEventListener(
+      this.dh.coreplus.pivot.PivotTable.EVENT_DISCONNECT,
+      this.handleTableDisconnect
+    );
+    this.pivotTable.addEventListener(
+      this.dh.coreplus.pivot.PivotTable.EVENT_RECONNECT,
+      this.handleTableReconnect
     );
   }
 
@@ -928,6 +953,15 @@ class IrisGridPivotModel<R extends UIPivotRow = UIPivotRow>
     this.pivotTable.removeEventListener(
       this.dh.coreplus.pivot.PivotTable.EVENT_UPDATED,
       this.handlePivotUpdated
+    );
+
+    this.pivotTable.removeEventListener(
+      this.dh.coreplus.pivot.PivotTable.EVENT_DISCONNECT,
+      this.handleTableDisconnect
+    );
+    this.pivotTable.removeEventListener(
+      this.dh.coreplus.pivot.PivotTable.EVENT_RECONNECT,
+      this.handleTableReconnect
     );
   }
 


### PR DESCRIPTION
Pass disconnect/reconnect events through the pivot model.

Blocked by
[DH-21140](https://deephaven.atlassian.net/browse/DH-21140)

[DH-21140]: https://deephaven.atlassian.net/browse/DH-21140?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ