### PR TITLE
fix(ui): DH-22995: wrap bare dashboard children in a panel on rehydration

### DIFF
--- a/plugins/ui/src/js/src/layout/Column.tsx
+++ b/plugins/ui/src/js/src/layout/Column.tsx
@@ -4,6 +4,7 @@ import type { RowOrColumn } from '@deephaven/golden-layout';
 import { Flex } from '@deephaven/components';
 import {
   normalizeColumnChildren,
+  wrapBareChildrenInPanel,
   type ColumnElementProps,
 } from './LayoutUtils';
 import { ParentItemContext, useParentItem } from './ParentItemContext';
@@ -52,9 +53,10 @@ function Column({ children, width }: ColumnElementProps): JSX.Element {
   if (initialLayoutConfig != null) {
     // If there's already an initial layout defined, user has likely already customized their layout.
     // Don't add a column here, or normalize the children which might add a stack unnecessarily.
-    // Just render the children as they are, and the initial layout config should already have the panels mapped out.
+    // The persisted layout already has the rows/columns/stacks mapped out, but bare
+    // content children still need a panel wrapper so they portal into their persisted panel.
     // eslint-disable-next-line react/jsx-no-useless-fragment
-    return <>{children}</>;
+    return <>{wrapBareChildrenInPanel(children)}</>;
   }
 
   if (panelId == null) {

--- a/plugins/ui/src/js/src/layout/LayoutUtils.test.tsx
+++ b/plugins/ui/src/js/src/layout/LayoutUtils.test.tsx
@@ -239,7 +239,9 @@ describe('wrapBareChildrenInPanel', () => {
     compareReactNodes(wrapBareChildrenInPanel(<Row />), [<Row />]);
     compareReactNodes(wrapBareChildrenInPanel(<Column />), [<Column />]);
     compareReactNodes(wrapBareChildrenInPanel(<Stack />), [<Stack />]);
-    compareReactNodes(wrapBareChildrenInPanel(<ReactPanel />), [<ReactPanel />]);
+    compareReactNodes(wrapBareChildrenInPanel(<ReactPanel />), [
+      <ReactPanel />,
+    ]);
   });
 
   test('passes through multiple layout elements unchanged', () => {
@@ -269,12 +271,7 @@ describe('wrapBareChildrenInPanel', () => {
     const bare = <div>Content</div>;
     compareReactNodes(
       wrapBareChildrenInPanel([<Row />, bare, <ReactPanel />, <Column />]),
-      [
-        <Row />,
-        <ReactPanel>{bare}</ReactPanel>,
-        <ReactPanel />,
-        <Column />,
-      ]
+      [<Row />, <ReactPanel>{bare}</ReactPanel>, <ReactPanel />, <Column />]
     );
   });
 

--- a/plugins/ui/src/js/src/layout/LayoutUtils.test.tsx
+++ b/plugins/ui/src/js/src/layout/LayoutUtils.test.tsx
@@ -11,6 +11,7 @@ import {
   normalizeColumnChildren,
   normalizeRowChildren,
   normalizeStackChildren,
+  wrapBareChildrenInPanel,
 } from './LayoutUtils';
 import Row from './Row';
 import Stack from './Stack';
@@ -230,5 +231,54 @@ describe('normalizeStackChildren', () => {
         <Row />
       </ReactPanel>,
     ]);
+  });
+});
+
+describe('wrapBareChildrenInPanel', () => {
+  test('passes through layout elements unchanged', () => {
+    compareReactNodes(wrapBareChildrenInPanel(<Row />), [<Row />]);
+    compareReactNodes(wrapBareChildrenInPanel(<Column />), [<Column />]);
+    compareReactNodes(wrapBareChildrenInPanel(<Stack />), [<Stack />]);
+    compareReactNodes(wrapBareChildrenInPanel(<ReactPanel />), [<ReactPanel />]);
+  });
+
+  test('passes through multiple layout elements unchanged', () => {
+    compareReactNodes(
+      wrapBareChildrenInPanel([<Row />, <Column />, <Stack />, <ReactPanel />]),
+      [<Row />, <Column />, <Stack />, <ReactPanel />]
+    );
+  });
+
+  test('wraps bare content elements in a ReactPanel', () => {
+    const heading = <div>Heading</div>;
+    compareReactNodes(wrapBareChildrenInPanel(heading), [
+      <ReactPanel>{heading}</ReactPanel>,
+    ]);
+  });
+
+  test('wraps multiple bare content elements each in their own ReactPanel', () => {
+    const a = <div>A</div>;
+    const b = <span>B</span>;
+    compareReactNodes(wrapBareChildrenInPanel([a, b]), [
+      <ReactPanel>{a}</ReactPanel>,
+      <ReactPanel>{b}</ReactPanel>,
+    ]);
+  });
+
+  test('wraps bare elements but leaves layout elements and panels untouched in mixed children', () => {
+    const bare = <div>Content</div>;
+    compareReactNodes(
+      wrapBareChildrenInPanel([<Row />, bare, <ReactPanel />, <Column />]),
+      [
+        <Row />,
+        <ReactPanel>{bare}</ReactPanel>,
+        <ReactPanel />,
+        <Column />,
+      ]
+    );
+  });
+
+  test('returns null for null children', () => {
+    expect(wrapBareChildrenInPanel(null)).toBeNull();
   });
 });

