### PR TITLE
fix: DH-21221: Fixed a bug with remote file source cache eviction

### DIFF
--- a/.github/skills/build-plugin/SKILL.md
+++ b/.github/skills/build-plugin/SKILL.md
@@ -7,11 +7,26 @@ description: Build and install Python plugins using plugin_builder.py. Use when 
 
 Use `plugin_builder.py` from repo root. Requires venv activation first.
 
+## First-time setup
+
+```bash
+# Python dependencies
+source .venv/bin/activate
+pip install --upgrade -r requirements.txt
+
+# JS dependencies (if building plugins with --js flag)
+nvm install
+npm install
+```
+
 ## Commands
 
 ```bash
-# Build and install a plugin
+# First install of a plugin (REQUIRED before using --reinstall)
 python tools/plugin_builder.py --install ui
+
+# First install with JS assets (for plugins with JS components)
+python tools/plugin_builder.py --js --install python-remote-file-source
 
 # Reinstall a plugin (use when code changed but version not bumped)
 python tools/plugin_builder.py --reinstall ui
@@ -19,23 +34,26 @@ python tools/plugin_builder.py --reinstall ui
 # Build multiple plugins
 python tools/plugin_builder.py --reinstall ui plotly-express
 
-# Build with JS assets
+# Build with JS assets and reinstall
 python tools/plugin_builder.py --js --reinstall ui
 
-# Build and start server
-python tools/plugin_builder.py --reinstall --server ui
+# Build, install, and start server
+python tools/plugin_builder.py --install --server ui
 ```
 
 ## Common flags
 
-- `--install` / `-i`: Install plugin
-- `--reinstall` / `-r`: Force reinstall (no version bump needed)
-- `--js` / `-j`: Also build JS assets
+- `--install` / `-i`: Install plugin (REQUIRED on first run)
+- `--reinstall` / `-r`: Force reinstall (no version bump needed, only after --install)
+- `--js` / `-j`: Also build JS assets (additive - Python build still happens)
 - `--server` / `-s`: Start deephaven-server after build
 - `--docs` / `-d`: Build documentation
+- `--server-arg` / `-sa`: Pass argument to deephaven server (e.g., `-sa --port=9999`)
 
 ## Notes
 
+- **Must use `--install` on first run** - `--reinstall` will fail if plugin not already installed
 - Assumes Python `.venv` is already sourced (`source .venv/bin/activate`)
 - Use `--reinstall` during development when version hasn't changed
+- Running with no flags defaults to `--js --install` for all plugins
 - First run may take longer to install dependencies

--- a/README.md
+++ b/README.md
@@ -227,7 +227,6 @@ Skip the venv setup if you already have one
 python -m venv .venv
 source .venv/bin/activate
 pip install --upgrade -r requirements.txt
-pip install click watchdog
 ```
 
 The script can then be used to help set up your venv.
@@ -288,12 +287,7 @@ This example will build the docs for the `ui` plugin and re-generate the snapsho
 python tools/plugin_builder.py --docs --snapshots ui
 ```
 
-To run the server, pass the `--server` flag.  
-First install `deephaven-server` if it is not already installed (if setup with `--configure=full` this is already done):
-
-```shell
-pip install deephaven-server
-```
+To run the server, pass the `--server` flag.
 
 This example reinstalls the `plotly-express` plugin, then starts the server:
 

--- a/plugins/python-remote-file-source/README.md
+++ b/plugins/python-remote-file-source/README.md
@@ -3,6 +3,7 @@
 A Deephaven bi-directional plugin to allow sourcing Python imports from a remote file source. It consists of a Python plugin installed and then instantiated in a Deephaven Core / Core+ worker. When a client connects to the plugin, a custom Python `sys.meta_path` finder and loader are registered that will send messages to the client to request content for loading modules.
 
 ## Plugin Messages
+
 Bi-directional communication between the server plugin and a client uses JSON-RPC.
 
 ### JSON-RPC Messages
@@ -10,21 +11,24 @@ Bi-directional communication between the server plugin and a client uses JSON-RP
 The plugin uses the following JSON-RPC v2 messages for communication between the Python server and the client:
 
 #### Request: `request_plugin_info`
+
 **Direction:** Client → Server
 
 Returns a list of top-level module names available for remote import.
 
 **Example:**
+
 ```json
 {
-   "jsonrpc": "2.0",
-   "id": "<unique id>",
-   "method": "request_plugin_info",
-   "params": {}
+  "jsonrpc": "2.0",
+  "id": "<unique id>",
+  "method": "request_plugin_info",
+  "params": {}
 }
 ```
 
 **Response:**
+
 ```json
 {
    "jsonrpc": "2.0",
@@ -36,61 +40,68 @@ Returns a list of top-level module names available for remote import.
 ```
 
 #### Request: `set_connection_id`
+
 **Direction:** Client → Server
 
 Sets the connection id on the MessageStream and tells the MessageStream it can register a `RemoteMetaPathFinder` to source Python imports for scripts run with a matching execution context connection id.
 
 **Example:**
+
 ```json
 {
-   "jsonrpc": "2.0",
-   "id": "<unique id>",
-   "method": "set_connection_id",
-   "params": {"id": "<connection id>"}
+  "jsonrpc": "2.0",
+  "id": "<unique id>",
+  "method": "set_connection_id",
+  "params": { "id": "<connection id>" }
 }
 ```
 
 **Response:**
+
 ```json
 {
-   "jsonrpc": "2.0",
-   "id": "<same id>",
-   "result": null
+  "jsonrpc": "2.0",
+  "id": "<same id>",
+  "result": null
 }
 ```
 
 #### Request: `fetch_module`
+
 **Direction:** Server → Client
 
 Requests the source code and file path for a Python module from the client. Used by the server to fetch remote modules for import.
 
 **Example:**
+
 ```json
 {
-   "jsonrpc": "2.0",
-   "id": "<unique id>",
-   "method": "fetch_module",
-   "params": {"module_name": "some.module.name"}
+  "jsonrpc": "2.0",
+  "id": "<unique id>",
+  "method": "fetch_module",
+  "params": { "module_name": "some.module.name" }
 }
 ```
 
 **Response:**
+
 ```json
 {
-   "jsonrpc": "2.0",
-   "id": "<same id>",
-   "result": {
-      "filepath": "/path/to/module.py",
-      "source": "<python source code as string>"
-   }
+  "jsonrpc": "2.0",
+  "id": "<same id>",
+  "result": {
+    "filepath": "/path/to/module.py",
+    "source": "<python source code as string>"
+  }
 }
 ```
+
 If the module spec is not found `result` will be `None`. The `filepath` property will contain a filesystem path or `<script>` if no associated path can be provided. The `source` property will either contain the source of the module, or `None` if no content exists.
 
 ## Plugin Structure
 
 The `src` directory contains the Python and JavaScript code for the plugin.  
-Within the `src` directory, the `deephaven/python_remote_file_source` directory contains the Python code, and the `js` directory contains the JavaScript code.  
+Within the `src` directory, the `deephaven/python_remote_file_source` directory contains the Python code, and the `js` directory contains the JavaScript code.
 
 The Python files have the following structure:  
 `plugin_object.py` defines a simple Python class that can send messages to the client.
@@ -99,14 +110,15 @@ The Python files have the following structure:
 
 The JavaScript files have the following structure:  
 `PythonRemoteFileSourcePlugin.ts` registers the plugin with Deephaven. This contains the client equivalent of the type in `plugin_type.py` and these should be kept in sync.  
-`PythonRemoteFileSourcePluginView.tsx` defines the plugin panel and message handling. This is where messages are received when sent from the Python side of the plugin. 
+`PythonRemoteFileSourcePluginView.tsx` defines the plugin panel and message handling. This is where messages are received when sent from the Python side of the plugin.
 
 Additionally, the `test` directory contains Python tests for the plugin.
-It's recommended to use `tox` to run the tests, and the `tox.ini` file is included in the project.  
+It's recommended to use `tox` to run the tests, and the `tox.ini` file is included in the project.
 
 ## Building the Plugin
 
 1. Install dependencies
+
 ```sh
 # Install js dependencies
 nvm install
@@ -120,6 +132,7 @@ pip install click watchdog deephaven-server
 ```
 
 2. Build the python-remote-file-source plugin
+
 ```sh
 python tools/plugin_builder.py python-remote-file-source
 ```
