### PR TITLE
feat: DH-22891: Example middleware plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3158,6 +3158,10 @@
       "resolved": "plugins/table-example/src/js",
       "link": true
     },
+    "node_modules/@deephaven/js-plugin-table-middleware-example": {
+      "resolved": "plugins/table-middleware-example/src/js",
+      "link": true
+    },
     "node_modules/@deephaven/js-plugin-theme-pack": {
       "resolved": "plugins/theme-pack/src/js",
       "link": true
@@ -31930,6 +31934,39 @@
       "dependencies": {
         "@deephaven/components": "^1.17.0",
         "@deephaven/jsapi-types": "^1.0.0-dev0.39.6"
+      },
+      "devDependencies": {
+        "@types/react": "^18.0.0",
+        "react": "^18.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0"
+      }
+    },
+    "plugins/table-middleware-example/src/js": {
+      "name": "@deephaven/js-plugin-table-middleware-example",
+      "version": "0.0.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@deephaven/log": "^1.8.0",
+        "@deephaven/plugin": "^1.17.0"
+      },
+      "devDependencies": {
+        "@types/react": "^18.0.0",
+        "react": "^18.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0"
+      }
+    },
+    "plugins/table-options-middleware-example/src/js": {
+      "name": "@deephaven/js-plugin-table-options-middleware-example",
+      "version": "0.0.0",
+      "extraneous": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@deephaven/log": "^1.8.0",
+        "@deephaven/plugin": "^1.17.0"
       },
       "devDependencies": {
         "@types/react": "^18.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -31949,7 +31949,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@deephaven/log": "^1.8.0",
-        "@deephaven/plugin": "^1.17.0"
+        "@deephaven/plugin": "^1.18.0"
       },
       "devDependencies": {
         "@types/react": "^18.0.0",

--- a/plugins/manifest.json
+++ b/plugins/manifest.json
@@ -32,6 +32,11 @@
       "main": "src/js/dist/index.js"
     },
     {
+      "name": "table-middleware-example",
+      "version": "0.0.0",
+      "main": "src/js/dist/index.js"
+    },
+    {
       "name": "pivot",
       "version": "0.0.0",
       "main": "src/js/dist/index.js"

--- a/plugins/table-middleware-example/src/js/.gitignore
+++ b/plugins/table-middleware-example/src/js/.gitignore
@@ -1,0 +1,5 @@
+# Ignore npm dependencies
+/node_modules
+
+# Ignore output directory
+/dist

--- a/plugins/table-middleware-example/src/js/LICENSE
+++ b/plugins/table-middleware-example/src/js/LICENSE
@@ -1,0 +1,176 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS

--- a/plugins/table-middleware-example/src/js/README.md
+++ b/plugins/table-middleware-example/src/js/README.md
@@ -1,0 +1,50 @@
+# Deephaven JS Plugin: Table Middleware Example
+
+A minimal `WidgetMiddlewarePlugin` that shows how a middleware plugin is
+inserted into a widget's render chain and what it can do to the next
+component: **wrap** it and **inject** props. It has no coupling to IrisGrid
+or any other specific widget — the functionality is intentionally slim so the
+middleware mechanics stand on their own.
+
+## What it does
+
+For every widget whose type is in `supportedTypes`
+(`Table`, `TreeTable`, `HierarchicalTable`, `PartitionedTable`), the middleware:
+
+1. **Injects** a custom prop (`exampleInjectedProp`) onto the wrapped
+   component. A widget that knows to read it can; one that doesn't ignores it.
+2. **Wraps** the wrapped component in an `ExampleMiddlewareContext.Provider`
+   (so descendants can read what the middleware contributed) plus a small
+   "Wrapped by example middleware" banner so the wrapping is visible.
+3. Logs the incoming widget metadata, proving the middleware sits in the chain.
+
+## How it's built
+
+The behavior lives in one shared body hook, `exampleMiddlewareBody`, which
+returns `{ inject, wrap }`. Two factory calls turn that single hook into the
+two components a `WidgetMiddlewarePlugin` needs:
+
+| Path | File | Factory |
+| --- | --- | --- |
+| Non-panel widget (e.g. dashboard widgets) | `ExampleWidgetMiddleware.tsx` | `createWidgetMiddleware` |
+| Panel (e.g. `IrisGridPanel` host) | `ExamplePanelMiddleware.tsx` | `createPanelMiddleware` |
+
+`createPanelMiddleware` owns the `forwardRef` ceremony and forwards
+golden-layout's panel ref down to the wrapped panel, so panel state (sorts,
+filters, column moves, etc.) is still persisted into `componentState`. The body
+hook never touches the ref.
+
+All the middleware helpers (`createWidgetMiddleware`, `createPanelMiddleware`,
+`MiddlewareBody`, `WidgetMiddlewarePlugin`, `PluginType.MIDDLEWARE_PLUGIN`) are
+imported directly from `@deephaven/plugin`.
+
+## Build
+
+```
+npm install
+npm run build
+```
+
+Bundle is emitted at `dist/index.js`. `plugins/manifest.json` registers
+`table-middleware-example` so the deephaven-plugins dev proxy serves
+the bundle.