--- a/plugins/ui/src/js/src/layout/LayoutUtils.tsx
+++ b/plugins/ui/src/js/src/layout/LayoutUtils.tsx
@@ -273,3 +273,37 @@ export function normalizeStackChildren(
     return child;
   });
 }
+
+/**
+ * Wraps any "bare" content children (elements that are neither layout elements -
+ * Row/Column/Stack - nor an explicit ReactPanel) in a ReactPanel.
+ *
+ * This is used when rehydrating from a persisted layout. In that case we skip
+ * re-creating the Row/Column/Stack golden-layout containers (they are restored
+ * from the saved config), but a bare content element (e.g. from
+ * `ui.dashboard(ui.heading(...))`) still needs a ReactPanel wrapper so it is
+ * portaled into its persisted PortalPanel. Without it, the element renders
+ * outside the layout and ends up off-screen / blank. See DH-22995.
+ *
+ * Layout elements and existing panels are passed through untouched so the
+ * persisted layout structure is preserved.
+ *
+ * @param children Children to wrap
+ * @returns Children with bare content elements wrapped in a ReactPanel
+ */
+export function wrapBareChildrenInPanel(
+  children: React.ReactNode
+): React.ReactNode {
+  return Children.map(children, child => {
+    if (
+      isValidElement(child) &&
+      child.type !== Row &&
+      child.type !== Column &&
+      child.type !== Stack &&
+      child.type !== ReactPanel
+    ) {
+      return <ReactPanel title="Untitled">{child}</ReactPanel>;
+    }
+    return child;
+  });
+}

--- a/plugins/ui/src/js/src/layout/LayoutUtils.tsx
+++ b/plugins/ui/src/js/src/layout/LayoutUtils.tsx
@@ -302,7 +302,7 @@ export function wrapBareChildrenInPanel(
       child.type !== Stack &&
       child.type !== ReactPanel
     ) {
-      return <ReactPanel title="Untitled">{child}</ReactPanel>;
+      return <ReactPanel>{child}</ReactPanel>;
     }
     return child;
   });

--- a/plugins/ui/src/js/src/layout/NestedDashboard.test.tsx
+++ b/plugins/ui/src/js/src/layout/NestedDashboard.test.tsx
@@ -10,7 +10,6 @@ import NestedDashboard from './NestedDashboard';
 import Row from './Row';
 import Column from './Column';
 import Stack from './Stack';