@@ -132,11 +145,13 @@ The plugin can be installed into a Deephaven instance with `pip install <wheel f
 The wheel file is stored in the `dist` directory after building the plugin.
 Exactly how this is done will depend on how you are running Deephaven.
 If using the venv created above, the plugin and server can be created with the following commands:
+
 ```sh
 pip install deephaven-server
 pip install plugins/python-remote-file-source/dist/deephaven_plugin_python_remote_file_source-*.whl
 deephaven server
 ```
+
 See the [plug-in documentation](https://deephaven.io/core/docs/how-to-guides/install-use-plugins/) for more information.
 
 ## Using the Plugin
@@ -155,7 +170,6 @@ A panel should appear for the plugin object showing the current configuration of
 
 ## Testing the Plugin
 
-
 1. Build the plugin (see [Building the Plugin](#building-the-plugin)).
 2. Start the server:
 
@@ -166,7 +180,8 @@ A panel should appear for the plugin object showing the current configuration of
     --server-arg \
     --jvm-args="-Dauthentication.psk=plugins.repo.test -Dprocess.info.system-info.enabled=false"
    ```
-> Note that the `-Dprocess.info.system-info.enabled=false` is only required for M1 / M2 Mac.
+
+   > Note that the `-Dprocess.info.system-info.enabled=false` is only required for M1 / M2 Mac.
 
 3. Before running tests for the first time, install dependencies for the test client:
    ```sh
@@ -175,4 +190,3 @@ A panel should appear for the plugin object showing the current configuration of
    npm install
    cd -
    ```
-

--- a/plugins/python-remote-file-source/README.md
+++ b/plugins/python-remote-file-source/README.md
@@ -128,7 +128,6 @@ npm install
 python -m venv .venv
 source .venv/bin/activate
 pip install --upgrade -r requirements.txt
-pip install click watchdog deephaven-server
 ```
 
 2. Build the python-remote-file-source plugin
@@ -147,7 +146,6 @@ Exactly how this is done will depend on how you are running Deephaven.
 If using the venv created above, the plugin and server can be created with the following commands:
 
 ```sh