--- a/plugins/table-middleware-example/src/js/package.json
+++ b/plugins/table-middleware-example/src/js/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@deephaven/js-plugin-table-middleware-example",
+  "version": "0.0.0",
+  "description": "Minimal example WidgetMiddlewarePlugin that wraps the next component and injects custom props for both the widget and panel paths.",
+  "keywords": [
+    "Deephaven",
+    "plugin",
+    "deephaven-js-plugin",
+    "middleware"
+  ],
+  "author": "Deephaven Data Labs LLC",
+  "license": "Apache-2.0",
+  "main": "dist/index.js",
+  "files": [
+    "dist/index.js"
+  ],
+  "scripts": {
+    "start": "vite build --watch",
+    "build": "vite build"
+  },
+  "dependencies": {
+    "@deephaven/log": "^1.8.0",
+    "@deephaven/plugin": "^1.17.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.0.0",
+    "react": "^18.0.0"
+  },
+  "peerDependencies": {
+    "react": "^18.0.0 || ^19.0.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/plugins/table-middleware-example/src/js/package.json
+++ b/plugins/table-middleware-example/src/js/package.json
@@ -12,8 +12,7 @@
   "license": "Apache-2.0",
   "main": "dist/index.js",
   "files": [
-    "dist/index.js",
-    "LICENSE"
+    "dist/index.js"
   ],
   "scripts": {
     "start": "vite build --watch",
@@ -21,7 +20,7 @@
   },
   "dependencies": {
     "@deephaven/log": "^1.8.0",
-    "@deephaven/plugin": "^1.17.0"
+    "@deephaven/plugin": "^1.18.0"
   },
   "devDependencies": {
     "@types/react": "^18.0.0",

--- a/plugins/table-middleware-example/src/js/package.json
+++ b/plugins/table-middleware-example/src/js/package.json
@@ -12,7 +12,8 @@
   "license": "Apache-2.0",
   "main": "dist/index.js",
   "files": [
-    "dist/index.js"
+    "dist/index.js",
+    "LICENSE"
   ],
   "scripts": {
     "start": "vite build --watch",

--- a/plugins/table-middleware-example/src/js/src/ExampleMiddlewareContext.ts
+++ b/plugins/table-middleware-example/src/js/src/ExampleMiddlewareContext.ts
@@ -8,7 +8,7 @@ import { createContext } from 'react';
  * widget API (there is no IrisGrid coupling here).
  */
 export interface ExampleMiddlewareContextValue {
-  /** A human-readable label identifying the middleware that wrapped the tree. */
+  /** A human-readable label identifying the middleware that wrapped the widget. */
   label: string;
 }
 

--- a/plugins/table-middleware-example/src/js/src/ExampleMiddlewareContext.ts
+++ b/plugins/table-middleware-example/src/js/src/ExampleMiddlewareContext.ts
@@ -1,0 +1,18 @@
+import { createContext } from 'react';
+
+/**
+ * Value provided by the example middleware's `wrap`. Any component rendered
+ * below the wrapped widget can read this with `useContext` to observe what the
+ * middleware contributed. Kept intentionally tiny — a single label — so the
+ * example stays focused on the middleware mechanics rather than any specific
+ * widget API (there is no IrisGrid coupling here).
+ */
+export interface ExampleMiddlewareContextValue {
+  /** A human-readable label identifying the middleware that wrapped the tree. */
+  label: string;
+}
+
+export const ExampleMiddlewareContext =
+  createContext<ExampleMiddlewareContextValue | null>(null);
+
+export default ExampleMiddlewareContext;

--- a/plugins/table-middleware-example/src/js/src/ExampleMiddlewarePlugin.ts
+++ b/plugins/table-middleware-example/src/js/src/ExampleMiddlewarePlugin.ts
@@ -1,0 +1,27 @@
+import { PluginType, type WidgetMiddlewarePlugin } from '@deephaven/plugin';
+import { ExampleWidgetMiddleware } from './ExampleWidgetMiddleware';
+import { ExamplePanelMiddleware } from './ExamplePanelMiddleware';
+
+/**
+ * Minimal `WidgetMiddlewarePlugin`. A middleware plugin is inserted into the
+ * render chain for every widget whose type matches `supportedTypes`, without
+ * the widget opting in. It can wrap the next component and inject props (see
+ * `exampleMiddlewareBody`).
+ *
+ * - `component` handles the non-panel widget path.
+ * - `panelComponent` handles the panel path and is ref-capable.
+ */
+export const ExampleMiddlewarePlugin: WidgetMiddlewarePlugin = {
+  name: '@deephaven/js-plugin-table-middleware-example',
+  type: PluginType.MIDDLEWARE_PLUGIN,
+  supportedTypes: [
+    'Table',
+    'TreeTable',
+    'HierarchicalTable',
+    'PartitionedTable',
+  ],
+  component: ExampleWidgetMiddleware,
+  panelComponent: ExamplePanelMiddleware,
+};
+
+export default ExampleMiddlewarePlugin;

--- a/plugins/table-middleware-example/src/js/src/ExamplePanelMiddleware.tsx
+++ b/plugins/table-middleware-example/src/js/src/ExamplePanelMiddleware.tsx
@@ -1,0 +1,17 @@
+import { createPanelMiddleware } from '@deephaven/plugin';
+import { exampleMiddlewareBody } from './exampleMiddlewareBody';
+
+/**
+ * Middleware for the panel path (the `IrisGridPanel` host and similar). Built
+ * with `createPanelMiddleware`, which owns the `forwardRef` ceremony and
+ * forwards golden-layout's panel ref down to the wrapped panel so its React
+ * state (sorts, filters, column moves, etc.) is still persisted into
+ * `componentState`. The shared body hook decides what to inject and how to
+ * wrap; it never touches the ref.
+ */
+export const ExamplePanelMiddleware = createPanelMiddleware(
+  exampleMiddlewareBody,
+  'ExamplePanelMiddleware'
+);
+
+export default ExamplePanelMiddleware;

--- a/plugins/table-middleware-example/src/js/src/ExampleWidgetMiddleware.tsx
+++ b/plugins/table-middleware-example/src/js/src/ExampleWidgetMiddleware.tsx
@@ -1,0 +1,14 @@
+import { createWidgetMiddleware } from '@deephaven/plugin';
+import { exampleMiddlewareBody } from './exampleMiddlewareBody';
+
+/**
+ * Middleware for the non-panel widget path (e.g. dashboard widgets rendered via
+ * `GridWidgetPlugin`). The widget path takes no ref, so this is a plain
+ * function component built from the shared body hook.
+ */
+export const ExampleWidgetMiddleware = createWidgetMiddleware(
+  exampleMiddlewareBody,
+  'ExampleWidgetMiddleware'
+);
+
+export default ExampleWidgetMiddleware;

--- a/plugins/table-middleware-example/src/js/src/exampleMiddlewareBody.tsx
+++ b/plugins/table-middleware-example/src/js/src/exampleMiddlewareBody.tsx
@@ -1,0 +1,66 @@
+import type { MiddlewareBody } from '@deephaven/plugin';
+import Log from '@deephaven/log';
+import { ExampleMiddlewareContext } from './ExampleMiddlewareContext';
+
+const log = Log.module('ExampleMiddleware');
+
+/**
+ * The single shared body of the example middleware. Both the widget path
+ * (`createWidgetMiddleware`) and the panel path (`createPanelMiddleware`) reuse
+ * this one hook, so the plugin expresses its behavior exactly once.
+ *
+ * It demonstrates the two things a middleware can do to the next component in
+ * the chain, with no coupling to any specific widget type (e.g. IrisGrid):
+ *
+ * 1. `inject` — merge extra props onto the wrapped `Component`. Here we add a
+ *    single `exampleInjectedProp`. The wrapped component receives it alongside
+ *    its normal props; a widget that knows to read it can use it, and any that
+ *    doesn't simply ignores it.
+ * 2. `wrap` — render a wrapper *around* the wrapped component. Here we provide
+ *    an `ExampleMiddlewareContext` so descendants can read what the middleware
+ *    contributed, plus a small banner so the wrapping is visible in the UI.
+ *
+ * The body never sees (and cannot drop) the panel ref — the factory forwards it
+ * for us, keeping golden-layout state persistence intact.
+ */
+export const exampleMiddlewareBody: MiddlewareBody<{
+  metadata?: { name?: string };
+}> = props => {
+  log.info('Middleware in chain. Incoming widget metadata:', props.metadata);
+
+  return {
+    // Extra prop threaded down to the next component in the chain.
+    inject: {
+      exampleInjectedProp: 'Hello from the example middleware!',
+    },
+    // Wrapper placed around the next component: a context provider + banner.
+    wrap: child => (
+      <ExampleMiddlewareContext.Provider
+        value={{ label: '@deephaven/js-plugin-table-middleware-example' }}
+      >
+        <div
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            height: '100%',
+          }}
+        >
+          <div
+            style={{
+              flex: '0 0 auto',
+              padding: '4px 8px',
+              fontSize: '12px',
+              opacity: 0.7,
+              borderBottom: '1px solid var(--dh-color-border, #3b3b3b)',
+            }}
+          >
+            Wrapped by example middleware
+          </div>
+          <div style={{ flex: '1 1 auto', minHeight: 0 }}>{child}</div>
+        </div>
+      </ExampleMiddlewareContext.Provider>
+    ),
+  };
+};
+
+export default exampleMiddlewareBody;

--- a/plugins/table-middleware-example/src/js/src/exampleMiddlewareBody.tsx
+++ b/plugins/table-middleware-example/src/js/src/exampleMiddlewareBody.tsx
@@ -26,7 +26,7 @@ const log = Log.module('ExampleMiddleware');
 export const exampleMiddlewareBody: MiddlewareBody<{
   metadata?: { name?: string };
 }> = props => {
-  log.info('Middleware in chain. Incoming widget metadata:', props.metadata);
+  log.debug('Middleware in chain. Incoming widget metadata:', props.metadata);
 
   return {
     // Extra prop threaded down to the next component in the chain.

--- a/plugins/table-middleware-example/src/js/src/index.ts
+++ b/plugins/table-middleware-example/src/js/src/index.ts
@@ -1,0 +1,12 @@
+import { ExampleMiddlewarePlugin } from './ExampleMiddlewarePlugin';
+
+export {
+  ExampleMiddlewareContext,
+  type ExampleMiddlewareContextValue,
+} from './ExampleMiddlewareContext';
+export { exampleMiddlewareBody } from './exampleMiddlewareBody';
+export { ExampleWidgetMiddleware } from './ExampleWidgetMiddleware';
+export { ExamplePanelMiddleware } from './ExamplePanelMiddleware';
+export { ExampleMiddlewarePlugin } from './ExampleMiddlewarePlugin';
+
+export default ExampleMiddlewarePlugin;

--- a/plugins/table-middleware-example/src/js/vite.config.ts
+++ b/plugins/table-middleware-example/src/js/vite.config.ts
@@ -1,0 +1,21 @@
+/* eslint-disable import/no-extraneous-dependencies */
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react-swc';
+
+// https://vitejs.dev/config/
+export default defineConfig(({ mode }) => ({
+  build: {
+    minify: false,
+    lib: {
+      entry: './src/index.ts',
+      fileName: () => 'index.js',
+      formats: ['cjs'],
+    },
+    rollupOptions: {
+      external: ['react', 'react-dom', '@deephaven/log', '@deephaven/plugin'],
+    },
+  },
+  define:
+    mode === 'production' ? { 'process.env.NODE_ENV': '"production"' } : {},
+  plugins: [react()],
+}));


### PR DESCRIPTION
## feat: DH-22891: Example middleware plugin

Adds `table-middleware-example`, a minimal `WidgetMiddlewarePlugin` demonstrating how a middleware plugin is inserted into a widget's render chain and how it can **wrap** the next component and **inject** custom props — with no coupling to IrisGrid or any other specific widget.

### What it does

- A single shared body hook (`exampleMiddlewareBody`) returning `{ inject, wrap }`: injects a custom `exampleInjectedProp` and wraps the wrapped component in an `ExampleMiddlewareContext.Provider` plus a small "Wrapped by example middleware" banner.
- The one body hook drives both middleware paths via the `@deephaven/plugin` factories: `createWidgetMiddleware` (non-panel / dashboard) and `createPanelMiddleware` (panel path, which preserves golden-layout's panel ref so `componentState` persistence stays intact).
- Wired up as a `PluginType.MIDDLEWARE_PLUGIN` with `supportedTypes: ['Table', 'TreeTable', 'HierarchicalTable', 'PartitionedTable']`, registered in `plugins/manifest.json`.
