### PR TITLE
ci: DH-20051: shard e2e tests and merge shard reports

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -61,7 +61,7 @@ jobs:
           path: /tmp/server-log.txt
 
   merge-reports:
-    if: ${{ !cancelled() }}
+    if: ${{ always() }}
     runs-on: ubuntu-24.04
     needs: [e2e-tests]
     steps:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -25,7 +25,7 @@ jobs:
           docker save tests-deephaven-plugins tests-e2e-tests | gzip > e2e-docker-images.tar.gz
 
       - name: Upload Docker images
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: e2e-docker-images
           path: e2e-docker-images.tar.gz
@@ -46,7 +46,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Download Docker images
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           name: e2e-docker-images
 
@@ -73,7 +73,7 @@ jobs:
             --shard=${{ steps.config.outputs.shard }}/${{ steps.config.outputs.shard_total }}
 
       - name: Upload Playwright blob report
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: playwright-report-blob-${{ matrix.config }}
@@ -86,7 +86,7 @@ jobs:
 
       - name: Upload server logs
         if: failure()
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: server-logs-${{ matrix.config }}
           path: /tmp/server-log.txt
@@ -105,7 +105,7 @@ jobs:
           node-version-file: '.nvmrc'
 
       - name: Download blob reports
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           pattern: playwright-report-blob-*
 
@@ -128,7 +128,7 @@ jobs:
           npx -y playwright@1.44.1 merge-reports --reporter html,github ./all-blob-reports
 
       - name: Upload HTML report
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: playwright-report
           path: playwright-report/

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -24,7 +24,7 @@ jobs:
         uses: docker/build-push-action@v7
         with:
           context: .
-          dockerfile: ./Dockerfile
+          file: ./Dockerfile
           push: false
           load: true
           tags: tests-deephaven-plugins
@@ -34,7 +34,7 @@ jobs:
         uses: docker/build-push-action@v7
         with:
           context: .
-          dockerfile: ./tests/Dockerfile
+          file: ./tests/Dockerfile
           push: false
           load: true
           tags: tests-e2e-tests

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -11,8 +11,29 @@ on:
       - 'release/**'
 
 jobs:
+  build-e2e-images:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Build Docker images
+        run: docker compose -f ./tests/docker-compose.yml build deephaven-plugins e2e-tests
+
+      - name: Export Docker images
+        run: |
+          docker save tests-deephaven-plugins tests-e2e-tests | gzip > e2e-docker-images.tar.gz
+
+      - name: Upload Docker images
+        uses: actions/upload-artifact@v5
+        with:
+          name: e2e-docker-images
+          path: e2e-docker-images.tar.gz
+          retention-days: 1
+
   e2e-tests:
     runs-on: ubuntu-24.04
+    needs: [build-e2e-images]
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}-e2e-tests-${{ matrix.config }}
       cancel-in-progress: true
@@ -23,6 +44,14 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+
+      - name: Download Docker images
+        uses: actions/download-artifact@v5
+        with:
+          name: e2e-docker-images
+
+      - name: Load Docker images
+        run: gunzip -c e2e-docker-images.tar.gz | docker load
 
       - name: Extract browser and shard config
         id: config
@@ -35,6 +64,8 @@ jobs:
           echo "shard_total=$shard_total" >> "$GITHUB_OUTPUT"
 
       - name: Run tests
+        env:
+          RUN_DOCKER_BUILD: 'false'
         run: |
           ./tools/run_docker.sh ./tests/docker-compose.yml e2e-tests \
             --reporter=blob \

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Export Docker images
         run: |
-          docker save tests-deephaven-plugins tests-e2e-tests | gzip > e2e-docker-images.tar.gz
+          docker save $(docker compose -f ./tests/docker-compose.yml images -q deephaven-plugins e2e-tests) | gzip > e2e-docker-images.tar.gz
 
       - name: Upload Docker images
         uses: actions/upload-artifact@v7

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -42,7 +42,7 @@ jobs:
             --shard=${{ steps.config.outputs.shard }}/${{ steps.config.outputs.shard_total }}
 
       - name: Upload Playwright blob report
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: playwright-report-blob-${{ matrix.config }}
@@ -55,7 +55,7 @@ jobs:
 
       - name: Upload server logs
         if: failure()
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: server-logs-${{ matrix.config }}
           path: /tmp/server-log.txt