-import ReactPanel from './ReactPanel';
 import { ReactPanelContext, usePanelId } from './ReactPanelContext';
 import {
   ReactPanelManagerContext,

--- a/plugins/ui/src/js/src/layout/NestedDashboard.test.tsx
+++ b/plugins/ui/src/js/src/layout/NestedDashboard.test.tsx
@@ -10,6 +10,7 @@ import NestedDashboard from './NestedDashboard';
 import Row from './Row';
 import Column from './Column';
 import Stack from './Stack';
+import ReactPanel from './ReactPanel';
 import { ReactPanelContext, usePanelId } from './ReactPanelContext';
 import {
   ReactPanelManagerContext,
@@ -29,6 +30,21 @@ jest.mock('./LayoutUtils', () => ({
   normalizeRowChildren: (children: React.ReactNode) => children,
   normalizeColumnChildren: (children: React.ReactNode) => children,
   normalizeStackChildren: (children: React.ReactNode) => children,
+  wrapBareChildrenInPanel: (children: React.ReactNode) => children,
+}));
+
+// Mock ReactPanel to a simple passthrough. These tests verify Row/Column/Stack
+// content-item behavior, not the panel's GoldenLayout interaction (which the
+// mock layout manager can't fully satisfy).
+jest.mock('./ReactPanel', () => ({
+  __esModule: true,
+  default: function MockReactPanel({
+    children,
+  }: {
+    children: React.ReactNode;
+  }): React.ReactNode {
+    return children;
+  },
 }));
 
 // Mock usePersistentState which requires FiberProvider context

--- a/plugins/ui/src/js/src/layout/Row.tsx
+++ b/plugins/ui/src/js/src/layout/Row.tsx
@@ -2,7 +2,11 @@ import React, { useEffect, useMemo } from 'react';
 import { useLayoutManager } from '@deephaven/dashboard';
 import type { RowOrColumn } from '@deephaven/golden-layout';
 import { Flex } from '@deephaven/components';
-import { normalizeRowChildren, type RowElementProps } from './LayoutUtils';
+import {
+  normalizeRowChildren,
+  wrapBareChildrenInPanel,
+  type RowElementProps,
+} from './LayoutUtils';
 import { ParentItemContext, useParentItem } from './ParentItemContext';
 import { usePanelId } from './ReactPanelContext';
 import { useInitialLayoutConfig } from './InitialLayoutConfigContext';
@@ -45,9 +49,10 @@ function Row({ children, height }: RowElementProps): JSX.Element {
   if (initialLayoutConfig != null) {
     // If there's already an initial layout defined, user has likely already customized their layout.
     // Don't add a row here, or normalize the children which might add a stack unnecessarily.
-    // Just render the children as they are, and the initial layout config should already have the panels mapped out.
+    // The persisted layout already has the rows/columns/stacks mapped out, but bare
+    // content children still need a panel wrapper so they portal into their persisted panel.
     // eslint-disable-next-line react/jsx-no-useless-fragment
-    return <>{children}</>;
+    return <>{wrapBareChildrenInPanel(children)}</>;
   }
 
   if (panelId == null) {

--- a/plugins/ui/src/js/src/layout/Stack.tsx
+++ b/plugins/ui/src/js/src/layout/Stack.tsx
@@ -1,7 +1,11 @@
 import React, { useEffect, useMemo } from 'react';
 import { useLayoutManager } from '@deephaven/dashboard';
 import type { Stack as StackType, RowOrColumn } from '@deephaven/golden-layout';
-import { normalizeStackChildren, type StackElementProps } from './LayoutUtils';
+import {
+  normalizeStackChildren,
+  wrapBareChildrenInPanel,
+  type StackElementProps,
+} from './LayoutUtils';
 import { ParentItemContext, useParentItem } from './ParentItemContext';
 import { useInitialLayoutConfig } from './InitialLayoutConfigContext';
 
@@ -52,10 +56,11 @@ function Stack(props: StackElementProps): JSX.Element | null {
   if (initialLayoutConfig != null) {
     // If there's already an initial layout defined, user has likely already customized their layout.
     // Don't add a stack here, or normalize the children which might add a stack unnecessarily.
-    // Just render the children as they are, and the initial layout config should already have the panels mapped out.
+    // The persisted layout already has the stacks mapped out, but bare content children
+    // still need a panel wrapper so they portal into their persisted panel.
     const { children } = props;
     // eslint-disable-next-line react/jsx-no-useless-fragment
-    return <>{children}</>;
+    return <>{wrapBareChildrenInPanel(children)}</>;
   }
 
   // eslint-disable-next-line react/jsx-props-no-spreading

--- a/tests/app.d/ui_nested_dashboard.py
+++ b/tests/app.d/ui_nested_dashboard.py
@@ -115,3 +115,9 @@ ui_nested_dashboard_interactive = nested_dashboard_interactive_component()
 ui_deeply_nested_dashboard = deeply_nested_dashboard_component()
 ui_nested_dashboard_with_state = nested_dashboard_with_state_component()
 ui_buggy_drag_panel = buggy_drag_panel()
+
+# DH-22995: A dashboard whose only child is a non-panel element. The element is
+# auto-wrapped in a panel. After persisting the layout (disable "Close Panels on
+# Disconnect") and refreshing, the panel reopens but its content renders
+# off-screen with an unnecessary scroll bar.
+ui_heading_dashboard = ui.panel(ui.dashboard(ui.heading("Reproducing DH-22995")))

--- a/tests/ui_nested_dashboard.spec.ts
+++ b/tests/ui_nested_dashboard.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import { openPanel, gotoPage, SELECTORS } from './utils';
+import { openPanel, gotoPage, waitForLoad, SELECTORS } from './utils';
 
 test.describe('Nested Dashboards', () => {
   test('renders a dashboard inside a panel', async ({ page }) => {
@@ -66,5 +66,60 @@ test.describe('Nested Dashboards', () => {
     await expect(outerPanel.getByText('Content Level 1')).toBeVisible();
     await expect(outerPanel.getByText('Content Level 2')).toBeVisible();
     await expect(outerPanel.getByText('Deepest Content')).toBeVisible();
+  });
+
+  // DH-22995: A dashboard whose only child is a non-panel element (auto-wrapped
+  // in a panel). After disabling "Close Panels on Disconnect" to persist the
+  // layout and refreshing the page, the panel reopens but its content renders
+  // off-screen with an unnecessary scroll bar instead of being visible.
+  test('dashboard content is visible after refresh with panels persisted', async ({
+    page,
+  }) => {
+    await gotoPage(page, '');
+
+    // Open the heading dashboard from the Panels menu
+    const appPanels = page.getByRole('button', { name: 'Panels', exact: true });
+    await expect(appPanels).toBeEnabled();
+    await appPanels.click();
+
+    const search = page.getByRole('searchbox', {
+      name: 'Find Table, Plot or Widget',
+      exact: true,
+    });
+    await search.fill('ui_heading_dashboard');
+    await page
+      .getByRole('button', { name: 'ui_heading_dashboard', exact: true })
+      .click();
+
+    // Reset mouse position to not cause unintended hover effects
+    await page.mouse.move(0, 0);
+
+    const heading = page.getByText('Reproducing DH-22995');
+
+    // The dashboard content renders and is visible within the viewport
+    await expect(heading).toBeVisible();
+    await expect(heading).toBeInViewport({ ratio: 1.0 });
+
+    // Disable "Close Panels on Disconnect" so the layout is persisted on refresh
+    await page
+      .getByRole('button', { name: 'More Actions...', exact: true })
+      .click();
+    await page
+      .getByRole('button', { name: 'Close Panels on Disconnect', exact: true })
+      .click();
+
+    // Wait for debounce option to save the setting before refreshing the page
+    await page.waitForTimeout(2000);
+
+    // Refresh the page - the dashboard should be restored from the persisted layout
+    await page.reload();
+    await waitForLoad(page);
+
+    // The heading is restored to the document and reported as visible...
+    await expect(heading).toBeVisible();
+
+    // ...but the bug causes it to render off-screen with an unnecessary scroll
+    // bar, so it is not actually within the viewport. This is the failing step.
+    await expect(heading).toBeInViewport({ ratio: 1.0 });
   });
 });


### PR DESCRIPTION
- When reloading a dashboard, we would bypass normalizing the children so they would re-render back in the location they were saved in. However, this fails if the user has not wrapped the content in a panel already, as we were not wrapping the children in a panel
- Wrap the bare children in a panel so they re-appear where the original panel was
- Created e2e and unit tests