### PR TITLE
chore: bump grid version to ^1.18.0 and remove workarounds

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35034,7 +35034,7 @@
         "@deephaven/dashboard": "^1.5.1",
         "@deephaven/dashboard-core-plugins": "^1.5.1",
         "@deephaven/golden-layout": "^1.5.1",
-        "@deephaven/grid": "^1.3.0",
+        "@deephaven/grid": "^1.18.0",
         "@deephaven/icons": "^1.2.0",
         "@deephaven/iris-grid": "^1.5.1",
         "@deephaven/jsapi-bootstrap": "^1.5.1",
@@ -35367,19 +35367,19 @@
       }
     },
     "plugins/ui/src/js/node_modules/@deephaven/grid": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@deephaven/grid/-/grid-1.3.0.tgz",
-      "integrity": "sha512-k5Te+dBqSyXW0TaV2rEYOD0UShIsvvIFsYUqQNadDJ7UA1QRgpDfRy7+KzV5BLnfdu57zDLqTpPFiPyjK058GA==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@deephaven/grid/-/grid-1.18.0.tgz",
+      "integrity": "sha512-2uF99HNqRhvqVOmLL1HSDlF7P8mjkS3LgFIxVZA6qxDbBQVo6sxr6ymPWChAd3I+MseDJedojgMjfsGTOOedFw==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@deephaven/utils": "^1.1.0",
+        "@deephaven/utils": "^1.10.0",
         "classnames": "^2.3.1",
         "color-convert": "^2.0.1",
         "event-target-shim": "^6.0.2",
         "linkifyjs": "^4.1.0",
         "lodash.clamp": "^4.0.3",
         "memoize-one": "^5.1.1",
-        "memoizee": "^0.4.15",
-        "prop-types": "^15.7.2"
+        "memoizee": "^0.4.15"
       },
       "engines": {
         "node": ">=16"
@@ -35523,12 +35523,14 @@
       }
     },
     "plugins/ui/src/js/node_modules/@deephaven/log": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@deephaven/log/-/log-1.1.0.tgz",
-      "integrity": "sha512-07Ww5o1iA9M65KoyHTfHTmCnzGIa/5OVP29pyP+FGmaXXMgujdvFRPfLHki0EeW92WOttXfK51kjDyzkBcs11Q==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@deephaven/log/-/log-1.8.0.tgz",
+      "integrity": "sha512-gzp6/7qW4W8Re+DLSaG33KEQJ30OrrNq3cNQA8fUeXQrabSNOIsyeVOaerQ/57c4zWhWVKamplax0LIYRsmDiw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "event-target-shim": "^6.0.2",
-        "jszip": "^3.10.1"
+        "jszip": "^3.10.1",
+        "safe-stable-stringify": "^2.5.0"
       },
       "engines": {
         "node": ">=16"
@@ -35598,11 +35600,12 @@
       }
     },
     "plugins/ui/src/js/node_modules/@deephaven/utils": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@deephaven/utils/-/utils-1.1.0.tgz",
-      "integrity": "sha512-GIEwXa5fdq2RWF2kx9YSu12mqhpt15YY4Z3pbdfZFMbLw/ilPZKVhpJK/twlFFo69ruwcetwORrVS2SKW4ng2g==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@deephaven/utils/-/utils-1.10.0.tgz",
+      "integrity": "sha512-KLs73wIU/T3ZA+H+YTlzQ1fT+6p02RfixMQ7+l8S+IyLxc+nwSMABYnoZybJJuRvw1huJuFv1+n0B0HDteDFZA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@deephaven/log": "^1.1.0",
+        "@deephaven/log": "^1.8.0",
         "nanoid": "^5.0.7"
       },
       "engines": {

--- a/plugins/ui/src/js/package.json
+++ b/plugins/ui/src/js/package.json
@@ -45,7 +45,7 @@
     "@deephaven/dashboard": "^1.5.1",
     "@deephaven/dashboard-core-plugins": "^1.5.1",
     "@deephaven/golden-layout": "^1.5.1",
-    "@deephaven/grid": "^1.3.0",
+    "@deephaven/grid": "^1.18.0",
     "@deephaven/icons": "^1.2.0",
     "@deephaven/iris-grid": "^1.5.1",
     "@deephaven/jsapi-bootstrap": "^1.5.1",

--- a/plugins/ui/src/js/src/elements/UITable/UITableModel.ts
+++ b/plugins/ui/src/js/src/elements/UITable/UITableModel.ts
@@ -599,7 +599,6 @@ class UITableModel extends IrisGridModel {
       columnMax: maxRowValue,
       axis,
       color: barColor,
-      // @ts-expect-error TODO: bump web version
       textColor,
       valuePlacement,
       opacity,

--- a/plugins/ui/src/js/src/elements/utils/HeatmapUtils.ts
+++ b/plugins/ui/src/js/src/elements/utils/HeatmapUtils.ts
@@ -1,5 +1,4 @@
-// TODO: GridColorUtils should be exported from @deephaven/grid (temporary workaround for now)
-import GridColorUtils from '@deephaven/grid/dist/GridColorUtils';
+import { GridColorUtils } from '@deephaven/grid';
 
 /**
  * Interpolate a color from a gradient at a given normalized position.


### PR DESCRIPTION
Part of DH-21376. Bumps grid version from ^1.3.0 to ^1.18.0, and cleans up `GridColorUtils` import.