### PR TITLE
fix(ui): DH-22743: check for existing panels from the layout root instead of the parent stack

### DIFF
--- a/plugins/ui/src/js/src/layout/ReactPanel.test.tsx
+++ b/plugins/ui/src/js/src/layout/ReactPanel.test.tsx
@@ -125,7 +125,7 @@ it('finds and closes existing panels from the layout root, but opens in the pare
     </ParentItemContext.Provider>
   );
 
-  const root = (useLayoutManager as jest.Mock).mock.results[0].value.root;
+  const { root } = (useLayoutManager as jest.Mock).mock.results[0].value;
 
   // Searches for an existing panel from the root, not just the parent
   expect(LayoutUtils.getStackForConfig).toHaveBeenCalledWith(root, {

--- a/plugins/ui/src/js/src/layout/ReactPanel.test.tsx
+++ b/plugins/ui/src/js/src/layout/ReactPanel.test.tsx
@@ -3,14 +3,17 @@ import { render, within } from '@testing-library/react';
 import {
   LayoutUtils,
   type WidgetDescriptor,
+  useLayoutManager,
   useListener,
 } from '@deephaven/dashboard';
+import type { ContentItem } from '@deephaven/golden-layout';
 import { TestUtils } from '@deephaven/test-utils';
 import ReactPanel from './ReactPanel';
 import {
   type ReactPanelManager,
   ReactPanelManagerContext,
 } from './ReactPanelManager';
+import { ParentItemContext } from './ParentItemContext';
 import { type ReactPanelProps } from './LayoutUtils';
 import PortalPanelManagerContext, {
   type PortalPanelMap,
@@ -107,6 +110,42 @@ it('opens panel on mount, and closes panel on unmount', () => {
   expect(LayoutUtils.closeComponent).toHaveBeenCalledTimes(1);
   expect(onOpen).toHaveBeenCalledTimes(1);
   expect(onClose).toHaveBeenCalledTimes(1);
+});
+
+it('finds and closes existing panels from the layout root, but opens in the parent stack', () => {
+  const onOpen = jest.fn();
+  const onClose = jest.fn();
+  // `useLayoutManager` is mocked to a plain function returning a static layout
+  // object (no real React hooks), so it's safe to call it here to grab the same
+  // `root` the component will see.
+  const { root } = useLayoutManager();
+  // Use a parent that is distinct from the root, e.g. the user moved the panel
+  // into a different stack within the layout.
+  const parent = TestUtils.createMockProxy<ContentItem>();
+
+  const { unmount } = render(
+    <ParentItemContext.Provider value={parent}>
+      {makeTestComponent({ onOpen, onClose })}
+    </ParentItemContext.Provider>
+  );
+
+  // Searches for an existing panel from the root, not just the parent
+  expect(LayoutUtils.getStackForConfig).toHaveBeenCalledWith(root, {
+    id: mockPanelId,
+  });
+  // Opens the panel in the parent stack rather than at the root
+  expect(LayoutUtils.openComponent).toHaveBeenCalledTimes(1);
+  expect(LayoutUtils.openComponent).toHaveBeenCalledWith(
+    expect.objectContaining({ root: parent })
+  );
+
+  unmount();
+
+  // Closes the panel from the root, since it may have been moved out of the parent
+  expect(LayoutUtils.closeComponent).toHaveBeenCalledTimes(1);
+  expect(LayoutUtils.closeComponent).toHaveBeenCalledWith(root, {
+    id: mockPanelId,
+  });
 });
 
 it('only calls open once if the panel has not closed and only children change', () => {

--- a/plugins/ui/src/js/src/layout/ReactPanel.test.tsx
+++ b/plugins/ui/src/js/src/layout/ReactPanel.test.tsx
@@ -115,11 +115,7 @@ it('opens panel on mount, and closes panel on unmount', () => {
 it('finds and closes existing panels from the layout root, but opens in the parent stack', () => {
   const onOpen = jest.fn();
   const onClose = jest.fn();
-  // `useLayoutManager` is mocked to a plain function returning a static layout
-  // object (no real React hooks), so it's safe to call it here to grab the same
-  // `root` the component will see.
-  const { root } = useLayoutManager();
-  // Use a parent that is distinct from the root, e.g. the user moved the panel
+  // Use a parent that is distinct from the layout root, e.g. the user moved the panel
   // into a different stack within the layout.
   const parent = TestUtils.createMockProxy<ContentItem>();
 
@@ -128,6 +124,8 @@ it('finds and closes existing panels from the layout root, but opens in the pare
       {makeTestComponent({ onOpen, onClose })}
     </ParentItemContext.Provider>
   );
+
+  const root = (useLayoutManager as jest.Mock).mock.results[0].value.root;
 
   // Searches for an existing panel from the root, not just the parent
   expect(LayoutUtils.getStackForConfig).toHaveBeenCalledWith(root, {

--- a/plugins/ui/src/js/src/layout/ReactPanel.tsx
+++ b/plugins/ui/src/js/src/layout/ReactPanel.tsx
@@ -139,18 +139,18 @@ function ReactPanel({
       'ui.panel must be a top-level component or used within a dashboard layout.'
     );
   }
-  const { eventHub } = layoutManager;
+  const { eventHub, root } = layoutManager;
 
   useEffect(
     () => () => {
       if (isPanelOpenRef.current) {
         log.debug('Closing panel', panelId);
-        LayoutUtils.closeComponent(parent, { id: panelId });
+        LayoutUtils.closeComponent(root, { id: panelId });
         isPanelOpenRef.current = false;
         onClose();
       }
     },
-    [parent, onClose, panelId]
+    [onClose, panelId, root]
   );
 
   const handlePanelClosed = useCallback(
@@ -178,7 +178,10 @@ function ReactPanel({
      */
     function openIfNecessary() {
       const itemConfig = { id: panelId };
-      const existingStack = LayoutUtils.getStackForConfig(parent, itemConfig);
+      // We check if we have an existing stack with this panel ID. Check from the root though,
+      // as the user may have moved the panel to a different stack, and we want to find it regardless
+      // of where it is in the layout.
+      const existingStack = LayoutUtils.getStackForConfig(root, itemConfig);
       if (existingStack == null) {
         const config = {
           type: 'react-component' as const,
@@ -189,6 +192,7 @@ function ReactPanel({
           isClosable,
         };
 
+        // If we didn't find it, we still want to open it in the same place in the layout as before (parent stack) instead of opening at the root
         LayoutUtils.openComponent({ root: parent, config });
         log.debug('Opened panel', panelId, config);
       } else if (openedMetadataRef.current !== metadata) {
@@ -210,10 +214,10 @@ function ReactPanel({
 
       if (prevPanelTitleRef.current !== panelTitle) {
         prevPanelTitleRef.current = panelTitle;
-        LayoutUtils.renameComponent(parent, itemConfig, panelTitle);
+        LayoutUtils.renameComponent(root, itemConfig, panelTitle);
       }
     },
-    [isClosable, parent, metadata, onOpen, panelId, panelTitle]
+    [isClosable, parent, metadata, onOpen, panelId, panelTitle, root]
   );
   const widgetStatus = useWidgetStatus();
 

--- a/tests/app.d/ui_nested_dashboard.py
+++ b/tests/app.d/ui_nested_dashboard.py
@@ -82,8 +82,39 @@ def nested_dashboard_with_state_component():
     )
 
 
+from deephaven import ui
+
+
+@ui.component
+def buggy_drag_panel():
+    """
+    DH-22743: A panel that can be dragged to a new stack, then updated to test for drag-related bugs.
+    In the bug described, it would duplicate the panel in the original location and the moved panel would go blank.
+    """
+    title, set_title = ui.use_state("title")
+
+    # Return it in a nested dashboard so it's easier to test
+    return ui.panel(
+        ui.dashboard(
+            ui.stack(
+                ui.panel(
+                    ui.text_field(
+                        default_value=title, on_change=set_title, label="Title"
+                    ),
+                    title="Input",
+                ),
+                ui.panel(
+                    ui.text("Drag this panel to a new stack, then change the value"),
+                    title=f"Drag me: {title}",
+                ),
+            )
+        )
+    )
+
+
 # Export the test components
 ui_nested_dashboard = nested_dashboard_component()
 ui_nested_dashboard_interactive = nested_dashboard_interactive_component()
 ui_deeply_nested_dashboard = deeply_nested_dashboard_component()
 ui_nested_dashboard_with_state = nested_dashboard_with_state_component()
+ui_buggy_drag_panel = buggy_drag_panel()

--- a/tests/app.d/ui_nested_dashboard.py
+++ b/tests/app.d/ui_nested_dashboard.py
@@ -82,9 +82,6 @@ def nested_dashboard_with_state_component():
     )
 
 
-from deephaven import ui
-
-
 @ui.component
 def buggy_drag_panel():
     """

--- a/tests/ui_buggy_drag_panel.spec.ts
+++ b/tests/ui_buggy_drag_panel.spec.ts
@@ -1,0 +1,115 @@
+import { expect, test, type Locator, type Page } from '@playwright/test';
+import { openPanel, gotoPage, SELECTORS } from './utils';
+
+/**
+ * Performs a golden-layout tab drag by manually driving the mouse. A simple
+ * `dragTo` does not work with golden-layout because it relies on a sequence of
+ * mousedown/mousemove/mouseup events and a drag threshold before the drag proxy
+ * is created.
+ * @param page The page
+ * @param tab The tab to drag
+ * @param target The target point to drop the tab at
+ */
+async function dragTabToTarget(
+  page: Page,
+  tab: Locator,
+  target: { x: number; y: number }
+): Promise<void> {
+  const box = await tab.boundingBox();
+  if (box == null) {
+    throw new Error('Could not get bounding box for tab to drag');
+  }
+  const startX = box.x + box.width / 2;
+  const startY = box.y + box.height / 2;
+
+  await page.mouse.move(startX, startY);
+  await page.mouse.down();
+  // Exceed the drag threshold to start the golden-layout drag proxy
+  await page.mouse.move(startX + 15, startY + 15, { steps: 5 });
+  // Move towards the drop target
+  await page.mouse.move(target.x, target.y, { steps: 20 });
+  // Settle on the target so golden-layout registers the drop zone
+  await page.mouse.move(target.x, target.y, { steps: 5 });
+  await page.mouse.up();
+}
+
+test.describe('Buggy Drag Panel (DH-22743)', () => {
+  test('dragged panel stays in place and updates after input change', async ({
+    page,
+  }) => {
+    await gotoPage(page, '');
+    await openPanel(
+      page,
+      'ui_buggy_drag_panel',
+      SELECTORS.WIDGET_LOADER_ELEMENT_VISIBLE,
+      true
+    );
+
+    const outerPanel = page
+      .locator(SELECTORS.WIDGET_LOADER_ELEMENT_VISIBLE)
+      .first();
+    await expect(outerPanel).toBeVisible();
+
+    // The nested dashboard starts with the Input panel and the draggable panel
+    // in a single stack.
+    const dragTab = page.locator('.lm_tab', { hasText: 'Drag me: title' });
+    await expect(dragTab).toHaveCount(1);
+    await expect(
+      outerPanel.getByText(
+        'Drag this panel to a new stack, then change the value'
+      )
+    ).toBeVisible();
+
+    // Drag the panel to the right edge of the nested dashboard to split it into
+    // a new stack.
+    const dashboardBox = await outerPanel.boundingBox();
+    if (dashboardBox == null) {
+      throw new Error('Could not get bounding box for the nested dashboard');
+    }
+    await dragTabToTarget(page, dragTab, {
+      x: dashboardBox.x + dashboardBox.width * 0.85,
+      y: dashboardBox.y + dashboardBox.height * 0.5,
+    });
+
+    // After the drag there should still be exactly one draggable panel (the bug
+    // duplicates it, leaving a blank panel in the original location).
+    await expect(
+      page.locator('.lm_tab', { hasText: 'Drag me: title' })
+    ).toHaveCount(1);
+    await expect(
+      outerPanel.getByText(
+        'Drag this panel to a new stack, then change the value'
+      )
+    ).toBeVisible();
+
+    // Record the location of the dragged panel so we can verify it does not move
+    // back after the input changes.
+    const draggedTab = page.locator('.lm_tab', { hasText: 'Drag me:' });
+    const beforeBox = await draggedTab.boundingBox();
+    if (beforeBox == null) {
+      throw new Error('Could not get bounding box for the dragged tab');
+    }
+
+    // Change the value in the Input panel.
+    const input = outerPanel.getByLabel('Title');
+    await input.fill('updated');
+
+    // The dragged panel title should update to reflect the new value...
+    const updatedTab = page.locator('.lm_tab', { hasText: 'Drag me: updated' });
+    await expect(updatedTab).toHaveCount(1);
+    // ...and the panel content should still be visible (not blank).
+    await expect(
+      outerPanel.getByText(
+        'Drag this panel to a new stack, then change the value'
+      )
+    ).toBeVisible();
+
+    // ...and it should still be in the location it was dragged to.
+    const afterBox = await updatedTab.boundingBox();
+    if (afterBox == null) {
+      throw new Error('Could not get bounding box for the updated tab');
+    }
+    expect(Math.abs(afterBox.x - beforeBox.x)).toBeLessThan(5);
+    expect(Math.abs(afterBox.y - beforeBox.y)).toBeLessThan(5);
+  });
+});


### PR DESCRIPTION
- When a user moves a panel to a different stack, look up, close, and rename it from the layout root so it's found regardless of where it lives in the layout. New panels are still opened in the parent stack.
- Added e2e and unit tests, ensured they passed
- Tested manually with the steps in the description of the ticket