@@ -74,7 +74,7 @@ jobs:
           node-version-file: '.nvmrc'
 
       - name: Download blob reports
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           pattern: playwright-report-blob-*
 
@@ -97,7 +97,7 @@ jobs:
           npx -y playwright@1.44.1 merge-reports --reporter html,github ./all-blob-reports
 
       - name: Upload HTML report
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: playwright-report
           path: playwright-report/

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -17,8 +17,28 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
-      - name: Build Docker images
-        run: docker compose -f ./tests/docker-compose.yml build deephaven-plugins e2e-tests
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Build deephaven-plugins image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          dockerfile: ./Dockerfile
+          push: false
+          load: true
+          tags: tests-deephaven-plugins
+          pull: true
+
+      - name: Build e2e-tests image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          dockerfile: ./tests/Dockerfile
+          push: false
+          load: true
+          tags: tests-e2e-tests
+          pull: true
 
       - name: Export Docker images
         run: |

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -9,7 +9,6 @@ on:
     branches:
       - main
       - 'release/**'
-  workflow_dispatch:
 
 jobs:
   e2e-tests:
@@ -23,7 +22,7 @@ jobs:
         config: [chromium-1-2, chromium-2-2, firefox-1-2, firefox-2-2, webkit-1-2, webkit-2-2]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Extract browser and shard config
         id: config
@@ -43,7 +42,7 @@ jobs:
             --shard=${{ steps.config.outputs.shard }}/${{ steps.config.outputs.shard_total }}
 
       - name: Upload Playwright blob report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         if: always()
         with:
           name: playwright-report-blob-${{ matrix.config }}
@@ -56,7 +55,7 @@ jobs:
 
       - name: Upload server logs
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: server-logs-${{ matrix.config }}
           path: /tmp/server-log.txt
@@ -67,15 +66,15 @@ jobs:
     needs: [e2e-tests]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version-file: '.nvmrc'
 
       - name: Download blob reports
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           pattern: playwright-report-blob-*
 
@@ -98,8 +97,17 @@ jobs:
           npx -y playwright@1.44.1 merge-reports --reporter html,github ./all-blob-reports
 
       - name: Upload HTML report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: playwright-report
           path: playwright-report/
-          retention-days: 90
+          retention-days: 30
+
+  e2e-test:
+    if: ${{ always() }}
+    runs-on: ubuntu-24.04
+    needs: [e2e-tests, merge-reports]
+    steps:
+      - name: Fail if any tests failed or cancelled
+        run: exit 1
+        if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Export Docker images
         run: |
-          docker save $(docker compose -f ./tests/docker-compose.yml images -q deephaven-plugins e2e-tests) | gzip > e2e-docker-images.tar.gz
+          docker save tests-deephaven-plugins tests-e2e-tests | gzip > e2e-docker-images.tar.gz
 
       - name: Upload Docker images
         uses: actions/upload-artifact@v7

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -9,27 +9,46 @@ on:
     branches:
       - main
       - 'release/**'
+  workflow_dispatch:
 
 jobs:
-  e2e-test:
+  e2e-tests:
     runs-on: ubuntu-24.04
     concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}
+      group: ${{ github.workflow }}-${{ github.ref }}-e2e-tests-${{ matrix.config }}
       cancel-in-progress: true
+    strategy:
+      fail-fast: false
+      matrix:
+        config: [chromium-1-2, chromium-2-2, firefox-1-2, firefox-2-2, webkit-1-2, webkit-2-2]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Run tests
-        run: './tools/run_docker.sh ./tests/docker-compose.yml e2e-tests'
+      - name: Extract browser and shard config
+        id: config
+        env:
+          MATRIX_CONFIG: ${{ matrix.config }}
+        run: |
+          IFS='-' read -r browser shard shard_total <<< "$MATRIX_CONFIG"
+          echo "browser=$browser" >> "$GITHUB_OUTPUT"
+          echo "shard=$shard" >> "$GITHUB_OUTPUT"
+          echo "shard_total=$shard_total" >> "$GITHUB_OUTPUT"
 
-      - name: Upload Playwright report
+      - name: Run tests
+        run: |
+          ./tools/run_docker.sh ./tests/docker-compose.yml e2e-tests \
+            --reporter=blob \
+            --project=${{ steps.config.outputs.browser }} \
+            --shard=${{ steps.config.outputs.shard }}/${{ steps.config.outputs.shard_total }}
+
+      - name: Upload Playwright blob report
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: playwright-report
-          path: playwright-report/
-          retention-days: 90
+          name: playwright-report-blob-${{ matrix.config }}
+          path: blob-report/
+          retention-days: 1
 
       - name: Dump server logs
         if: failure()
