### PR TITLE
chore(ui): Clean up children typing to use NodeType

### DIFF
--- a/plugins/ui/src/deephaven/ui/components/action_button.py
+++ b/plugins/ui/src/deephaven/ui/components/action_button.py
@@ -21,13 +21,13 @@ from .types import (
 )
 
 from .basic import component_element
-from ..elements import Element
+from ..elements import Element, NodeType
 
 ActionButtonElement = Element
 
 
 def action_button(
-    *children: Any,
+    *children: NodeType,
     type: ButtonType = "button",
     on_press: PressEventCallable | None = None,
     on_press_start: PressEventCallable | None = None,

--- a/plugins/ui/src/deephaven/ui/components/action_group.py
+++ b/plugins/ui/src/deephaven/ui/components/action_group.py
@@ -17,12 +17,12 @@ from .types import (
     Position,
 )
 from .basic import component_element
-from ..elements import Element
+from ..elements import Element, NodeType
 from ..types import ActionGroupDensity, SelectedKeys, SelectionMode, Key, Selection
 
 
 def action_group(
-    *children: Any,
+    *children: NodeType,
     is_emphasized: bool | None = None,
     density: ActionGroupDensity | None = "regular",
     is_justified: bool | None = None,

--- a/plugins/ui/src/deephaven/ui/components/badge.py
+++ b/plugins/ui/src/deephaven/ui/components/badge.py
@@ -10,12 +10,12 @@ from .types import (
     Position,
 )
 from .basic import component_element
-from ..elements import Element
+from ..elements import Element, NodeType
 from ..types import BadgeVariant
 
 
 def badge(
-    *children: Any,
+    *children: NodeType,
     variant: BadgeVariant | None = None,
     flex: LayoutFlex | None = None,
     flex_grow: float | None = None,

--- a/plugins/ui/src/deephaven/ui/components/basic.py
+++ b/plugins/ui/src/deephaven/ui/components/basic.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 from typing import Any
-from ..elements import BaseElement
+from ..elements import BaseElement, NodeType
 
 NAME_PREFIX = "deephaven.ui.components."
 
 
-def component_element(name: str, /, *children: Any, **props: Any) -> BaseElement:
+def component_element(name: str, /, *children: NodeType, **props: Any) -> BaseElement:
     """
     Base class for UI elements.
     All names are automatically prefixed with "deephaven.ui.components.", and

--- a/plugins/ui/src/deephaven/ui/components/button.py
+++ b/plugins/ui/src/deephaven/ui/components/button.py
@@ -22,11 +22,11 @@ from .types import (
     Position,
 )
 from .basic import component_element
-from ..elements import Element
+from ..elements import Element, NodeType
 
 
 def button(
-    *children: Any,
+    *children: NodeType,
     variant: ButtonVariant | None = "accent",
     style: ButtonStyle | None = "fill",
     static_color: StaticColor | None = None,

--- a/plugins/ui/src/deephaven/ui/components/button_group.py
+++ b/plugins/ui/src/deephaven/ui/components/button_group.py
@@ -13,13 +13,13 @@ from .types import (
     Position,
 )
 from .basic import component_element
-from ..elements import Element
+from ..elements import Element, NodeType
 
 BUTTON_GROUP_NAME = "ButtonGroup"
 
 
 def button_group(
-    *children: Any,
+    *children: NodeType,
     is_disabled: bool | None = None,
     orientation: Orientation = "horizontal",
     align: ButtonGroupAlignment = "start",

--- a/plugins/ui/src/deephaven/ui/components/checkbox.py
+++ b/plugins/ui/src/deephaven/ui/components/checkbox.py
@@ -14,11 +14,11 @@ from .types import (
     Position,
 )
 from .basic import component_element
-from ..elements import Element
+from ..elements import Element, NodeType
 
 
 def checkbox(
-    *children: Any,
+    *children: NodeType,
     is_emphasized: bool | None = None,
     is_indeterminate: bool | None = None,
     default_selected: bool | None = None,

--- a/plugins/ui/src/deephaven/ui/components/checkbox_group.py
+++ b/plugins/ui/src/deephaven/ui/components/checkbox_group.py
@@ -16,12 +16,12 @@ from .types import (
     LabelPosition,
 )
 from .basic import component_element
-from ..elements import Element
+from ..elements import Element, NodeType
 from ..types import Key, Selection
 
 
 def checkbox_group(
-    *children: Any,
+    *children: NodeType,
     orientation: Orientation = "vertical",
     is_emphasized: bool | None = None,
     value: Selection | None = None,

--- a/plugins/ui/src/deephaven/ui/components/color_picker.py
+++ b/plugins/ui/src/deephaven/ui/components/color_picker.py
@@ -2,12 +2,12 @@ from __future__ import annotations
 from typing import Any, Callable
 
 from .basic import component_element
-from ..elements import Element
+from ..elements import Element, NodeType
 from ..types import CSSColor
 
 
 def color_picker(
-    *children: Any,
+    *children: NodeType,
     label: Any = None,
     size: str = "M",
     rounding: str = "default",

--- a/plugins/ui/src/deephaven/ui/components/column.py
+++ b/plugins/ui/src/deephaven/ui/components/column.py
@@ -2,11 +2,11 @@ from __future__ import annotations
 
 from typing import Any
 from .basic import component_element
-from ..elements import Element
+from ..elements import Element, NodeType
 
 
 def column(
-    *children: Any, width: float | None = None, key: str | None = None
+    *children: NodeType, width: float | None = None, key: str | None = None
 ) -> Element:
     """
     A column is a container that can be used to group elements.

--- a/plugins/ui/src/deephaven/ui/components/combo_box.py
+++ b/plugins/ui/src/deephaven/ui/components/combo_box.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Callable, Any
+from typing import Callable, Any, cast
 
 from .types import (
     FocusEventCallable,
@@ -244,6 +244,12 @@ def combo_box(
 
     children, props = unpack_item_table_source(children, props, SUPPORTED_SOURCE_ARGS)
 
+    # Table, PartitionedTable, and ItemTableSource children are not valid React
+    # node types, but are passed through here because the JS side has special
+    # handling for these table types. Cast to the expected child type.
     return component_element(
-        "ComboBox", *children, _nullable_props=_NULLABLE_PROPS, **props
+        "ComboBox",
+        *cast("tuple[NodeType, ...]", children),
+        _nullable_props=_NULLABLE_PROPS,
+        **props,
     )

--- a/plugins/ui/src/deephaven/ui/components/content.py
+++ b/plugins/ui/src/deephaven/ui/components/content.py
@@ -10,13 +10,13 @@ from .types import (
     Position,
 )
 from .basic import component_element
-from ..elements import Element
+from ..elements import Element, NodeType
 
 CONTENT_NAME = "Content"
 
 
 def content(
-    *children: Any,
+    *children: NodeType,
     flex: LayoutFlex | None = None,
     flex_grow: float | None = None,
     flex_shrink: float | None = None,

--- a/plugins/ui/src/deephaven/ui/components/disclosure_panel.py
+++ b/plugins/ui/src/deephaven/ui/components/disclosure_panel.py
@@ -9,11 +9,11 @@ from .types import (
     Position,
 )
 from .basic import component_element
-from ..elements import Element
+from ..elements import Element, NodeType
 
 
 def disclosure_panel(
-    *children: Any,
+    *children: NodeType,
     flex: LayoutFlex | None = None,
     flex_grow: float | None = None,
     flex_shrink: float | None = None,

--- a/plugins/ui/src/deephaven/ui/components/disclosure_title.py
+++ b/plugins/ui/src/deephaven/ui/components/disclosure_title.py
@@ -10,11 +10,11 @@ from .types import (
     HeadingLevel,
 )
 from .basic import component_element
-from ..elements import Element
+from ..elements import Element, NodeType
 
 
 def disclosure_title(
-    *children: Any,
+    *children: NodeType,
     level: HeadingLevel = 3,
     flex: LayoutFlex | None = None,
     flex_grow: float | None = None,

--- a/plugins/ui/src/deephaven/ui/components/flex.py
+++ b/plugins/ui/src/deephaven/ui/components/flex.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 from typing import Any
 from .basic import component_element
-from ..elements import Element
+from ..elements import Element, NodeType
 from .types import (
     LayoutFlex,
     Direction,
@@ -18,7 +18,7 @@ from .types import (
 
 
 def flex(
-    *children: Any,
+    *children: NodeType,
     direction: Direction | None = None,
     wrap: Wrap | None = None,
     justify_content: JustifyContent | None = None,

--- a/plugins/ui/src/deephaven/ui/components/form.py
+++ b/plugins/ui/src/deephaven/ui/components/form.py
@@ -19,11 +19,11 @@ from .types import (
     NecessityIndicator,
 )
 from .basic import component_element
-from ..elements import Element
+from ..elements import Element, NodeType
 
 
 def form(
-    *children: Any,
+    *children: NodeType,
     is_quiet: bool | None = None,
     is_emphasized: bool | None = None,
     is_disabled: bool | None = None,

--- a/plugins/ui/src/deephaven/ui/components/fragment.py
+++ b/plugins/ui/src/deephaven/ui/components/fragment.py
@@ -2,10 +2,10 @@ from __future__ import annotations
 
 from typing import Any
 from .basic import component_element
-from ..elements import Element
+from ..elements import Element, NodeType
 
 
-def fragment(*children: Any, key: str | None = None) -> Element:
+def fragment(*children: NodeType, key: str | None = None) -> Element:
     """
     A React.Fragment: https://react.dev/reference/react/Fragment.
     Used to group elements together without a wrapper node.

--- a/plugins/ui/src/deephaven/ui/components/grid.py
+++ b/plugins/ui/src/deephaven/ui/components/grid.py
@@ -15,14 +15,14 @@ from .types import (
     AlignItems,
 )
 from .basic import component_element
-from ..elements import Element
+from ..elements import Element, NodeType
 from ..types import Undefined, UndefinedType
 
 _NULLABLE_PROPS = ["justify_content", "align_content", "align_items"]
 
 
 def grid(
-    *children: Any,
+    *children: NodeType,
     areas: list[str] | None = None,
     rows: str | list[DimensionValue] | None = None,
     columns: str | list[DimensionValue] | None = None,

--- a/plugins/ui/src/deephaven/ui/components/heading.py
+++ b/plugins/ui/src/deephaven/ui/components/heading.py
@@ -12,13 +12,13 @@ from .types import (
 )
 from ..types import Color
 from .basic import component_element
-from ..elements import Element
+from ..elements import Element, NodeType
 
 HEADING_NAME = "Heading"
 
 
 def heading(
-    *children: Any,
+    *children: NodeType,
     level: HeadingLevel = 3,
     color: Color | None = None,
     flex: LayoutFlex | None = None,

--- a/plugins/ui/src/deephaven/ui/components/html.py
+++ b/plugins/ui/src/deephaven/ui/components/html.py
@@ -5,10 +5,10 @@ Provides a set of functions for creating raw HTML elements.
 
 The components provided in deephaven.ui should be preferred over this module.
 """
-from ..elements import BaseElement
+from ..elements import BaseElement, NodeType
 
 
-def html_element(tag: str, *children: Any, **attributes: Any) -> BaseElement:
+def html_element(tag: str, *children: NodeType, **attributes: Any) -> BaseElement:
     """
     Create a new HTML element. Render just returns the children that are passed in.
 
@@ -23,7 +23,7 @@ def html_element(tag: str, *children: Any, **attributes: Any) -> BaseElement:
     return BaseElement(f"deephaven.ui.html.{tag}", *children, **attributes)
 
 
-def div(*children: Any, **attributes: Any) -> BaseElement:
+def div(*children: NodeType, **attributes: Any) -> BaseElement:
     """
     Creates an HTML "div" element with the specified children and attributes.
 
@@ -37,7 +37,7 @@ def div(*children: Any, **attributes: Any) -> BaseElement:
     return html_element("div", *children, **attributes)
 
 
-def span(*children: Any, **attributes: Any) -> BaseElement:
+def span(*children: NodeType, **attributes: Any) -> BaseElement:
     """
     Creates an HTML "span" element with the specified children and attributes.
 
@@ -51,7 +51,7 @@ def span(*children: Any, **attributes: Any) -> BaseElement:
     return html_element("span", *children, **attributes)
 
 
-def h1(*children: Any, **attributes: Any) -> BaseElement:
+def h1(*children: NodeType, **attributes: Any) -> BaseElement:
     """
     Creates an HTML "h1" element with the specified children and attributes.
 
@@ -65,7 +65,7 @@ def h1(*children: Any, **attributes: Any) -> BaseElement:
     return html_element("h1", *children, **attributes)
 
 
-def h2(*children: Any, **attributes: Any) -> BaseElement:
+def h2(*children: NodeType, **attributes: Any) -> BaseElement:
     """
     Creates an HTML "h2" element with the specified children and attributes.
 
@@ -79,7 +79,7 @@ def h2(*children: Any, **attributes: Any) -> BaseElement:
     return html_element("h2", *children, **attributes)
 
 
-def h3(*children: Any, **attributes: Any) -> BaseElement:
+def h3(*children: NodeType, **attributes: Any) -> BaseElement:
     """
     Creates an HTML "h3" element with the specified children and attributes.
 
@@ -93,7 +93,7 @@ def h3(*children: Any, **attributes: Any) -> BaseElement:
     return html_element("h3", *children, **attributes)
 
 
-def h4(*children: Any, **attributes: Any) -> BaseElement:
+def h4(*children: NodeType, **attributes: Any) -> BaseElement:
     """
     Creates an HTML "h4" element with the specified children and attributes.
 
@@ -107,7 +107,7 @@ def h4(*children: Any, **attributes: Any) -> BaseElement:
     return html_element("h4", *children, **attributes)
 
 
-def h5(*children: Any, **attributes: Any) -> BaseElement:
+def h5(*children: NodeType, **attributes: Any) -> BaseElement:
     """
     Creates an HTML "h5" element with the specified children and attributes.
 
@@ -121,7 +121,7 @@ def h5(*children: Any, **attributes: Any) -> BaseElement:
     return html_element("h5", *children, **attributes)
 
 
-def h6(*children: Any, **attributes: Any) -> BaseElement:
+def h6(*children: NodeType, **attributes: Any) -> BaseElement:
     """
     Creates an HTML "h6" element with the specified children and attributes.
 
@@ -135,7 +135,7 @@ def h6(*children: Any, **attributes: Any) -> BaseElement:
     return html_element("h6", *children, **attributes)
 
 
-def p(*children: Any, **attributes: Any) -> BaseElement:
+def p(*children: NodeType, **attributes: Any) -> BaseElement:
     """
     Creates an HTML "p" element with the specified children and attributes.
 
@@ -149,7 +149,7 @@ def p(*children: Any, **attributes: Any) -> BaseElement:
     return html_element("p", *children, **attributes)
 
 
-def a(*children: Any, **attributes: Any) -> BaseElement:
+def a(*children: NodeType, **attributes: Any) -> BaseElement:
     """
     Creates an HTML "a" element with the specified children and attributes.
 
@@ -163,7 +163,7 @@ def a(*children: Any, **attributes: Any) -> BaseElement:
     return html_element("a", *children, **attributes)
 
 
-def ul(*children: Any, **attributes: Any) -> BaseElement:
+def ul(*children: NodeType, **attributes: Any) -> BaseElement:
     """
     Creates an HTML "ul" element with the specified children and attributes.
 
@@ -177,7 +177,7 @@ def ul(*children: Any, **attributes: Any) -> BaseElement:
     return html_element("ul", *children, **attributes)
 
 
-def ol(*children: Any, **attributes: Any) -> BaseElement:
+def ol(*children: NodeType, **attributes: Any) -> BaseElement:
     """
     Creates an HTML "ol" element with the specified children and attributes.
 
@@ -191,7 +191,7 @@ def ol(*children: Any, **attributes: Any) -> BaseElement:
     return html_element("ol", *children, **attributes)
 
 
-def li(*children: Any, **attributes: Any) -> BaseElement:
+def li(*children: NodeType, **attributes: Any) -> BaseElement:
     """
     Creates an HTML "li" element with the specified children and attributes.
 
@@ -205,7 +205,7 @@ def li(*children: Any, **attributes: Any) -> BaseElement:
     return html_element("li", *children, **attributes)
 
 
-def table(*children: Any, **attributes: Any) -> BaseElement:
+def table(*children: NodeType, **attributes: Any) -> BaseElement:
     """
     Creates an HTML "table" element with the specified children and attributes.
 
@@ -219,7 +219,7 @@ def table(*children: Any, **attributes: Any) -> BaseElement:
     return html_element("table", *children, **attributes)
 
 
-def thead(*children: Any, **attributes: Any) -> BaseElement:
+def thead(*children: NodeType, **attributes: Any) -> BaseElement:
     """
     Creates an HTML "thead" element with the specified children and attributes.
 
@@ -233,7 +233,7 @@ def thead(*children: Any, **attributes: Any) -> BaseElement:
     return html_element("thead", *children, **attributes)
 
 
-def tbody(*children: Any, **attributes: Any) -> BaseElement:
+def tbody(*children: NodeType, **attributes: Any) -> BaseElement:
     """
     Creates an HTML "tbody" element with the specified children and attributes.
 
@@ -247,7 +247,7 @@ def tbody(*children: Any, **attributes: Any) -> BaseElement:
     return html_element("tbody", *children, **attributes)
 
 
-def tr(*children: Any, **attributes: Any) -> BaseElement:
+def tr(*children: NodeType, **attributes: Any) -> BaseElement:
     """
     Creates an HTML "tr" element with the specified children and attributes.
 
@@ -261,7 +261,7 @@ def tr(*children: Any, **attributes: Any) -> BaseElement:
     return html_element("tr", *children, **attributes)
 
 
-def th(*children: Any, **attributes: Any) -> BaseElement:
+def th(*children: NodeType, **attributes: Any) -> BaseElement:
     """
     Creates an HTML "th" element with the specified children and attributes.
 
@@ -275,7 +275,7 @@ def th(*children: Any, **attributes: Any) -> BaseElement:
     return html_element("th", *children, **attributes)
 
 
-def td(*children: Any, **attributes: Any) -> BaseElement:
+def td(*children: NodeType, **attributes: Any) -> BaseElement:
     """
     Creates an HTML "td" element with the specified children and attributes.
 
@@ -289,7 +289,7 @@ def td(*children: Any, **attributes: Any) -> BaseElement:
     return html_element("td", *children, **attributes)
 
 
-def b(*children: Any, **attributes: Any) -> BaseElement:
+def b(*children: NodeType, **attributes: Any) -> BaseElement:
     """
     Creates an HTML "b" element with the specified children and attributes.
 
@@ -303,7 +303,7 @@ def b(*children: Any, **attributes: Any) -> BaseElement:
     return html_element("b", *children, **attributes)
 
 
-def i(*children: Any, **attributes: Any) -> BaseElement:
+def i(*children: NodeType, **attributes: Any) -> BaseElement:
     """
     Creates an HTML "i" element with the specified children and attributes.
 
@@ -317,7 +317,7 @@ def i(*children: Any, **attributes: Any) -> BaseElement:
     return html_element("i", *children, **attributes)
 
 
-def br(*children: Any, **attributes: Any) -> BaseElement:
+def br(*children: NodeType, **attributes: Any) -> BaseElement:
     """
     Creates an HTML "br" element with the specified children and attributes.
 
@@ -331,7 +331,7 @@ def br(*children: Any, **attributes: Any) -> BaseElement:
     return html_element("br", *children, **attributes)
 
 
-def hr(*children: Any, **attributes: Any) -> BaseElement:
+def hr(*children: NodeType, **attributes: Any) -> BaseElement:
     """
     Creates an HTML "hr" element with the specified children and attributes.
 
@@ -345,7 +345,7 @@ def hr(*children: Any, **attributes: Any) -> BaseElement:
     return html_element("hr", *children, **attributes)
 
 
-def pre(*children: Any, **attributes: Any) -> BaseElement:
+def pre(*children: NodeType, **attributes: Any) -> BaseElement:
     """
     Creates an HTML "pre" element with the specified children and attributes.
 
@@ -359,7 +359,7 @@ def pre(*children: Any, **attributes: Any) -> BaseElement:
     return html_element("pre", *children, **attributes)
 
 
-def code(*children: Any, **attributes: Any) -> BaseElement:
+def code(*children: NodeType, **attributes: Any) -> BaseElement:
     """
     Creates an HTML "code" element with the specified children and attributes.
 
@@ -373,7 +373,7 @@ def code(*children: Any, **attributes: Any) -> BaseElement:
     return html_element("code", *children, **attributes)
 
 
-def img(*children: Any, **attributes: Any) -> BaseElement:
+def img(*children: NodeType, **attributes: Any) -> BaseElement:
     """
     Creates an HTML "img" element with the specified children and attributes.
 
@@ -387,7 +387,7 @@ def img(*children: Any, **attributes: Any) -> BaseElement:
     return html_element("img", *children, **attributes)
 
 
-def button(*children: Any, **attributes: Any) -> BaseElement:
+def button(*children: NodeType, **attributes: Any) -> BaseElement:
     """
     Creates an HTML "button" element with the specified children and attributes.
 
@@ -401,7 +401,7 @@ def button(*children: Any, **attributes: Any) -> BaseElement:
     return html_element("button", *children, **attributes)
 
 
-def input(*children: Any, **attributes: Any) -> BaseElement:
+def input(*children: NodeType, **attributes: Any) -> BaseElement:
     """
     Creates an HTML "input" element with the specified children and attributes.
 
@@ -415,7 +415,7 @@ def input(*children: Any, **attributes: Any) -> BaseElement:
     return html_element("input", *children, **attributes)
 
 
-def form(*children: Any, **attributes: Any) -> BaseElement:
+def form(*children: NodeType, **attributes: Any) -> BaseElement:
     """
     Creates an HTML "form" element with the specified children and attributes.
 
@@ -429,7 +429,7 @@ def form(*children: Any, **attributes: Any) -> BaseElement:
     return html_element("form", *children, **attributes)
 
 
-def label(*children: Any, **attributes: Any) -> BaseElement:
+def label(*children: NodeType, **attributes: Any) -> BaseElement:
     """
     Creates an HTML "label" element with the specified children and attributes.
 
@@ -443,7 +443,7 @@ def label(*children: Any, **attributes: Any) -> BaseElement:
     return html_element("label", *children, **attributes)
 
 
-def select(*children: Any, **attributes: Any) -> BaseElement:
+def select(*children: NodeType, **attributes: Any) -> BaseElement:
     """
     Creates an HTML "select" element with the specified children and attributes.
 
@@ -457,7 +457,7 @@ def select(*children: Any, **attributes: Any) -> BaseElement:
     return html_element("select", *children, **attributes)
 
 
-def option(*children: Any, **attributes: Any) -> BaseElement:
+def option(*children: NodeType, **attributes: Any) -> BaseElement:
     """
     Creates an HTML "option" element with the specified children and attributes.
 
@@ -471,7 +471,7 @@ def option(*children: Any, **attributes: Any) -> BaseElement:
     return html_element("option", *children, **attributes)
 
 
-def textarea(*children: Any, **attributes: Any) -> BaseElement:
+def textarea(*children: NodeType, **attributes: Any) -> BaseElement:
     """
     Creates an HTML "textarea" element with the specified children and attributes.
 
@@ -485,7 +485,7 @@ def textarea(*children: Any, **attributes: Any) -> BaseElement:
     return html_element("textarea", *children, **attributes)
 
 
-def style(*children: Any, **attributes: Any) -> BaseElement:
+def style(*children: NodeType, **attributes: Any) -> BaseElement:
     """
     Creates an HTML "style" element with the specified children and attributes.
 

--- a/plugins/ui/src/deephaven/ui/components/illustrated_message.py
+++ b/plugins/ui/src/deephaven/ui/components/illustrated_message.py
@@ -9,11 +9,11 @@ from .types import (
     Position,
 )
 from .basic import component_element
-from ..elements import Element
+from ..elements import Element, NodeType
 
 
 def illustrated_message(
-    *children: Any,
+    *children: NodeType,
     flex: LayoutFlex | None = None,
     flex_grow: float | None = None,
     flex_shrink: float | None = None,

--- a/plugins/ui/src/deephaven/ui/components/link.py
+++ b/plugins/ui/src/deephaven/ui/components/link.py
@@ -13,7 +13,7 @@ from .types import (
     Position,
 )
 from .basic import component_element
-from ..elements import Element
+from ..elements import Element, NodeType
 from ..types import LinkVariant, NavigationTarget
 from ..hooks.use_navigate import build_navigate_payload
 
@@ -32,7 +32,7 @@ def _parse_link_to(to: str | NavigationTarget) -> dict:
 
 
 def link(
-    *children: Any,
+    *children: NodeType,
     variant: LinkVariant | None = "primary",
     is_quiet: bool | None = None,
     auto_focus: bool | None = None,

--- a/plugins/ui/src/deephaven/ui/components/list_view.py
+++ b/plugins/ui/src/deephaven/ui/components/list_view.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
-from typing import Callable, Any
+from typing import Callable, Any, cast
 
 from deephaven.table import Table
 
 from .item_table_source import ItemTableSource
-from ..elements import Element
+from ..elements import Element, NodeType
 from .._internal.utils import create_props, unpack_item_table_source
 from .basic import component_element
 from .item import Item
@@ -182,4 +182,9 @@ def list_view(
 
     children, props = unpack_item_table_source(children, props, SUPPORTED_SOURCE_ARGS)
 
-    return component_element("ListView", *children, **props)
+    # Table and ItemTableSource children are not valid React node types, but are
+    # passed through here because the JS side has special handling for these
+    # table types. Cast to the expected child type.
+    return component_element(
+        "ListView", *cast("tuple[NodeType, ...]", children), **props
+    )

--- a/plugins/ui/src/deephaven/ui/components/logic_button.py
+++ b/plugins/ui/src/deephaven/ui/components/logic_button.py
@@ -20,11 +20,11 @@ from .types import (
     Position,
 )
 from .basic import component_element
-from ..elements import Element
+from ..elements import Element, NodeType
 
 
 def logic_button(
-    *children: Any,
+    *children: NodeType,
     variant: str | None = None,
     is_disabled: bool | None = None,
     auto_focus: bool | None = None,

--- a/plugins/ui/src/deephaven/ui/components/panel.py
+++ b/plugins/ui/src/deephaven/ui/components/panel.py
@@ -13,12 +13,12 @@ from .types import (
     Overflow,
     CSSProperties,
 )
-from ..elements import Element
+from ..elements import Element, NodeType
 from ..types import Color
 
 
 def panel(
-    *children: Any,
+    *children: NodeType,
     title: str | None = None,
     direction: Direction | None = "column",
     wrap: Wrap | None = None,

--- a/plugins/ui/src/deephaven/ui/components/picker.py
+++ b/plugins/ui/src/deephaven/ui/components/picker.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Callable, Any
+from typing import Callable, Any, cast
 
 from deephaven.table import Table, PartitionedTable
 from .basic import component_element
@@ -225,6 +225,12 @@ def picker(
 
     children, props = unpack_item_table_source(children, props, SUPPORTED_SOURCE_ARGS)
 
+    # Table, PartitionedTable, and ItemTableSource children are not valid React
+    # node types, but are passed through here because the JS side has special
+    # handling for these table types. Cast to the expected child type.
     return component_element(
-        "Picker", *children, _nullable_props=_NULLABLE_PROPS, **props
+        "Picker",
+        *cast("tuple[NodeType, ...]", children),
+        _nullable_props=_NULLABLE_PROPS,
+        **props,
     )

--- a/plugins/ui/src/deephaven/ui/components/radio_group.py
+++ b/plugins/ui/src/deephaven/ui/components/radio_group.py
@@ -18,7 +18,7 @@ from .types import (
     ValidationBehavior,
 )
 from .basic import component_element
-from ..elements import Element
+from ..elements import Element, NodeType
 from ..types import Undefined, UndefinedType
 from .._internal.utils import create_props
 
@@ -27,7 +27,7 @@ _NULLABLE_PROPS = ["value", "default_value"]
 
 
 def radio_group(
-    *children: Any,
+    *children: NodeType,
     is_emphasized: bool | None = None,
     orientation: Orientation = "vertical",
     value: str | None | UndefinedType = Undefined,

--- a/plugins/ui/src/deephaven/ui/components/row.py
+++ b/plugins/ui/src/deephaven/ui/components/row.py
@@ -2,10 +2,12 @@ from __future__ import annotations
 
 from typing import Any
 from .basic import component_element
-from ..elements import Element
+from ..elements import Element, NodeType
 
 
-def row(*children: Any, height: float | None = None, key: str | None = None) -> Element:
+def row(
+    *children: NodeType, height: float | None = None, key: str | None = None
+) -> Element:
     """
     A row is a container that can be used to group elements.
     Each element will be placed to the right of its prior sibling.

--- a/plugins/ui/src/deephaven/ui/components/stack.py
+++ b/plugins/ui/src/deephaven/ui/components/stack.py
@@ -2,11 +2,11 @@ from __future__ import annotations
 
 from typing import Any
 from .basic import component_element
-from ..elements import Element
+from ..elements import Element, NodeType
 
 
 def stack(
-    *children: Any,
+    *children: NodeType,
     height: float | None = None,
     width: float | None = None,
     active_item_index: int | None = None,

--- a/plugins/ui/src/deephaven/ui/components/switch.py
+++ b/plugins/ui/src/deephaven/ui/components/switch.py
@@ -11,11 +11,11 @@ from .types import (
     Position,
 )
 from .basic import component_element
-from ..elements import Element
+from ..elements import Element, NodeType
 
 
 def switch(
-    *children: Any,
+    *children: NodeType,
     is_emphasized: bool | None = None,
     default_selected: bool | None = None,
     is_selected: bool | None = None,

--- a/plugins/ui/src/deephaven/ui/components/tab.py
+++ b/plugins/ui/src/deephaven/ui/components/tab.py
@@ -3,13 +3,13 @@ from typing import Any
 
 from .basic import component_element
 
-from ..elements import Element
+from ..elements import Element, NodeType
 
 from ..types import Key
 
 
 def tab(
-    *children: Any,
+    *children: NodeType,
     title: Any | None = None,
     key: Key | None = None,
     icon: Element | None = None,

--- a/plugins/ui/src/deephaven/ui/components/tab_list.py
+++ b/plugins/ui/src/deephaven/ui/components/tab_list.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from typing import Any
 
+from ..elements import NodeType
 from .basic import component_element
 
 from .types import (
@@ -14,7 +15,7 @@ from .types import (
 
 
 def tab_list(
-    *children: Any,
+    *children: NodeType,
     flex: LayoutFlex | None = None,
     flex_grow: float | None = None,
     flex_shrink: float | None = None,

--- a/plugins/ui/src/deephaven/ui/components/tab_panels.py
+++ b/plugins/ui/src/deephaven/ui/components/tab_panels.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from typing import Any
 
+from ..elements import NodeType
 from .basic import component_element
 
 from .types import (
@@ -14,7 +15,7 @@ from .types import (
 
 
 def tab_panels(
-    *children: Any,
+    *children: NodeType,
     flex: LayoutFlex | None = None,
     flex_grow: float | None = None,
     flex_shrink: float | None = None,

--- a/plugins/ui/src/deephaven/ui/components/tabs.py
+++ b/plugins/ui/src/deephaven/ui/components/tabs.py
@@ -15,7 +15,7 @@ from .types import (
 )
 
 from ..types import Key, TabDensity, Undefined, UndefinedType
-from ..elements import BaseElement
+from ..elements import BaseElement, Element
 
 TabElement = BaseElement
 
@@ -24,7 +24,7 @@ _NULLABLE_PROPS = ["selected_key"]
 
 
 def tabs(
-    *children: Any,
+    *children: Element,
     disabled_keys: Iterable[Key] | None = None,
     is_disabled: bool | None = None,
     is_quiet: bool | None = None,

--- a/plugins/ui/src/deephaven/ui/components/text.py
+++ b/plugins/ui/src/deephaven/ui/components/text.py
@@ -10,11 +10,11 @@ from .types import (
 )
 from ..types import Color
 from .basic import component_element
-from ..elements import Element
+from ..elements import Element, NodeType
 
 
 def text(
-    *children: Any,
+    *children: NodeType,
     color: Color | None = None,
     flex: LayoutFlex | None = None,
     flex_grow: float | None = None,

--- a/plugins/ui/src/deephaven/ui/components/toggle_button.py
+++ b/plugins/ui/src/deephaven/ui/components/toggle_button.py
@@ -20,11 +20,11 @@ from .types import (
     Position,
 )
 from .basic import component_element
-from ..elements import Element
+from ..elements import Element, NodeType
 
 
 def toggle_button(
-    *children: Any,
+    *children: NodeType,
     is_emphasized: bool | None = None,
     is_selected: bool | None = None,
     default_selected: bool | None = None,

--- a/plugins/ui/src/deephaven/ui/components/view.py
+++ b/plugins/ui/src/deephaven/ui/components/view.py
@@ -12,12 +12,12 @@ from .types import (
     Position,
 )
 from .basic import component_element
-from ..elements import Element
+from ..elements import Element, NodeType
 from ..types import Color
 
 
 def view(
-    *children: Any,
+    *children: NodeType,
     element_type: ElementTypes | None = None,
     flex: LayoutFlex | None = None,
     flex_grow: float | None = None,

--- a/plugins/ui/src/deephaven/ui/elements/BaseElement.py
+++ b/plugins/ui/src/deephaven/ui/elements/BaseElement.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from typing import Any
-from .Element import Element
+from .Element import Element, NodeType
 from .._internal import dict_to_react_props, RenderContext
 
 
@@ -22,7 +22,7 @@ class BaseElement(Element):
         self,
         name: str,
         /,
-        *children: Any,
+        *children: NodeType,
         key: str | None = None,
         _nullable_props: list[str] = [],
         **props: Any,

--- a/plugins/ui/src/deephaven/ui/elements/Element.py
+++ b/plugins/ui/src/deephaven/ui/elements/Element.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Any, Dict, List, Union
+from typing import Any, Dict, List, Tuple, Union
 from .._internal import RenderContext
 
 PropsType = Dict[str, Any]
@@ -48,4 +48,6 @@ class Element(ABC):
 
 
 # Some props don't support Undefined, so they need to add it themselves
-NodeType = Union[None, bool, int, str, Element, List["NodeType"]]
+NodeType = Union[
+    None, bool, float, int, str, Element, List["NodeType"], Tuple["NodeType", ...]
+]

--- a/plugins/ui/src/deephaven/ui/elements/__init__.py
+++ b/plugins/ui/src/deephaven/ui/elements/__init__.py
@@ -12,6 +12,7 @@ __all__ = [
     "DashboardElement",
     "Element",
     "FunctionElement",
+    "NodeType",
     "PropsType",
     "resolve",
 ]

--- a/tests/app.d/ui.py
+++ b/tests/app.d/ui.py
@@ -63,18 +63,20 @@ def ui_cells_component():
         set_cells(lambda old_cells: [c for c in old_cells if c != delete_id])
 
     return ui.view(
-        map(
-            lambda i: ui.flex(
-                ui_cell(label=f"Cell {i}"),
-                ui.action_button(
-                    ui.icon("trash"),
-                    aria_label="Delete cell",
-                    on_press=lambda _: delete_cell(i),
+        list(
+            map(
+                lambda i: ui.flex(
+                    ui_cell(label=f"Cell {i}"),
+                    ui.action_button(
+                        ui.icon("trash"),
+                        aria_label="Delete cell",
+                        on_press=lambda _: delete_cell(i),
+                    ),
+                    align_items="end",
+                    key=str(i),
                 ),
-                align_items="end",
-                key=str(i),
-            ),
-            cells,
+                cells,
+            )
         ),
         ui.action_button(ui.icon("add"), "Add cell", on_press=add_cell),
         overflow="auto",


### PR DESCRIPTION
- Replace untyped `*children: Any` parameters with the proper `NodeType` type across deephaven.ui components and HTML elements, expand `NodeType` to include float and tuple, and export `NodeType` from the elements package.
- combo_box, list_view, and picker accept Table/PartitionedTable/ItemTableSource children that are handled specially on the JS side. Add an explicit cast to NodeType.
- Doing this change as it will help with component memoization (particularly, passing in a `map` for children was causing issues with memoization)