-pip install deephaven-server
 pip install plugins/python-remote-file-source/dist/deephaven_plugin_python_remote_file_source-*.whl
 deephaven server
 ```

--- a/plugins/python-remote-file-source/src/deephaven/python_remote_file_source/plugin_object.py
+++ b/plugins/python-remote-file-source/src/deephaven/python_remote_file_source/plugin_object.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
+import logging
 import sys
 from typing import Optional
+
+logger = logging.getLogger(__name__)
 
 
 class PluginObject:
@@ -16,13 +19,41 @@ class PluginObject:
     def __init__(self):
         pass
 
-    def evict_module_cache(self) -> None:
+    def _is_module_in_top_level_names(
+        self, module_fullname: str, top_level_module_fullnames: set[str]
+    ) -> bool:
         """
-        Evict any cached modules that were loaded from the `RemoteModuleLoader`.
+        Check if a module fullname matches any of the top-level module names.
+        Args:
+            module_fullname: The full name of the module to check.
+            top_level_module_fullnames: The set of top-level module names to check against.
+        Returns:
+            bool: True if the module matches any top-level name, False otherwise.
         """
+        if not top_level_module_fullnames:
+            return False
+
+        for top_level_name in top_level_module_fullnames:
+            if module_fullname == top_level_name or module_fullname.startswith(
+                top_level_name + "."
+            ):
+                return True
+
+        return False
+
+    def evict_module_cache(self, top_level_module_fullnames: set[str]) -> None:
+        """
+        Evict any cached modules that match the given top-level module names.
+        Args:
+            top_level_module_fullnames: The set of top-level module names to evict.
+        """
+        evicted = []
         for mod_name in list(sys.modules.keys()):
-            if self.is_sourced_by_plugin(mod_name):
+            if self._is_module_in_top_level_names(mod_name, top_level_module_fullnames):
                 del sys.modules[mod_name]
+                evicted.append(mod_name)
+        
+        logger.debug(f"Evicted {len(evicted)} modules: {evicted} --------------------------------------------------------------------------------------")
 
     def get_top_level_module_fullnames(self) -> set[str]:
         """
@@ -47,31 +78,48 @@ class PluginObject:
             connection_id is not None
             and connection_id != self._execution_context_connection_id
         ):
+            logger.debug("Connection ID is not the active execution context: %s != %s", connection_id, self._execution_context_connection_id)
             return False
 
-        if self._top_level_module_fullnames is None:
-            return False
-
-        for top_level_name in self._top_level_module_fullnames:
-            if module_fullname == top_level_name or module_fullname.startswith(
-                top_level_name + "."
-            ):
-                return True
-
-        return False
+        return self._is_module_in_top_level_names(
+            module_fullname, self._top_level_module_fullnames
+        )
 
     def set_execution_context(
-        self, connection_id: Optional[str], top_level_module_fullnames: set[str]
+        self, connection_id: Optional[str], top_level_module_fullnames: set[str] | dict
     ) -> None:
         """
         Set the execution context for the object. This includes the set of top
         level module fullnames that can be sourced by the client.
         Args:
             connection_id: The connection id for the execution context.
-            top_level_module_fullnames: The set of top level module fullnames.
+            top_level_module_fullnames: A dict or set of top level module fullnames.
+                If a dict is provided, the keys will be used as the set of fullnames
+                and the values will be ignored. This gracefully handles the
+                mismatch between Python {} and {"value"} producing different
+                types in Python in cases where a client is building the arg in
+                a string expression.
         Returns:
             None
         """
-        self.evict_module_cache()
+        logger.debug(
+            f"set_execution_context: cn={connection_id}, "
+            f"old={self._top_level_module_fullnames}, "
+            f"new={top_level_module_fullnames}"
+        )
+        
+        # Convert dict to set
+        if isinstance(top_level_module_fullnames, dict):
+            top_level_module_fullnames = set(top_level_module_fullnames.keys())
+        
+        # Evict cached modules
+        # 1. Any matching the old configuration to ensure remote sources from
+        #    previous execution contexts are cleared out.
+        # 2. Any matching the new configuration to ensure that if there are any
+        #    server sourced modules that have already been loaded, they will get
+        #    evicted so that the new remote source can be loaded.
+        combined_names = self._top_level_module_fullnames | top_level_module_fullnames
+        self.evict_module_cache(combined_names)
+
         self._execution_context_connection_id = connection_id
         self._top_level_module_fullnames = top_level_module_fullnames

--- a/plugins/python-remote-file-source/src/deephaven/python_remote_file_source/plugin_object.py
+++ b/plugins/python-remote-file-source/src/deephaven/python_remote_file_source/plugin_object.py
@@ -52,8 +52,10 @@ class PluginObject:
             if self._is_module_in_top_level_names(mod_name, top_level_module_fullnames):
                 del sys.modules[mod_name]
                 evicted.append(mod_name)
-        
-        logger.debug(f"Evicted {len(evicted)} modules: {evicted} --------------------------------------------------------------------------------------")
+
+        logger.debug(
+            f"Evicted {len(evicted)} modules: {evicted} --------------------------------------------------------------------------------------"
+        )
 
     def get_top_level_module_fullnames(self) -> set[str]:
         """
@@ -78,7 +80,11 @@ class PluginObject:
             connection_id is not None
             and connection_id != self._execution_context_connection_id
         ):
-            logger.debug("Connection ID is not the active execution context: %s != %s", connection_id, self._execution_context_connection_id)
+            logger.debug(
+                "Connection ID is not the active execution context: %s != %s",
+                connection_id,
+                self._execution_context_connection_id,
+            )
             return False
 
         return self._is_module_in_top_level_names(
@@ -107,11 +113,11 @@ class PluginObject:
             f"old={self._top_level_module_fullnames}, "
             f"new={top_level_module_fullnames}"
         )
-        
+
         # Convert dict to set
         if isinstance(top_level_module_fullnames, dict):
             top_level_module_fullnames = set(top_level_module_fullnames.keys())
-        
+
         # Evict cached modules
         # 1. Any matching the old configuration to ensure remote sources from
         #    previous execution contexts are cleared out.

--- a/plugins/python-remote-file-source/src/deephaven/python_remote_file_source/plugin_object.py
+++ b/plugins/python-remote-file-source/src/deephaven/python_remote_file_source/plugin_object.py
@@ -116,7 +116,7 @@ class PluginObject:
 
         # Convert dict to set
         if isinstance(top_level_module_fullnames, dict):
-            top_level_module_fullnames = set(top_level_module_fullnames.keys())
+            top_level_module_fullnames = set(top_level_module_fullnames)
 
         # Evict cached modules
         # 1. Any matching the old configuration to ensure remote sources from

--- a/plugins/python-remote-file-source/test/deephaven/python-remote-file-source/test_import_context.py
+++ b/plugins/python-remote-file-source/test/deephaven/python-remote-file-source/test_import_context.py
@@ -71,6 +71,10 @@ class TestImportWithExecutionContext(unittest.TestCase):
         # Save original sys.meta_path
         self.original_meta_path = sys.meta_path.copy()
 
+        # Register remote finder for all tests
+        finder = RemoteMetaPathFinder(self.mock_connection, self.plugin)
+        sys.meta_path.insert(0, finder)
+
     def tearDown(self):
         """Clean up after each test"""
         # Remove test modules from sys.modules
@@ -94,12 +98,6 @@ class TestImportWithExecutionContext(unittest.TestCase):
         self.test_modules.add(name)
         return module
 
-    def _register_remote_finder(self):
-        """Register RemoteMetaPathFinder at the beginning of sys.meta_path"""
-        finder = RemoteMetaPathFinder(self.mock_connection, self.plugin)
-        sys.meta_path.insert(0, finder)
-        return finder
-
     def test_case_1a_local_exists_no_remote_configured(self):
         """
         Case 1a: Local version exists, no remote source configured
@@ -107,9 +105,6 @@ class TestImportWithExecutionContext(unittest.TestCase):
         """
         # Create a local module
         self._create_local_module("test_module_1a")
-
-        # Register the remote finder (but don't configure any remote modules)
-        self._register_remote_finder()
 
         # Don't call set_execution_context, so no remote modules are configured
         # Import should use local module
@@ -129,9 +124,6 @@ class TestImportWithExecutionContext(unittest.TestCase):
 
         # Configure remote module
         self.mock_connection.add_remote_module("test_module_1b")
-
-        # Register the remote finder
-        self._register_remote_finder()
 
         # Configure execution context to use remote source
         self.plugin.set_execution_context(self.connection_id, {"test_module_1b"})
@@ -157,9 +149,6 @@ class TestImportWithExecutionContext(unittest.TestCase):
         # Configure and then remove remote module
         self.mock_connection.add_remote_module("test_module_1c")
 
-        # Register the remote finder
-        self._register_remote_finder()
-
         # First: Configure execution context to use remote source
         # This should evict the local module from cache
         self.plugin.set_execution_context(self.connection_id, {"test_module_1c"})
@@ -184,9 +173,6 @@ class TestImportWithExecutionContext(unittest.TestCase):
         Case 2a: Local version doesn't exist, no remote source configured
         Expected: ImportError
         """
-        # Register the remote finder
-        self._register_remote_finder()
-
         # Don't configure any remote modules
         # Import should fail
         with self.assertRaises(ModuleNotFoundError):
@@ -199,9 +185,6 @@ class TestImportWithExecutionContext(unittest.TestCase):
         """
         # Configure remote module (no local version)
         self.mock_connection.add_remote_module("test_module_2b")
-
-        # Register the remote finder
-        self._register_remote_finder()
 
         # Configure execution context to use remote source
         self.plugin.set_execution_context(self.connection_id, {"test_module_2b"})
@@ -225,9 +208,6 @@ class TestImportWithExecutionContext(unittest.TestCase):
         # Configure remote module (no local version)
         self.mock_connection.add_remote_module("test_module_2c")
 
-        # Register the remote finder
-        self._register_remote_finder()
-
         # First: Configure execution context to use remote source
         self.plugin.set_execution_context(self.connection_id, {"test_module_2c"})
         self.test_modules.add("test_module_2c")  # Track for cleanup
@@ -250,9 +230,6 @@ class TestImportWithExecutionContext(unittest.TestCase):
 
         # Configure remote module
         self.mock_connection.add_remote_module("test_cache_module")
-
-        # Register the remote finder
-        self._register_remote_finder()
 
         # First import: no remote configured, should get local
         module1 = import_module("test_cache_module")
@@ -281,9 +258,6 @@ class TestImportWithExecutionContext(unittest.TestCase):
         self.mock_connection.add_remote_module("test_package", is_package=True)
         self.mock_connection.add_remote_module("test_package.submodule")
 
-        # Register the remote finder
-        self._register_remote_finder()
-
         # Configure execution context for the package
         self.plugin.set_execution_context(self.connection_id, {"test_package"})
 
@@ -301,9 +275,6 @@ class TestImportWithExecutionContext(unittest.TestCase):
         """
         # Configure remote module
         self.mock_connection.add_remote_module("test_connection_module")
-
-        # Register the remote finder
-        self._register_remote_finder()
 
         # Configure execution context with different connection ID
         different_connection_id = "different-connection"
@@ -323,9 +294,6 @@ class TestImportWithExecutionContext(unittest.TestCase):
         """
         # Configure remote module
         self.mock_connection.add_remote_module("test_dict_module")
-
-        # Register the remote finder
-        self._register_remote_finder()
 
         # Pass a dict instead of a set (values should be ignored)
         self.plugin.set_execution_context(
@@ -352,9 +320,6 @@ class TestImportWithExecutionContext(unittest.TestCase):
         # Configure remote versions
         self.mock_connection.add_remote_module("test_pkg", is_package=True)
         self.mock_connection.add_remote_module("test_pkg.submodule")
-
-        # Register the remote finder
-        self._register_remote_finder()
 
         # Set execution context - this should evict both modules
         self.plugin.set_execution_context(self.connection_id, {"test_pkg"})

--- a/plugins/python-remote-file-source/test/deephaven/python-remote-file-source/test_import_context.py
+++ b/plugins/python-remote-file-source/test/deephaven/python-remote-file-source/test_import_context.py
@@ -116,6 +116,11 @@ class TestImportWithExecutionContext(unittest.TestCase):
         self.connection_id = "test-connection-1"
         self.mock_connection = MockConnection(self.connection_id)
 
+        # Pre-register all remote modules (they won't be used until set_execution_context is called)
+        self.mock_connection.add_remote_module(TEST_MODULE)
+        self.mock_connection.add_remote_module(TEST_PACKAGE, is_package=True)
+        self.mock_connection.add_remote_module(f"{TEST_PACKAGE}.submodule")
+
         # Keep track of modules we create for cleanup
         self.test_modules = set()
 
@@ -149,169 +154,78 @@ class TestImportWithExecutionContext(unittest.TestCase):
         self.local_finder.add_module(name, is_package)
         self.test_modules.add(name)
 
-    def test_case_1a_local_exists_no_remote_configured(self):
+    def _assert_import_is_local(self, module_name: str):
+        """Import a module and assert it came from the local finder"""
+        # Track for cleanup in tearDown since import_module will cache it in sys.modules
+        self.test_modules.add(module_name)
+
+        module = import_module(module_name)
+        self.assertEqual(
+            module.value, "local", f"Expected {module_name} to be local, got remote"
+        )
+
+    def _assert_import_is_remote(self, module_name: str):
+        """Import a module and assert it came from the remote source"""
+        # Track for cleanup in tearDown since import_module will cache it in sys.modules
+        self.test_modules.add(module_name)
+
+        module = import_module(module_name)
+        self.assertEqual(
+            module.value, "remote", f"Expected {module_name} to be remote, got local"
+        )
+
+    def test_case_1_local_exists_remote_lifecycle(self):
         """
-        Case 1a: Local version exists, no remote source configured
-        Expected: Local module gets loaded
+        Test import behavior when a local module exists through the full remote lifecycle.
+        Verifies: Local → remote override → local again
         """
-        # Create a local module
+        # Start with local module available
         self._create_local_module(TEST_MODULE)
+        self._assert_import_is_local(TEST_MODULE)
 
-        # Don't call set_execution_context, so no remote modules are configured
-        # Import should use local module
-        module = import_module(TEST_MODULE)
-
-        self.assertEqual(module.value, "local")
-
-    def test_case_1b_local_exists_remote_configured(self):
-        """
-        Case 1b: Local version exists, remote source configured
-        Expected: Remote module gets loaded (overrides local)
-        """
-        # Create a local module
-        self._create_local_module(TEST_MODULE)
-
-        # Configure remote module
-        self.mock_connection.add_remote_module(TEST_MODULE)
-
-        # Configure execution context to use remote source
+        # Configure remote source (should evict local from cache)
         self.plugin.set_execution_context(self.connection_id, {TEST_MODULE})
+        self._assert_import_is_remote(TEST_MODULE)
 
-        # Import should use remote module
-        module = import_module(TEST_MODULE)
-
-        self.assertEqual(module.value, "remote")
-
-    def test_case_1c_local_exists_remote_removed(self):
-        """
-        Case 1c: Local version exists, remote source was configured but now removed
-        Expected: Local module gets loaded
-        """
-        # Register a local module with the finder
-        self._create_local_module(TEST_MODULE)
-
-        # Configure remote module
-        self.mock_connection.add_remote_module(TEST_MODULE)
-
-        # First: Configure execution context to use remote source
-        # This should evict the local module from cache
-        self.plugin.set_execution_context(self.connection_id, {TEST_MODULE})
-        module = import_module(TEST_MODULE)
-        self.assertEqual(module.value, "remote")
-
-        # Second: Remove remote configuration (clear execution context)
-        # This should evict the remote module from cache
+        # Remove remote configuration (should evict from cache and fall back to local)
         self.plugin.set_execution_context(self.connection_id, set())
+        self._assert_import_is_local(TEST_MODULE)
 
-        # Import should now fall back to local module from finder
-        module = import_module(TEST_MODULE)
-        self.assertEqual(module.value, "local")
-
-    def test_case_2a_local_not_exists_no_remote_configured(self):
+    def test_case_2_local_not_exists_remote_lifecycle(self):
         """
-        Case 2a: Local version doesn't exist, no remote source configured
-        Expected: ImportError
+        Test import behavior when no local module exists through the full remote lifecycle.
+        Verifies: Fail → succeed with remote → fail when remote removed
         """
-        # Don't configure any remote modules
-        # Import should fail
-        with self.assertRaises(ModuleNotFoundError):
-            import_module("nonexistent_module_2a")
-
-    def test_case_2b_local_not_exists_remote_configured(self):
-        """
-        Case 2b: Local version doesn't exist, remote source configured
-        Expected: Remote module gets loaded
-        """
-        # Configure remote module (no local version)
-        self.mock_connection.add_remote_module(TEST_MODULE)
-
-        # Configure execution context to use remote source
-        self.plugin.set_execution_context(self.connection_id, {TEST_MODULE})
-
-        # Import should use remote module
-        self.test_modules.add(TEST_MODULE)  # Track for cleanup
-        module = import_module(TEST_MODULE)
-
-        self.assertEqual(module.value, "remote")
-
-    def test_case_2c_local_not_exists_remote_removed(self):
-        """
-        Case 2c: Local version doesn't exist, remote source was configured but now removed
-        Expected: ImportError
-        """
-        # Configure remote module (no local version)
-        self.mock_connection.add_remote_module(TEST_MODULE)
-
-        # First: Configure execution context to use remote source
-        self.plugin.set_execution_context(self.connection_id, {TEST_MODULE})
-        self.test_modules.add(TEST_MODULE)  # Track for cleanup
-        module = import_module(TEST_MODULE)
-        self.assertEqual(module.value, "remote")
-
-        # Second: Remove remote configuration
-        self.plugin.set_execution_context(self.connection_id, set())
-
-        # Import should now fail
+        # Import without local or remote - should fail
         with self.assertRaises(ModuleNotFoundError):
             import_module(TEST_MODULE)
 
-    def test_cache_eviction_on_context_change(self):
-        """
-        Test that module cache is properly evicted when execution context changes
-        """
-        # Register a local module with the finder
-        self._create_local_module(TEST_MODULE)
-
-        # Configure remote module
-        self.mock_connection.add_remote_module(TEST_MODULE)
-
-        # First import: no remote configured, should get local
-        module1 = import_module(TEST_MODULE)
-        self.assertEqual(module1.value, "local")
-
         # Configure remote source
         self.plugin.set_execution_context(self.connection_id, {TEST_MODULE})
+        self._assert_import_is_remote(TEST_MODULE)
 
-        # Second import: remote configured, should get remote (cache should be evicted)
-        module2 = import_module(TEST_MODULE)
-        self.assertEqual(module2.value, "remote")
-
-        # Clear remote source
+        # Remove remote configuration - should fail again since no local module exists
         self.plugin.set_execution_context(self.connection_id, set())
-
-        # Third import: should fall back to local again (cache evicted, finder re-provides)
-        module3 = import_module(TEST_MODULE)
-        self.assertEqual(module3.value, "local")
+        with self.assertRaises(ModuleNotFoundError):
+            import_module(TEST_MODULE)
 
     def test_submodule_import_with_remote_source(self):
         """
         Test that submodule imports work correctly with remote sources
         """
-        # Configure remote package and submodule
-        self.mock_connection.add_remote_module(TEST_PACKAGE, is_package=True)
-        self.mock_connection.add_remote_module(f"{TEST_PACKAGE}.submodule")
-
         # Configure execution context for the package
         self.plugin.set_execution_context(self.connection_id, {TEST_PACKAGE})
 
         # Import package and submodule
-        self.test_modules.add(TEST_PACKAGE)
-        package = import_module(TEST_PACKAGE)
-        self.assertEqual(package.value, "remote")
-
-        submodule = import_module(f"{TEST_PACKAGE}.submodule")
-        self.assertEqual(submodule.value, "remote")
+        self._assert_import_is_remote(TEST_PACKAGE)
+        self._assert_import_is_remote(f"{TEST_PACKAGE}.submodule")
 
     def test_connection_id_mismatch(self):
         """
         Test that modules aren't loaded when connection ID doesn't match
         """
-        # Configure remote module
-        self.mock_connection.add_remote_module(TEST_MODULE)
-
         # Configure execution context with different connection ID
-        different_connection_id = "different-connection"
-        self.plugin.set_execution_context(different_connection_id, {TEST_MODULE})
+        self.plugin.set_execution_context("different-connection", {TEST_MODULE})
 
         # Import should fail because connection IDs don't match
         # The finder returns None, so standard import mechanism should fail
@@ -323,18 +237,13 @@ class TestImportWithExecutionContext(unittest.TestCase):
         Test that set_execution_context properly handles dict input
         (converted to set of keys)
         """
-        # Configure remote module
-        self.mock_connection.add_remote_module(TEST_MODULE)
-
         # Pass a dict instead of a set (values should be ignored)
         self.plugin.set_execution_context(
             self.connection_id, {TEST_MODULE: "ignored_value"}
         )
 
         # Import should work
-        self.test_modules.add(TEST_MODULE)
-        module = import_module(TEST_MODULE)
-        self.assertEqual(module.value, "remote")
+        self._assert_import_is_remote(TEST_MODULE)
 
     def test_evict_multiple_related_modules(self):
         """
@@ -351,10 +260,6 @@ class TestImportWithExecutionContext(unittest.TestCase):
         # Both should be in sys.modules
         self.assertIn(TEST_PACKAGE, sys.modules)
         self.assertIn(f"{TEST_PACKAGE}.submodule", sys.modules)
-
-        # Configure remote versions
-        self.mock_connection.add_remote_module(TEST_PACKAGE, is_package=True)
-        self.mock_connection.add_remote_module(f"{TEST_PACKAGE}.submodule")
 
         # Set execution context - this should evict both modules
         self.plugin.set_execution_context(self.connection_id, {TEST_PACKAGE})

--- a/plugins/python-remote-file-source/test/deephaven/python-remote-file-source/test_import_context.py
+++ b/plugins/python-remote-file-source/test/deephaven/python-remote-file-source/test_import_context.py
@@ -22,6 +22,7 @@ from src.deephaven.python_remote_file_source.json_rpc import (
 
 # Test module name constants
 TEST_MODULE = "test_module"
+TEST_PACKAGE = "test_package"
 
 
 class MockConnection:
@@ -229,28 +230,28 @@ class TestImportWithExecutionContext(unittest.TestCase):
         Test that module cache is properly evicted when execution context changes
         """
         # Create a local module
-        self._create_local_module("test_cache_module")
+        self._create_local_module(TEST_MODULE)
 
         # Configure remote module
-        self.mock_connection.add_remote_module("test_cache_module")
+        self.mock_connection.add_remote_module(TEST_MODULE)
 
         # First import: no remote configured, should get local
-        module1 = import_module("test_cache_module")
+        module1 = import_module(TEST_MODULE)
         self.assertEqual(module1.value, "local")
 
         # Configure remote source
-        self.plugin.set_execution_context(self.connection_id, {"test_cache_module"})
+        self.plugin.set_execution_context(self.connection_id, {TEST_MODULE})
 
         # Second import: remote configured, should get remote (cache should be evicted)
-        module2 = import_module("test_cache_module")
+        module2 = import_module(TEST_MODULE)
         self.assertEqual(module2.value, "remote")
 
         # Clear remote source and re-create local module
         self.plugin.set_execution_context(self.connection_id, set())
-        self._create_local_module("test_cache_module")
+        self._create_local_module(TEST_MODULE)
 
         # Third import: no remote, should get local again (cache evicted again)
-        module3 = import_module("test_cache_module")
+        module3 = import_module(TEST_MODULE)
         self.assertEqual(module3.value, "local")
 
     def test_submodule_import_with_remote_source(self):
@@ -258,18 +259,18 @@ class TestImportWithExecutionContext(unittest.TestCase):
         Test that submodule imports work correctly with remote sources
         """
         # Configure remote package and submodule
-        self.mock_connection.add_remote_module("test_package", is_package=True)
-        self.mock_connection.add_remote_module("test_package.submodule")
+        self.mock_connection.add_remote_module(TEST_PACKAGE, is_package=True)
+        self.mock_connection.add_remote_module(f"{TEST_PACKAGE}.submodule")
 
         # Configure execution context for the package
-        self.plugin.set_execution_context(self.connection_id, {"test_package"})
+        self.plugin.set_execution_context(self.connection_id, {TEST_PACKAGE})
 
         # Import package and submodule
-        self.test_modules.add("test_package")
-        package = import_module("test_package")
+        self.test_modules.add(TEST_PACKAGE)
+        package = import_module(TEST_PACKAGE)
         self.assertEqual(package.value, "remote")
 
-        submodule = import_module("test_package.submodule")
+        submodule = import_module(f"{TEST_PACKAGE}.submodule")
         self.assertEqual(submodule.value, "remote")
 
     def test_connection_id_mismatch(self):
@@ -277,18 +278,16 @@ class TestImportWithExecutionContext(unittest.TestCase):
         Test that modules aren't loaded when connection ID doesn't match
         """
         # Configure remote module
-        self.mock_connection.add_remote_module("test_connection_module")
+        self.mock_connection.add_remote_module(TEST_MODULE)
 
         # Configure execution context with different connection ID
         different_connection_id = "different-connection"
-        self.plugin.set_execution_context(
-            different_connection_id, {"test_connection_module"}
-        )
+        self.plugin.set_execution_context(different_connection_id, {TEST_MODULE})
 
         # Import should fail because connection IDs don't match
         # The finder returns None, so standard import mechanism should fail
         with self.assertRaises(ModuleNotFoundError):
-            import_module("test_connection_module")
+            import_module(TEST_MODULE)
 
     def test_dict_to_set_conversion(self):
         """
@@ -296,16 +295,16 @@ class TestImportWithExecutionContext(unittest.TestCase):
         (converted to set of keys)
         """
         # Configure remote module
-        self.mock_connection.add_remote_module("test_dict_module")
+        self.mock_connection.add_remote_module(TEST_MODULE)
 
         # Pass a dict instead of a set (values should be ignored)
         self.plugin.set_execution_context(
-            self.connection_id, {"test_dict_module": "ignored_value"}
+            self.connection_id, {TEST_MODULE: "ignored_value"}
         )
 
         # Import should work
-        self.test_modules.add("test_dict_module")
-        module = import_module("test_dict_module")
+        self.test_modules.add(TEST_MODULE)
+        module = import_module(TEST_MODULE)
         self.assertEqual(module.value, "remote")
 
     def test_evict_multiple_related_modules(self):
@@ -313,24 +312,27 @@ class TestImportWithExecutionContext(unittest.TestCase):
         Test that eviction works for packages and their submodules
         """
         # Create local package and submodule
-        pkg = self._create_local_module("test_pkg")
-        sub = self._create_local_module("test_pkg.submodule")
+        pkg = self._create_local_module(TEST_PACKAGE)
+        sub = self._create_local_module(f"{TEST_PACKAGE}.submodule")
 
         # Both should be in sys.modules
-        self.assertIn("test_pkg", sys.modules)
-        self.assertIn("test_pkg.submodule", sys.modules)
+        self.assertIn(TEST_PACKAGE, sys.modules)
+        self.assertIn(f"{TEST_PACKAGE}.submodule", sys.modules)
 
         # Configure remote versions
-        self.mock_connection.add_remote_module("test_pkg", is_package=True)
-        self.mock_connection.add_remote_module("test_pkg.submodule")
+        self.mock_connection.add_remote_module(TEST_PACKAGE, is_package=True)
+        self.mock_connection.add_remote_module(f"{TEST_PACKAGE}.submodule")
 
         # Set execution context - this should evict both modules
-        self.plugin.set_execution_context(self.connection_id, {"test_pkg"})
+        self.plugin.set_execution_context(self.connection_id, {TEST_PACKAGE})
 
         # Both should have been evicted from sys.modules
-        self.assertFalse("test_pkg" in sys.modules, "test_pkg should be evicted")
         self.assertFalse(
-            "test_pkg.submodule" in sys.modules, "test_pkg.submodule should be evicted"
+            TEST_PACKAGE in sys.modules, f"{TEST_PACKAGE} should be evicted"
+        )
+        self.assertFalse(
+            f"{TEST_PACKAGE}.submodule" in sys.modules,
+            f"{TEST_PACKAGE}.submodule should be evicted",
         )
 
 

--- a/plugins/python-remote-file-source/test/deephaven/python-remote-file-source/test_import_context.py
+++ b/plugins/python-remote-file-source/test/deephaven/python-remote-file-source/test_import_context.py
@@ -20,6 +20,9 @@ from src.deephaven.python_remote_file_source.json_rpc import (
     JsonRpcResponse,
 )
 
+# Test module name constants
+TEST_MODULE = "test_module"
+
 
 class MockConnection:
     """Mock connection for testing"""
@@ -104,11 +107,11 @@ class TestImportWithExecutionContext(unittest.TestCase):
         Expected: Local module gets loaded
         """
         # Create a local module
-        self._create_local_module("test_module_1a")
+        self._create_local_module(TEST_MODULE)
 
         # Don't call set_execution_context, so no remote modules are configured
         # Import should use local module
-        module = import_module("test_module_1a")
+        module = import_module(TEST_MODULE)
 
         self.assertEqual(module.value, "local")
         self.assertIsNotNone(module.__file__)
@@ -120,16 +123,16 @@ class TestImportWithExecutionContext(unittest.TestCase):
         Expected: Remote module gets loaded (overrides local)
         """
         # Create a local module
-        self._create_local_module("test_module_1b")
+        self._create_local_module(TEST_MODULE)
 
         # Configure remote module
-        self.mock_connection.add_remote_module("test_module_1b")
+        self.mock_connection.add_remote_module(TEST_MODULE)
 
         # Configure execution context to use remote source
-        self.plugin.set_execution_context(self.connection_id, {"test_module_1b"})
+        self.plugin.set_execution_context(self.connection_id, {TEST_MODULE})
 
         # Import should use remote module
-        module = import_module("test_module_1b")
+        module = import_module(TEST_MODULE)
 
         self.assertEqual(module.value, "remote")
         # Check __spec__.origin since remote modules may not have __file__
@@ -144,15 +147,15 @@ class TestImportWithExecutionContext(unittest.TestCase):
         Expected: Local module gets loaded
         """
         # Create a local module FIRST (before registering finder)
-        local_module = self._create_local_module("test_module_1c")
+        local_module = self._create_local_module(TEST_MODULE)
 
         # Configure and then remove remote module
-        self.mock_connection.add_remote_module("test_module_1c")
+        self.mock_connection.add_remote_module(TEST_MODULE)
 
         # First: Configure execution context to use remote source
         # This should evict the local module from cache
-        self.plugin.set_execution_context(self.connection_id, {"test_module_1c"})
-        module = import_module("test_module_1c")
+        self.plugin.set_execution_context(self.connection_id, {TEST_MODULE})
+        module = import_module(TEST_MODULE)
         self.assertEqual(module.value, "remote")
 
         # Second: Remove remote configuration (clear execution context)
@@ -160,10 +163,10 @@ class TestImportWithExecutionContext(unittest.TestCase):
         self.plugin.set_execution_context(self.connection_id, set())
 
         # RE-CREATE the local module since it was evicted
-        self._create_local_module("test_module_1c")
+        self._create_local_module(TEST_MODULE)
 
         # Import should now use local module
-        module = import_module("test_module_1c")
+        module = import_module(TEST_MODULE)
         self.assertEqual(module.value, "local")
         self.assertIsNotNone(module.__file__)
         self.assertIn("local", module.__file__)  # type: ignore
@@ -184,14 +187,14 @@ class TestImportWithExecutionContext(unittest.TestCase):
         Expected: Remote module gets loaded
         """
         # Configure remote module (no local version)
-        self.mock_connection.add_remote_module("test_module_2b")
+        self.mock_connection.add_remote_module(TEST_MODULE)
 
         # Configure execution context to use remote source
-        self.plugin.set_execution_context(self.connection_id, {"test_module_2b"})
+        self.plugin.set_execution_context(self.connection_id, {TEST_MODULE})
 
         # Import should use remote module
-        self.test_modules.add("test_module_2b")  # Track for cleanup
-        module = import_module("test_module_2b")
+        self.test_modules.add(TEST_MODULE)  # Track for cleanup
+        module = import_module(TEST_MODULE)
 
         self.assertEqual(module.value, "remote")
         # Check __spec__.origin since remote modules may not have __file__
@@ -206,12 +209,12 @@ class TestImportWithExecutionContext(unittest.TestCase):
         Expected: ImportError
         """
         # Configure remote module (no local version)
-        self.mock_connection.add_remote_module("test_module_2c")
+        self.mock_connection.add_remote_module(TEST_MODULE)
 
         # First: Configure execution context to use remote source
-        self.plugin.set_execution_context(self.connection_id, {"test_module_2c"})
-        self.test_modules.add("test_module_2c")  # Track for cleanup
-        module = import_module("test_module_2c")
+        self.plugin.set_execution_context(self.connection_id, {TEST_MODULE})
+        self.test_modules.add(TEST_MODULE)  # Track for cleanup
+        module = import_module(TEST_MODULE)
         self.assertEqual(module.value, "remote")
 
         # Second: Remove remote configuration
@@ -219,7 +222,7 @@ class TestImportWithExecutionContext(unittest.TestCase):
 
         # Import should now fail
         with self.assertRaises(ModuleNotFoundError):
-            import_module("test_module_2c")
+            import_module(TEST_MODULE)
 
     def test_cache_eviction_on_context_change(self):
         """

--- a/plugins/python-remote-file-source/test/deephaven/python-remote-file-source/test_import_context.py
+++ b/plugins/python-remote-file-source/test/deephaven/python-remote-file-source/test_import_context.py
@@ -1,0 +1,370 @@
+"""
+Tests for verifying import behavior with set_execution_context.
+
+These tests verify that:
+1. When a module is in set_execution_context, remote sources are used
+2. When a module is not in set_execution_context, standard Python imports are used
+3. Module cache eviction works correctly when switching between remote and local sources
+"""
+
+import sys
+import unittest
+from importlib import import_module
+from types import ModuleType
+from typing import Optional
+
+from src.deephaven.python_remote_file_source.plugin_object import PluginObject
+from src.deephaven.python_remote_file_source.module_loader import RemoteMetaPathFinder
+from src.deephaven.python_remote_file_source.json_rpc import (
+    JsonRpcRequest,
+    JsonRpcResponse,
+)
+
+
+class MockConnection:
+    """Mock connection for testing"""
+
+    def __init__(self, connection_id: str):
+        self.id = connection_id
+        self._remote_modules = {}
+
+    def add_remote_module(self, name: str, is_package: bool = False):
+        """Register a remote module that can be fetched"""
+        self._remote_modules[name] = {
+            "name": name,
+            "origin": f"<remote:{name}>",
+            "is_package": is_package,
+            "source": "value = 'remote'",
+            "submodule_search_locations": [] if is_package else None,
+        }
+
+    def request_data_sync(
+        self, request_msg: JsonRpcRequest, timeout: Optional[float] = None
+    ) -> JsonRpcResponse:
+        """Mock request_data_sync that returns pre-configured module data"""
+        module_name = request_msg["params"]["module_name"]  # type: ignore
+        if module_name in self._remote_modules:
+            return {"result": self._remote_modules[module_name]}  # type: ignore
+        return {"error": f"Module {module_name} not found"}  # type: ignore
+
+    async def request_data(self, request_msg: JsonRpcRequest) -> JsonRpcResponse:
+        """Stub for protocol compliance - not used in tests"""
+        return {}  # type: ignore
+
+    def send_message(self, message: str) -> None:
+        """Stub for protocol compliance - not used in tests"""
+        pass
+
+
+class TestImportWithExecutionContext(unittest.TestCase):
+    """Test import behavior with set_execution_context"""
+
+    def setUp(self):
+        """Set up test fixtures"""
+        self.plugin = PluginObject()
+        self.connection_id = "test-connection-1"
+        self.mock_connection = MockConnection(self.connection_id)
+
+        # Keep track of modules we create for cleanup
+        self.test_modules = set()
+
+        # Save original sys.meta_path
+        self.original_meta_path = sys.meta_path.copy()
+
+    def tearDown(self):
+        """Clean up after each test"""
+        # Remove test modules from sys.modules
+        for module_name in list(sys.modules.keys()):
+            if any(module_name.startswith(test_mod) for test_mod in self.test_modules):
+                del sys.modules[module_name]
+
+        # Restore original sys.meta_path
+        sys.meta_path = self.original_meta_path
+
+        # Clear plugin state
+        self.plugin._execution_context_connection_id = None
+        self.plugin._top_level_module_fullnames = set()
+
+    def _create_local_module(self, name: str) -> ModuleType:
+        """Create a local module in sys.modules for testing"""
+        module = ModuleType(name)
+        module.__file__ = f"<local:{name}>"
+        exec(compile("value = 'local'", module.__file__, "exec"), module.__dict__)
+        sys.modules[name] = module
+        self.test_modules.add(name)
+        return module
+
+    def _register_remote_finder(self):
+        """Register RemoteMetaPathFinder at the beginning of sys.meta_path"""
+        finder = RemoteMetaPathFinder(self.mock_connection, self.plugin)
+        sys.meta_path.insert(0, finder)
+        return finder
+
+    def test_case_1a_local_exists_no_remote_configured(self):
+        """
+        Case 1a: Local version exists, no remote source configured
+        Expected: Local module gets loaded
+        """
+        # Create a local module
+        self._create_local_module("test_module_1a")
+
+        # Register the remote finder (but don't configure any remote modules)
+        self._register_remote_finder()
+
+        # Don't call set_execution_context, so no remote modules are configured
+        # Import should use local module
+        module = import_module("test_module_1a")
+
+        self.assertEqual(module.value, "local")
+        self.assertIsNotNone(module.__file__)
+        self.assertIn("local", module.__file__)  # type: ignore
+
+    def test_case_1b_local_exists_remote_configured(self):
+        """
+        Case 1b: Local version exists, remote source configured
+        Expected: Remote module gets loaded (overrides local)
+        """
+        # Create a local module
+        self._create_local_module("test_module_1b")
+
+        # Configure remote module
+        self.mock_connection.add_remote_module("test_module_1b")
+
+        # Register the remote finder
+        self._register_remote_finder()
+
+        # Configure execution context to use remote source
+        self.plugin.set_execution_context(self.connection_id, {"test_module_1b"})
+
+        # Import should use remote module
+        module = import_module("test_module_1b")
+
+        self.assertEqual(module.value, "remote")
+        # Check __spec__.origin since remote modules may not have __file__
+        self.assertIsNotNone(module.__spec__)
+        if module.__spec__ is not None:
+            self.assertIsNotNone(module.__spec__.origin)
+            self.assertIn("remote", module.__spec__.origin)  # type: ignore
+
+    def test_case_1c_local_exists_remote_removed(self):
+        """
+        Case 1c: Local version exists, remote source was configured but now removed
+        Expected: Local module gets loaded
+        """
+        # Create a local module FIRST (before registering finder)
+        local_module = self._create_local_module("test_module_1c")
+
+        # Configure and then remove remote module
+        self.mock_connection.add_remote_module("test_module_1c")
+
+        # Register the remote finder
+        self._register_remote_finder()
+
+        # First: Configure execution context to use remote source
+        # This should evict the local module from cache
+        self.plugin.set_execution_context(self.connection_id, {"test_module_1c"})
+        module = import_module("test_module_1c")
+        self.assertEqual(module.value, "remote")
+
+        # Second: Remove remote configuration (clear execution context)
+        # This should evict the remote module from cache
+        self.plugin.set_execution_context(self.connection_id, set())
+
+        # RE-CREATE the local module since it was evicted
+        self._create_local_module("test_module_1c")
+
+        # Import should now use local module
+        module = import_module("test_module_1c")
+        self.assertEqual(module.value, "local")
+        self.assertIsNotNone(module.__file__)
+        self.assertIn("local", module.__file__)  # type: ignore
+
+    def test_case_2a_local_not_exists_no_remote_configured(self):
+        """
+        Case 2a: Local version doesn't exist, no remote source configured
+        Expected: ImportError
+        """
+        # Register the remote finder
+        self._register_remote_finder()
+
+        # Don't configure any remote modules
+        # Import should fail
+        with self.assertRaises(ModuleNotFoundError):
+            import_module("nonexistent_module_2a")
+
+    def test_case_2b_local_not_exists_remote_configured(self):
+        """
+        Case 2b: Local version doesn't exist, remote source configured
+        Expected: Remote module gets loaded
+        """
+        # Configure remote module (no local version)
+        self.mock_connection.add_remote_module("test_module_2b")
+
+        # Register the remote finder
+        self._register_remote_finder()
+
+        # Configure execution context to use remote source
+        self.plugin.set_execution_context(self.connection_id, {"test_module_2b"})
+
+        # Import should use remote module
+        self.test_modules.add("test_module_2b")  # Track for cleanup
+        module = import_module("test_module_2b")
+
+        self.assertEqual(module.value, "remote")
+        # Check __spec__.origin since remote modules may not have __file__
+        self.assertIsNotNone(module.__spec__)
+        if module.__spec__ is not None:
+            self.assertIsNotNone(module.__spec__.origin)
+            self.assertIn("remote", module.__spec__.origin)  # type: ignore
+
+    def test_case_2c_local_not_exists_remote_removed(self):
+        """
+        Case 2c: Local version doesn't exist, remote source was configured but now removed
+        Expected: ImportError
+        """
+        # Configure remote module (no local version)
+        self.mock_connection.add_remote_module("test_module_2c")
+
+        # Register the remote finder
+        self._register_remote_finder()
+
+        # First: Configure execution context to use remote source
+        self.plugin.set_execution_context(self.connection_id, {"test_module_2c"})
+        self.test_modules.add("test_module_2c")  # Track for cleanup
+        module = import_module("test_module_2c")
+        self.assertEqual(module.value, "remote")
+
+        # Second: Remove remote configuration
+        self.plugin.set_execution_context(self.connection_id, set())
+
+        # Import should now fail
+        with self.assertRaises(ModuleNotFoundError):
+            import_module("test_module_2c")
+
+    def test_cache_eviction_on_context_change(self):
+        """
+        Test that module cache is properly evicted when execution context changes
+        """
+        # Create a local module
+        self._create_local_module("test_cache_module")
+
+        # Configure remote module
+        self.mock_connection.add_remote_module("test_cache_module")
+
+        # Register the remote finder
+        self._register_remote_finder()
+
+        # First import: no remote configured, should get local
+        module1 = import_module("test_cache_module")
+        self.assertEqual(module1.value, "local")
+
+        # Configure remote source
+        self.plugin.set_execution_context(self.connection_id, {"test_cache_module"})
+
+        # Second import: remote configured, should get remote (cache should be evicted)
+        module2 = import_module("test_cache_module")
+        self.assertEqual(module2.value, "remote")
+
+        # Clear remote source and re-create local module
+        self.plugin.set_execution_context(self.connection_id, set())
+        self._create_local_module("test_cache_module")
+
+        # Third import: no remote, should get local again (cache evicted again)
+        module3 = import_module("test_cache_module")
+        self.assertEqual(module3.value, "local")
+
+    def test_submodule_import_with_remote_source(self):
+        """
+        Test that submodule imports work correctly with remote sources
+        """
+        # Configure remote package and submodule
+        self.mock_connection.add_remote_module("test_package", is_package=True)
+        self.mock_connection.add_remote_module("test_package.submodule")
+
+        # Register the remote finder
+        self._register_remote_finder()
+
+        # Configure execution context for the package
+        self.plugin.set_execution_context(self.connection_id, {"test_package"})
+
+        # Import package and submodule
+        self.test_modules.add("test_package")
+        package = import_module("test_package")
+        self.assertEqual(package.value, "remote")
+
+        submodule = import_module("test_package.submodule")
+        self.assertEqual(submodule.value, "remote")
+
+    def test_connection_id_mismatch(self):
+        """
+        Test that modules aren't loaded when connection ID doesn't match
+        """
+        # Configure remote module
+        self.mock_connection.add_remote_module("test_connection_module")
+
+        # Register the remote finder
+        self._register_remote_finder()
+
+        # Configure execution context with different connection ID
+        different_connection_id = "different-connection"
+        self.plugin.set_execution_context(
+            different_connection_id, {"test_connection_module"}
+        )
+
+        # Import should fail because connection IDs don't match
+        # The finder returns None, so standard import mechanism should fail
+        with self.assertRaises(ModuleNotFoundError):
+            import_module("test_connection_module")
+
+    def test_dict_to_set_conversion(self):
+        """
+        Test that set_execution_context properly handles dict input
+        (converted to set of keys)
+        """
+        # Configure remote module
+        self.mock_connection.add_remote_module("test_dict_module")
+
+        # Register the remote finder
+        self._register_remote_finder()
+
+        # Pass a dict instead of a set (values should be ignored)
+        self.plugin.set_execution_context(
+            self.connection_id, {"test_dict_module": "ignored_value"}
+        )
+
+        # Import should work
+        self.test_modules.add("test_dict_module")
+        module = import_module("test_dict_module")
+        self.assertEqual(module.value, "remote")
+
+    def test_evict_multiple_related_modules(self):
+        """
+        Test that eviction works for packages and their submodules
+        """
+        # Create local package and submodule
+        pkg = self._create_local_module("test_pkg")
+        sub = self._create_local_module("test_pkg.submodule")
+
+        # Both should be in sys.modules
+        self.assertIn("test_pkg", sys.modules)
+        self.assertIn("test_pkg.submodule", sys.modules)
+
+        # Configure remote versions
+        self.mock_connection.add_remote_module("test_pkg", is_package=True)
+        self.mock_connection.add_remote_module("test_pkg.submodule")
+
+        # Register the remote finder
+        self._register_remote_finder()
+
+        # Set execution context - this should evict both modules
+        self.plugin.set_execution_context(self.connection_id, {"test_pkg"})
+
+        # Both should have been evicted from sys.modules
+        self.assertFalse("test_pkg" in sys.modules, "test_pkg should be evicted")
+        self.assertFalse(
+            "test_pkg.submodule" in sys.modules, "test_pkg.submodule should be evicted"
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/plugins/python-remote-file-source/test/deephaven/python-remote-file-source/test_import_context.py
+++ b/plugins/python-remote-file-source/test/deephaven/python-remote-file-source/test_import_context.py
@@ -10,8 +10,10 @@ These tests verify that:
 import sys
 import unittest
 from importlib import import_module
+from importlib.abc import Loader, MetaPathFinder
+from importlib.machinery import ModuleSpec
 from types import ModuleType
-from typing import Optional
+from typing import Optional, Sequence
 
 from src.deephaven.python_remote_file_source.plugin_object import PluginObject
 from src.deephaven.python_remote_file_source.module_loader import RemoteMetaPathFinder
@@ -23,6 +25,51 @@ from src.deephaven.python_remote_file_source.json_rpc import (
 # Test module name constants
 TEST_MODULE = "test_module"
 TEST_PACKAGE = "test_package"
+
+
+class MockLocalLoader(Loader):
+    """Loader that provides modules from memory, mimicking file-based loaders"""
+
+    def __init__(self, source: str):
+        self._source = source
+
+    def create_module(self, spec: ModuleSpec):
+        return None
+
+    def exec_module(self, module: ModuleType):
+        origin = (module.__spec__.origin if module.__spec__ else None) or "<string>"
+        exec(compile(self._source, origin, "exec"), module.__dict__)
+
+
+class MockLocalFinder(MetaPathFinder):
+    """Low-priority finder that serves 'local' modules from memory"""
+
+    def __init__(self):
+        self._modules = {}
+
+    def add_module(self, name: str, is_package: bool = False):
+        """Register a local module that can be imported"""
+        self._modules[name] = {
+            "source": "value = 'local'",
+            "is_package": is_package,
+        }
+
+    def find_spec(
+        self,
+        fullname: str,
+        path: Optional[Sequence[str]],
+        target: Optional[ModuleType] = None,
+    ):
+        if fullname not in self._modules:
+            return None
+
+        module_data = self._modules[fullname]
+        return ModuleSpec(
+            name=fullname,
+            origin=f"<local:{fullname}>",
+            is_package=module_data["is_package"],
+            loader=MockLocalLoader(module_data["source"]),
+        )
 
 
 class MockConnection:
@@ -75,7 +122,11 @@ class TestImportWithExecutionContext(unittest.TestCase):
         # Save original sys.meta_path
         self.original_meta_path = sys.meta_path.copy()
 
-        # Register remote finder for all tests
+        # Register local finder at end (low priority, like default loaders)
+        self.local_finder = MockLocalFinder()
+        sys.meta_path.append(self.local_finder)
+
+        # Register remote finder at start (high priority)
         finder = RemoteMetaPathFinder(self.mock_connection, self.plugin)
         sys.meta_path.insert(0, finder)
 
@@ -93,14 +144,10 @@ class TestImportWithExecutionContext(unittest.TestCase):
         self.plugin._execution_context_connection_id = None
         self.plugin._top_level_module_fullnames = set()
 
-    def _create_local_module(self, name: str) -> ModuleType:
-        """Create a local module in sys.modules for testing"""
-        module = ModuleType(name)
-        module.__file__ = f"<local:{name}>"
-        exec(compile("value = 'local'", module.__file__, "exec"), module.__dict__)
-        sys.modules[name] = module
+    def _create_local_module(self, name: str, is_package: bool = False):
+        """Register a local module with the low-priority finder"""
+        self.local_finder.add_module(name, is_package)
         self.test_modules.add(name)
-        return module
 
     def test_case_1a_local_exists_no_remote_configured(self):
         """
@@ -115,8 +162,6 @@ class TestImportWithExecutionContext(unittest.TestCase):
         module = import_module(TEST_MODULE)
 
         self.assertEqual(module.value, "local")
-        self.assertIsNotNone(module.__file__)
-        self.assertIn("local", module.__file__)  # type: ignore
 
     def test_case_1b_local_exists_remote_configured(self):
         """
@@ -136,21 +181,16 @@ class TestImportWithExecutionContext(unittest.TestCase):
         module = import_module(TEST_MODULE)
 
         self.assertEqual(module.value, "remote")
-        # Check __spec__.origin since remote modules may not have __file__
-        self.assertIsNotNone(module.__spec__)
-        if module.__spec__ is not None:
-            self.assertIsNotNone(module.__spec__.origin)
-            self.assertIn("remote", module.__spec__.origin)  # type: ignore
 
     def test_case_1c_local_exists_remote_removed(self):
         """
         Case 1c: Local version exists, remote source was configured but now removed
         Expected: Local module gets loaded
         """
-        # Create a local module FIRST (before registering finder)
-        local_module = self._create_local_module(TEST_MODULE)
+        # Register a local module with the finder
+        self._create_local_module(TEST_MODULE)
 
-        # Configure and then remove remote module
+        # Configure remote module
         self.mock_connection.add_remote_module(TEST_MODULE)
 
         # First: Configure execution context to use remote source
@@ -163,14 +203,9 @@ class TestImportWithExecutionContext(unittest.TestCase):
         # This should evict the remote module from cache
         self.plugin.set_execution_context(self.connection_id, set())
 
-        # RE-CREATE the local module since it was evicted
-        self._create_local_module(TEST_MODULE)
-
-        # Import should now use local module
+        # Import should now fall back to local module from finder
         module = import_module(TEST_MODULE)
         self.assertEqual(module.value, "local")
-        self.assertIsNotNone(module.__file__)
-        self.assertIn("local", module.__file__)  # type: ignore
 
     def test_case_2a_local_not_exists_no_remote_configured(self):
         """
@@ -198,11 +233,6 @@ class TestImportWithExecutionContext(unittest.TestCase):
         module = import_module(TEST_MODULE)
 
         self.assertEqual(module.value, "remote")
-        # Check __spec__.origin since remote modules may not have __file__
-        self.assertIsNotNone(module.__spec__)
-        if module.__spec__ is not None:
-            self.assertIsNotNone(module.__spec__.origin)
-            self.assertIn("remote", module.__spec__.origin)  # type: ignore
 
     def test_case_2c_local_not_exists_remote_removed(self):
         """
@@ -229,7 +259,7 @@ class TestImportWithExecutionContext(unittest.TestCase):
         """
         Test that module cache is properly evicted when execution context changes
         """
-        # Create a local module
+        # Register a local module with the finder
         self._create_local_module(TEST_MODULE)
 
         # Configure remote module
@@ -246,11 +276,10 @@ class TestImportWithExecutionContext(unittest.TestCase):
         module2 = import_module(TEST_MODULE)
         self.assertEqual(module2.value, "remote")
 
-        # Clear remote source and re-create local module
+        # Clear remote source
         self.plugin.set_execution_context(self.connection_id, set())
-        self._create_local_module(TEST_MODULE)
 
-        # Third import: no remote, should get local again (cache evicted again)
+        # Third import: should fall back to local again (cache evicted, finder re-provides)
         module3 = import_module(TEST_MODULE)
         self.assertEqual(module3.value, "local")
 
@@ -311,9 +340,13 @@ class TestImportWithExecutionContext(unittest.TestCase):
         """
         Test that eviction works for packages and their submodules
         """
-        # Create local package and submodule
-        pkg = self._create_local_module(TEST_PACKAGE)
-        sub = self._create_local_module(f"{TEST_PACKAGE}.submodule")
+        # Register local package and submodule with the finder
+        self._create_local_module(TEST_PACKAGE, is_package=True)
+        self._create_local_module(f"{TEST_PACKAGE}.submodule")
+
+        # Import both to get them into sys.modules
+        import_module(TEST_PACKAGE)
+        import_module(f"{TEST_PACKAGE}.submodule")
 
         # Both should be in sys.modules
         self.assertIn(TEST_PACKAGE, sys.modules)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,8 @@ build
 pip
 setuptools
 tox
+
+# Plugin builder dependencies
+click
+watchdog
+deephaven-server

--- a/tools/plugin_builder.py
+++ b/tools/plugin_builder.py
@@ -341,7 +341,7 @@ def run_configure(
         run_main_command("pre-commit install")
         run_main_command("npm install")
     if configure == "full":
-        # currently deephaven-server is installed as part of the sphinx_ext requirements
+        # Install additional dependencies for building documentation
         run_main_command("pip install -r sphinx_ext/sphinx-requirements.txt")
 
 


### PR DESCRIPTION
DH-21221: Remote cache eviction was based on list of remote sources from previous run. This works for 2 consecutive remote file source runs, but it missed a case important to controller imports:

1. script is run without remote sources configured, but the import is available on the server. Module gets cached to `sys.modules`
2. subsequent run attempts to override the source, cache is only evicted based on previous remote sources which don't include the new override. Cached module is fetched from `sys.modules` instead of fetching from remote source

The fix is to evict any module paths configured for previous run + any configured for current run.

I also moved some plugin dev dependencies into `requirements.txt` for the repo and adjusted docs accordingly. Should make things a little simpler to get up and running and for agents to do the right thing.

## Testing
I added unit tests that test the sequencing of local vs remote import availability to confirm cache eviction works properly. I also verified the tests catch the original bug by commenting out the `| top_level_module_fullnames` inclusion in `PluginObject.set_execution_context()`

```py
combined_names = self._top_level_module_fullnames | top_level_module_fullnames
```

```py
combined_names = self._top_level_module_fullnames | # top_level_module_fullnames
```

> Note: Testing the controller import scenario will be tested as part of the VS Code PR https://github.com/deephaven/vscode-deephaven/pull/315