@@ -39,5 +58,48 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: server-logs
+          name: server-logs-${{ matrix.config }}
           path: /tmp/server-log.txt
+
+  merge-reports:
+    if: ${{ !cancelled() }}
+    runs-on: ubuntu-24.04
+    needs: [e2e-tests]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+
+      - name: Download blob reports
+        uses: actions/download-artifact@v4
+        with:
+          pattern: playwright-report-blob-*
+
+      - name: Merge into HTML report
+        run: |
+          mkdir -p all-blob-reports
+          for dir in playwright-report-blob-*; do
+            [ -d "$dir" ] || continue
+            zip_file=$(find "$dir" -type f -name '*.zip' | head -n 1)
+            [ -n "$zip_file" ] || continue
+            shard_name=${dir#playwright-report-blob-}
+            cp "$zip_file" "all-blob-reports/${shard_name}.zip"
+          done
+
+          if ! find all-blob-reports -type f -name '*.zip' | grep -q .; then
+            echo "No blob report zip files were found after download."
+            exit 1
+          fi
+
+          npx -y playwright@1.44.1 merge-reports --reporter html,github ./all-blob-reports
+
+      - name: Upload HTML report
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 90

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -11,49 +11,8 @@ on:
       - 'release/**'
 
 jobs:
-  build-e2e-images:
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v5
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
-
-      - name: Build deephaven-plugins image
-        uses: docker/build-push-action@v7
-        with:
-          context: .
-          file: ./Dockerfile
-          push: false
-          load: true
-          tags: tests-deephaven-plugins
-          pull: true
-
-      - name: Build e2e-tests image
-        uses: docker/build-push-action@v7
-        with:
-          context: .
-          file: ./tests/Dockerfile
-          push: false
-          load: true
-          tags: tests-e2e-tests
-          pull: true
-
-      - name: Export Docker images
-        run: |
-          docker save tests-deephaven-plugins tests-e2e-tests | gzip > e2e-docker-images.tar.gz
-
-      - name: Upload Docker images
-        uses: actions/upload-artifact@v7
-        with:
-          name: e2e-docker-images
-          path: e2e-docker-images.tar.gz
-          retention-days: 1
-
   e2e-tests:
     runs-on: ubuntu-24.04
-    needs: [build-e2e-images]
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}-e2e-tests-${{ matrix.config }}
       cancel-in-progress: true
@@ -64,14 +23,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
-
-      - name: Download Docker images
-        uses: actions/download-artifact@v8
-        with:
-          name: e2e-docker-images
-
-      - name: Load Docker images
-        run: gunzip -c e2e-docker-images.tar.gz | docker load
 
       - name: Extract browser and shard config
         id: config
@@ -84,8 +35,6 @@ jobs:
           echo "shard_total=$shard_total" >> "$GITHUB_OUTPUT"
 
       - name: Run tests
-        env:
-          RUN_DOCKER_BUILD: 'false'
         run: |
           ./tools/run_docker.sh ./tests/docker-compose.yml e2e-tests \
             --reporter=blob \
@@ -93,7 +42,7 @@ jobs:
             --shard=${{ steps.config.outputs.shard }}/${{ steps.config.outputs.shard_total }}
 
       - name: Upload Playwright blob report
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v5
         if: always()
         with:
           name: playwright-report-blob-${{ matrix.config }}
@@ -106,7 +55,7 @@ jobs:
 
       - name: Upload server logs
         if: failure()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v5
         with:
           name: server-logs-${{ matrix.config }}
           path: /tmp/server-log.txt
@@ -125,7 +74,7 @@ jobs:
           node-version-file: '.nvmrc'
 
       - name: Download blob reports
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v5
         with:
           pattern: playwright-report-blob-*
 
@@ -148,7 +97,7 @@ jobs:
           npx -y playwright@1.44.1 merge-reports --reporter html,github ./all-blob-reports
 
       - name: Upload HTML report
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v5
         with:
           name: playwright-report
           path: playwright-report/

--- a/playwright-docker.config.ts
+++ b/playwright-docker.config.ts
@@ -7,7 +7,6 @@ const config: PlaywrightTestConfig = {
     ...DefaultConfig.use,
     baseURL: 'http://deephaven-plugins:10000/ide/',
   },
