### PR TITLE
fix: DH-23019: Render a widget error differently for DashboardWidgetHandler

### DIFF
--- a/plugins/ui/src/js/src/widget/DashboardWidgetHandler.test.tsx
+++ b/plugins/ui/src/js/src/widget/DashboardWidgetHandler.test.tsx
@@ -1,0 +1,93 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import DashboardWidgetHandler from './DashboardWidgetHandler';
+import { type WidgetHandlerProps } from './WidgetHandler';
+import { WIDGET_ELEMENT } from './WidgetUtils';
+import { makeWidgetDescriptor } from './WidgetTestUtils';
+
+const mockWidgetHandler = jest.fn((props: WidgetHandlerProps) => (
+  <div>WidgetHandler</div>
+));
+jest.mock(
+  './WidgetHandler',
+  () => (props: WidgetHandlerProps) => mockWidgetHandler(props)
+);
+
+jest.mock('../layout/ReactPanel', () => ({
+  __esModule: true,
+  default: function MockReactPanel(): React.ReactNode {
+    return <div className="mock-react-panel">ReactPanel</div>;
+  },
+}));
+
+beforeEach(() => {
+  mockWidgetHandler.mockClear();
+});
+
+function getRenderProps(): WidgetHandlerProps {
+  expect(mockWidgetHandler).toHaveBeenCalledTimes(1);
+  return mockWidgetHandler.mock.calls[0][0];
+}
+
+it('passes renderErrorDocument to WidgetHandler', () => {
+  render(
+    <DashboardWidgetHandler
+      id="test-id"
+      widgetDescriptor={makeWidgetDescriptor()}
+    />
+  );
+
+  const props = getRenderProps();
+  expect(props.renderErrorDocument).toBeInstanceOf(Function);
+});
+
+it('renders panels from renderErrorDocument for a rehydrated element widget', () => {
+  const widgetDescriptor = makeWidgetDescriptor({ type: WIDGET_ELEMENT });
+  render(
+    <DashboardWidgetHandler
+      id="test-id"
+      widgetDescriptor={widgetDescriptor}
+      initialData={{ panelIds: ['panel-1', 'panel-2'] }}
+    />
+  );
+
+  const props = getRenderProps();
+  const errorResult = props.renderErrorDocument?.(new Error('Test error'));
+
+  // The error document should match the empty document (the panels), not an error view
+  const emptyResult = props.renderEmptyDocument?.();
+  expect(errorResult).toStrictEqual(emptyResult);
+
+  // It should render one ReactPanel per panelId
+  const { container } = render(
+    <div>{React.Children.toArray(errorResult)}</div>
+  );
+  expect(container.querySelectorAll('.mock-react-panel')).toHaveLength(2);
+});
+
+it('renders a single panel from renderErrorDocument when there are no panelIds', () => {
+  const widgetDescriptor = makeWidgetDescriptor({ type: WIDGET_ELEMENT });
+  render(
+    <DashboardWidgetHandler id="test-id" widgetDescriptor={widgetDescriptor} />
+  );
+
+  const props = getRenderProps();
+  const errorResult = props.renderErrorDocument?.(new Error('Test error'));
+
+  const { container } = render(
+    <div>{React.Children.toArray(errorResult)}</div>
+  );
+  expect(container.querySelectorAll('.mock-react-panel')).toHaveLength(1);
+});
+
+it('renders nothing from renderErrorDocument for a non-element widget', () => {
+  const widgetDescriptor = makeWidgetDescriptor({ type: 'widget-type' });
+  render(
+    <DashboardWidgetHandler id="test-id" widgetDescriptor={widgetDescriptor} />
+  );
+
+  const props = getRenderProps();
+  const errorResult = props.renderErrorDocument?.(new Error('Test error'));
+
+  expect(errorResult).toBeNull();
+});

--- a/plugins/ui/src/js/src/widget/DashboardWidgetHandler.tsx
+++ b/plugins/ui/src/js/src/widget/DashboardWidgetHandler.tsx
@@ -69,7 +69,7 @@ function DashboardWidgetHandler({
 
   const renderErrorDocument = useCallback(
     // When opening a DashboardWidgetHandler, the panels may already be open, so we don't need to render anything other than in the empty case.
-    (error: NonNullable<unknown>) => renderEmptyDocument(),
+    () => renderEmptyDocument(),
     [renderEmptyDocument]
   );
 

--- a/plugins/ui/src/js/src/widget/DashboardWidgetHandler.tsx
+++ b/plugins/ui/src/js/src/widget/DashboardWidgetHandler.tsx
@@ -67,12 +67,19 @@ function DashboardWidgetHandler({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [widgetDescriptor]);
 
+  const renderErrorDocument = useCallback(
+    // When opening a DashboardWidgetHandler, the panels may already be open, so we don't need to render anything other than in the empty case.
+    (error: NonNullable<unknown>) => renderEmptyDocument(),
+    [renderEmptyDocument]
+  );
+
   return (
     <WidgetHandler
       id={id}
       onDataChange={handleDataChange}
       onClose={handleClose}
       renderEmptyDocument={renderEmptyDocument}
+      renderErrorDocument={renderErrorDocument}
       // eslint-disable-next-line react/jsx-props-no-spreading
       {...otherProps}
     />

--- a/plugins/ui/src/js/src/widget/WidgetHandler.test.tsx
+++ b/plugins/ui/src/js/src/widget/WidgetHandler.test.tsx
@@ -7,9 +7,11 @@ import { type PluginModuleMap, PluginsContext } from '@deephaven/plugin';
 import { type Operation } from 'fast-json-patch';
 import WidgetHandler, { type WidgetHandlerProps } from './WidgetHandler';
 import { type DocumentHandlerProps } from './DocumentHandler';
+import { type WidgetMessageEvent } from './WidgetTypes';
 import {
   makeWidget,
   makeWidgetDescriptor,
+  makeWidgetEventDocumentError,
   makeWidgetEventDocumentPatched,
   makeWidgetEventJsonRpcResponse,
   makeWidgetEventMethodEvent,
@@ -45,6 +47,8 @@ function makeWidgetHandler({
   widgetDescriptor: widget = makeWidgetDescriptor(),
   onClose = jest.fn(),
   initialData = undefined,
+  renderEmptyDocument = undefined,
+  renderErrorDocument = undefined,
   pluginsValue = new Map(),
 }: Partial<WidgetHandlerProps> & {
   pluginsValue?: React.ProviderProps<PluginModuleMap | null>['value'];
@@ -56,6 +60,8 @@ function makeWidgetHandler({
         widgetDescriptor={widget}
         onClose={onClose}
         initialData={initialData}
+        renderEmptyDocument={renderEmptyDocument}
+        renderErrorDocument={renderErrorDocument}
       />
     </PluginsContext.Provider>
   );
@@ -368,6 +374,146 @@ it('handles rendering widget error if widget is null (query disconnected)', asyn
   expect(screen.getByText('Test error')).toBeVisible();
 
   unmount();
+});
+
+describe('renderErrorDocument', () => {
+  beforeEach(() => {
+    // Render children so the error document is visible in the DOM
+    mockDocumentHandler.mockImplementation(props => (
+      <div className="test-document-handler">{props.children}</div>
+    ));
+  });
+
+  /**
+   * Renders a widget, responds to the initial setState so the jsonClient is
+   * ready, then returns the listener so the caller can dispatch further events.
+   */
+  async function setupReadyWidget(
+    props: Partial<WidgetHandlerProps> = {}
+  ): Promise<{
+    listener: (event: WidgetMessageEvent) => void;
+    unmount: () => void;
+  }> {
+    const mockAddEventListener = jest.fn((() =>
+      jest.fn()) as dh.Widget['addEventListener']);
+    mockWidgetWrapper = {
+      widget: makeWidget({
+        addEventListener: mockAddEventListener,
+        getDataAsString: jest.fn(() => ''),
+        sendMessage: jest.fn(),
+      }),
+      error: null,
+      api: jest.fn() as unknown as typeof dh,
+    };
+
+    const { unmount } = render(makeWidgetHandler(props));
+
+    const listener = mockAddEventListener.mock.calls[0][1];
+
+    // Respond to the initial setState so the jsonClient is ready
+    await act(async () => {
+      listener(makeWidgetEventJsonRpcResponse(0));
+    });
+
+    return { listener, unmount };
+  }
+
+  it('renders the default WidgetErrorView on a document error', async () => {
+    const { listener, unmount } = await setupReadyWidget();
+
+    await act(async () => {
+      listener(
+        makeWidgetEventDocumentError({
+          name: 'DocumentError',
+          message: 'Something went wrong',
+        })
+      );
+    });
+
+    // The default error document is the WidgetErrorView
+    expect(document.querySelector('.ui-widget-error-view')).toBeInTheDocument();
+    expect(screen.getByText('Something went wrong')).toBeVisible();
+
+    unmount();
+  });
+
+  it('uses a custom renderErrorDocument on a document error', async () => {
+    const renderErrorDocument = jest.fn(() => (
+      <div className="custom-error-document">Custom error</div>
+    ));
+
+    const { listener, unmount } = await setupReadyWidget({
+      renderErrorDocument,
+    });
+
+    await act(async () => {
+      listener(
+        makeWidgetEventDocumentError({
+          name: 'DocumentError',
+          message: 'Something went wrong',
+        })
+      );
+    });
+
+    // The custom renderer is used with the parsed error
+    expect(renderErrorDocument).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'DocumentError',
+        message: 'Something went wrong',
+      })
+    );
+    expect(screen.getByText('Custom error')).toBeVisible();
+    // The default WidgetErrorView should not be shown
+    expect(
+      document.querySelector('.ui-widget-error-view')
+    ).not.toBeInTheDocument();
+
+    unmount();
+  });
+
+  it('uses a custom renderErrorDocument when the widget is null (query disconnected)', async () => {
+    const renderErrorDocument = jest.fn(() => (
+      <div className="custom-error-document">Custom error</div>
+    ));
+
+    mockWidgetWrapper = {
+      widget: null,
+      error: new Error('Test error'),
+      api: null,
+    };
+
+    const { unmount } = render(makeWidgetHandler({ renderErrorDocument }));
+
+    expect(renderErrorDocument).toHaveBeenCalledWith(new Error('Test error'));
+    expect(screen.getByText('Custom error')).toBeVisible();
+    // The default WidgetErrorView should not be shown
+    expect(
+      document.querySelector('.ui-widget-error-view')
+    ).not.toBeInTheDocument();
+
+    unmount();
+  });
+
+  it('renders nothing when a custom renderErrorDocument returns null', async () => {
+    const renderErrorDocument = jest.fn(() => null);
+
+    mockWidgetWrapper = {
+      widget: null,
+      error: new Error('Test error'),
+      api: null,
+    };
+
+    const { container, unmount } = render(
+      makeWidgetHandler({ renderErrorDocument })
+    );
+
+    expect(renderErrorDocument).toHaveBeenCalledWith(new Error('Test error'));
+    // Nothing is rendered and the document handler is not used
+    expect(container).toBeEmptyDOMElement();
+    expect(mockDocumentHandler).not.toHaveBeenCalled();
+
+    unmount();
+  });
 });
 
 /**

--- a/plugins/ui/src/js/src/widget/WidgetHandler.tsx
+++ b/plugins/ui/src/js/src/widget/WidgetHandler.tsx
@@ -89,6 +89,11 @@ export interface WidgetHandlerProps {
 
   /** What to render when the document is empty and in a loading state */
   renderEmptyDocument?: () => JSX.Element | JSX.Element[] | null;
+
+  /** What to render when the document is empty and in an error state */
+  renderErrorDocument?: (
+    error: NonNullable<unknown>
+  ) => JSX.Element | JSX.Element[] | null;
 }
 
 function WidgetHandler({
@@ -98,6 +103,7 @@ function WidgetHandler({
   initialData: initialDataProp,
   id,
   renderEmptyDocument: renderEmptyDocumentProp,
+  renderErrorDocument: renderErrorDocumentProp,
 }: WidgetHandlerProps): JSX.Element | null {
   const { widget, error: widgetError } = useWidget(widgetDescriptor);
   const [isLoading, setIsLoading] = useState(true);
@@ -219,14 +225,25 @@ function WidgetHandler({
 
   const pluginsElementMap = usePluginsElementMap();
 
+  const renderErrorDocument = useCallback(
+    (docError: NonNullable<unknown>) => {
+      if (renderErrorDocumentProp != null) {
+        return renderErrorDocumentProp(docError);
+      }
+
+      // If there's an error and the document hasn't rendered yet (mostly applies to dashboards), explicitly show an error view
+      return <WidgetErrorView error={docError} />;
+    },
+    [renderErrorDocumentProp]
+  );
+
   const renderEmptyDocument = useCallback(
     /**
      * Renders an empty document. This is used when the widget is loading or has an error.
      */
     () => {
       if (error != null) {
-        // If there's an error and the document hasn't rendered yet (mostly applies to dashboards), explicitly show an error view
-        return <WidgetErrorView error={error} />;
+        return renderErrorDocument(error);
       }
       const result = renderEmptyDocumentProp?.();
       if (result != null) {
@@ -236,7 +253,7 @@ function WidgetHandler({
       // Dashboards should not have a default document. It breaks its render flow
       return null;
     },
-    [error, renderEmptyDocumentProp]
+    [error, renderEmptyDocumentProp, renderErrorDocument]
   );
 
   const [uriObjectMap] = useState<Map<string, UriExportedObject>>(new Map());

--- a/plugins/ui/src/js/src/widget/WidgetHandler.tsx
+++ b/plugins/ui/src/js/src/widget/WidgetHandler.tsx
@@ -269,7 +269,7 @@ function WidgetHandler({
      * @returns The rendered document
      */
     (doc: object | undefined): React.ReactNode => {
-      if (document === undefined || jsonClient == null) {
+      if (doc === undefined || jsonClient == null) {
         return renderEmptyDocument();
       }
 
@@ -373,7 +373,6 @@ function WidgetHandler({
       return hydratedDocument as React.ReactNode;
     },
     [
-      document,
       jsonClient,
       id,
       renderEmptyDocument,

--- a/plugins/ui/src/js/src/widget/WidgetTestUtils.ts
+++ b/plugins/ui/src/js/src/widget/WidgetTestUtils.ts
@@ -3,8 +3,10 @@ import { TestUtils } from '@deephaven/test-utils';
 import type { dh } from '@deephaven/jsapi-types';
 import { type Operation } from 'fast-json-patch';
 import {
+  METHOD_DOCUMENT_ERROR,
   METHOD_DOCUMENT_PATCHED,
   METHOD_EVENT,
+  type WidgetError,
   type WidgetMessageEvent,
 } from './WidgetTypes';
 
@@ -55,6 +57,23 @@ export function makeWidgetEventDocumentPatched(
   patch: Operation[] = []
 ): WidgetMessageEvent {
   return makeWidgetEvent(makeDocumentPatchedJsonRpcString(patch));
+}
+
+export function makeWidgetEventDocumentError(
+  error: Partial<WidgetError> = {}
+): WidgetMessageEvent {
+  const widgetError: WidgetError = {
+    name: 'Error',
+    message: 'Document error',
+    ...error,
+  };
+  return makeWidgetEvent(
+    JSON.stringify({
+      jsonrpc: '2.0',
+      method: METHOD_DOCUMENT_ERROR,
+      params: [JSON.stringify(widgetError)],
+    })
+  );
 }
 
 export function makeWidgetDescriptor({


### PR DESCRIPTION
- When it's a `DashboardWidgetHandler`, all opened ReactPanels should still be rendered, otherwise they'll register as panels closed and disappear.
- Tested against dev-gplus with the steps to reproduce from DH-23019. Also have a branch in Enterprise that adds e2e tests for this.