-  reporter: process.env.CI ? [['github'], ['html']] : DefaultConfig.reporter,
 };
 
 export default config;

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -4,13 +4,11 @@
 FROM mcr.microsoft.com/playwright:v1.44.1-jammy AS playwright
 WORKDIR /work/
 
-# Update packages list and install some build tools.
-# Installing fonts-dejavu-core so we have some common fonts with the GH actions
-# runner that can be used to render unicode fonts. See web-client-ui README for more info.
+# Install a minimal font package so rendering is closer to GH Actions runners.
 RUN set -eux; \
     apt-get update; \
-    apt-get install build-essential --yes; \
-    apt-get install fonts-dejavu-core --yes;
+    apt-get install --no-install-recommends -y fonts-dejavu-core; \
+    rm -rf /var/lib/apt/lists/*
 
 RUN fc-list : family;
 

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /work/
 # Install a minimal font package so rendering is closer to GH Actions runners.
 RUN set -eux; \
     apt-get update; \
-    apt-get install --no-install-recommends -y fonts-dejavu-core; \
+    apt-get install --no-install-recommends --yes fonts-dejavu-core; \
     rm -rf /var/lib/apt/lists/*
 
 RUN fc-list : family;

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -28,7 +28,7 @@ services:
       - ../blob-report:/work/blob-report
       - ../playwright-report:/work/playwright-report
       - ../plugins:/work/plugins
-    entrypoint: 'npx playwright test --config=playwright-docker.config.ts'
+    entrypoint: 'npm exec -- playwright test --config=playwright-docker.config.ts'
     depends_on:
       deephaven-plugins:
         condition: service_healthy
@@ -36,7 +36,7 @@ services:
   update-snapshots:
     extends:
       service: e2e-tests
-    entrypoint: 'npx playwright test --config=playwright-docker.config.ts --update-snapshots'
+    entrypoint: 'npm exec -- playwright test --config=playwright-docker.config.ts --update-snapshots'
     depends_on:
       deephaven-plugins:
         condition: service_healthy

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
   deephaven-plugins:
     container_name: deephaven-plugins
@@ -27,6 +25,7 @@ services:
     volumes:
       - ../tests:/work/tests
       - ../test-results:/work/test-results
+      - ../blob-report:/work/blob-report
       - ../playwright-report:/work/playwright-report
       - ../plugins:/work/plugins
     entrypoint: 'npx playwright test --config=playwright-docker.config.ts'

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -28,7 +28,7 @@ services:
       - ../blob-report:/work/blob-report
       - ../playwright-report:/work/playwright-report
       - ../plugins:/work/plugins
-    entrypoint: 'npm exec -- playwright test --config=playwright-docker.config.ts'
+    entrypoint: 'npx playwright test --config=playwright-docker.config.ts'
     depends_on:
       deephaven-plugins:
         condition: service_healthy
@@ -36,7 +36,7 @@ services:
   update-snapshots:
     extends:
       service: e2e-tests
-    entrypoint: 'npm exec -- playwright test --config=playwright-docker.config.ts --update-snapshots'
+    entrypoint: 'npx playwright test --config=playwright-docker.config.ts --update-snapshots'
     depends_on:
       deephaven-plugins:
         condition: service_healthy

--- a/tests/ui_plotly.spec.ts
+++ b/tests/ui_plotly.spec.ts
@@ -7,7 +7,7 @@ test.describe('plotly works in deephaven.ui', () => {
     test(name, async ({ page }) => {
       await gotoPage(page, '');
       await openPanel(page, name, SELECTORS.WIDGET_LOADER_ELEMENT_VISIBLE);
-
+      expect(false).toBe(true);
       await expect(
         page.locator(SELECTORS.WIDGET_LOADER_ELEMENT_VISIBLE)
       ).toHaveScreenshot();

--- a/tests/ui_plotly.spec.ts
+++ b/tests/ui_plotly.spec.ts
@@ -7,7 +7,7 @@ test.describe('plotly works in deephaven.ui', () => {
     test(name, async ({ page }) => {
       await gotoPage(page, '');
       await openPanel(page, name, SELECTORS.WIDGET_LOADER_ELEMENT_VISIBLE);
-      expect(false).toBe(true);
+      
       await expect(
         page.locator(SELECTORS.WIDGET_LOADER_ELEMENT_VISIBLE)
       ).toHaveScreenshot();

--- a/tools/run_docker.sh
+++ b/tools/run_docker.sh
@@ -3,16 +3,21 @@
 COMPOSE_FILE=$1
 shift
 
+BUILD_FLAG=(--build)
+if [[ "${RUN_DOCKER_BUILD:-true}" == "false" ]]; then
+  BUILD_FLAG=()
+fi
+
 # Start the containers
 if [[ "${CI}" == "1" || "${CI}" == "true" ]]; then
   # In CI, keep the container in case we need to dump logs in another
   # step of the GH action. It should be cleaned up automatically by the CI runner.
-  docker compose -f "${COMPOSE_FILE}" run --service-ports --build -e CI=true "$@"
+  docker compose -f "${COMPOSE_FILE}" run --service-ports "${BUILD_FLAG[@]}" -e CI=true "$@"
   exit_code=$?
   # stop instead of down to preserve container logs
   docker compose -f "${COMPOSE_FILE}" stop deephaven-plugins
 else
-  docker compose -f "${COMPOSE_FILE}" run --service-ports --rm --build "$@"
+  docker compose -f "${COMPOSE_FILE}" run --service-ports --rm "${BUILD_FLAG[@]}" "$@"
   exit_code=$?
   docker compose -f "${COMPOSE_FILE}" down
 fi

--- a/tools/run_docker.sh
+++ b/tools/run_docker.sh
@@ -3,21 +3,16 @@
 COMPOSE_FILE=$1
 shift
 
-BUILD_FLAG=(--build)
-if [[ "${RUN_DOCKER_BUILD:-true}" == "false" ]]; then
-  BUILD_FLAG=()
-fi
-
 # Start the containers
 if [[ "${CI}" == "1" || "${CI}" == "true" ]]; then
   # In CI, keep the container in case we need to dump logs in another
   # step of the GH action. It should be cleaned up automatically by the CI runner.
-  docker compose -f "${COMPOSE_FILE}" run --service-ports "${BUILD_FLAG[@]}" -e CI=true "$@"
+  docker compose -f "${COMPOSE_FILE}" run --service-ports --build -e CI=true "$@"
   exit_code=$?
   # stop instead of down to preserve container logs
   docker compose -f "${COMPOSE_FILE}" stop deephaven-plugins
 else
-  docker compose -f "${COMPOSE_FILE}" run --service-ports --rm "${BUILD_FLAG[@]}" "$@"
+  docker compose -f "${COMPOSE_FILE}" run --service-ports --rm --build "$@"
   exit_code=$?
   docker compose -f "${COMPOSE_FILE}" down
 fi


### PR DESCRIPTION
This PR shards the end-to-end workflow to reduce overall time and keep full test coverage.  
Before: 51-53 mins
After: 22 mins

## Changes:
- Workflow fan-out: e2e.yml now runs a matrix of browser/shard configs: chromium 1/2, chromium 2/2, firefox 1/2, firefox 2/2, webkit 1/2, webkit 2/2.
- Shard execution: Each matrix job parses its browser and shard index and runs Playwright with project plus shard arguments.
- Report fan-in: Each shard uploads a blob artifact. A merge-reports job downloads shard blobs and merges them into one final HTML report artifact.
- Container output persistence: docker-compose.yml mounts blob-report so shard blob outputs are available to artifact upload.

CI reliability fixes:
   - playwright-docker.config.ts no longer overrides reporter in CI, allowing workflow-level blob reporter selection.
   - Dockerfile removes large build-essential install and keeps minimal font install to avoid no-space-left failures on runners.
   - docker-compose.yml removes obsolete compose version field warning.

Current e2e tests:
<img width="1049" height="863" alt="Screenshot 2026-06-11 at 3 10 59 PM" src="https://github.com/user-attachments/assets/c50d0138-7486-4a8d-9b05-6597c54de77e" />

e2e tests with sharding:
<img width="1057" height="77" alt="Screenshot 2026-06-11 at 3 11 55 PM" src="https://github.com/user-attachments/assets/294cc5af-3314-4e61-a401-02c598f53ac2" />

More details, showing how long each separate shard takes:
<img width="563" height="390" alt="Screenshot 2026-06-12 at 11 33 15 AM" src="https://github.com/user-attachments/assets/7499be1e-49db-4cfa-96e9-011bc0e8937e" />
