### PR TITLE
fix: DH-21776: Respect caseSensitive filterParams in AG Grid filters

### DIFF
--- a/plugins/ag-grid/README.md
+++ b/plugins/ag-grid/README.md
@@ -7,6 +7,8 @@ Display Deephaven tables using [AG Grid](https://www.ag-grid.com/).
 The `src` directory contains the Python and JavaScript code for the plugin.  
 Within the `src` directory, the `deephaven/ag_grid` directory contains the Python code, and the `js` directory contains the JavaScript code.
 
+> **Note:** The Python package in this plugin is only used for development purposes and is not published. Only the JavaScript package is published.
+
 The Python files have the following structure:  
 [`AgGridMessageStream.py`](./src/deephaven/ag_grid/AgGridMessageStream.py) defines a simple Python class that can send messages to the client. It just sends the Deephaven table along.
 [`AgGridType.py`](./src/deephaven/ag_grid/AgGridType.py) defines the Python type for the plugin (which is used for registration) and a simple message stream. These can be modified to handle different objects or messages. An initial message is sent from the Python side to the client, then additional messages can be sent back and forth.  
@@ -44,3 +46,14 @@ ag_result = AgGrid(_result)
 ```
 
 ![AG Grid example](ag-grid-example.png)
+
+### Column Definitions
+
+Pass `column_defs` to override properties on the [AG Grid column definitions](https://www.ag-grid.com/javascript-data-grid/column-definitions/) generated from the table schema. It maps a column name to the properties to merge on top of the generated definition. For example, to make filtering on the `Strings` column [case sensitive](https://www.ag-grid.com/javascript-data-grid/filter-set-filter-list/#enabling-value-case-sensitivity):
+
+```python
+ag_result = AgGrid(
+    _result,
+    column_defs={"Strings": {"filterParams": {"caseSensitive": True}}},
+)
+```

--- a/plugins/ag-grid/src/deephaven/ag_grid/AgGrid.py
+++ b/plugins/ag-grid/src/deephaven/ag_grid/AgGrid.py
@@ -1,3 +1,7 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
 from deephaven.table import Table
 
 
@@ -7,9 +11,24 @@ class AgGrid:
     """
 
     _table: Table
+    _column_defs: Dict[str, Dict[str, Any]]
 
-    def __init__(self, table: Table):
+    def __init__(
+        self, table: Table, column_defs: Optional[Dict[str, Dict[str, Any]]] = None
+    ):
+        """
+        Create a new AgGrid.
+
+        Args:
+            table: The table to display in the grid
+            column_defs: Optional map from column name to a partial AG Grid column definition.
+                The provided properties are merged on top of the column definitions generated
+                from the table schema on the client.
+                For example, to make the filter for a column case sensitive:
+                ``column_defs={"Column_X": {"filterParams": {"caseSensitive": True}}}``
+        """
         self._table = table
+        self._column_defs = column_defs if column_defs is not None else {}
 
     @property
     def table(self) -> Table:
@@ -20,3 +39,13 @@ class AgGrid:
             The table for the AgGrid
         """
         return self._table
+
+    @property
+    def column_defs(self) -> Dict[str, Dict[str, Any]]:
+        """
+        Returns the column definition overrides for the AgGrid
+
+        Returns:
+            Map from column name to a partial AG Grid column definition
+        """
+        return self._column_defs

--- a/plugins/ag-grid/src/deephaven/ag_grid/AgGridMessageStream.py
+++ b/plugins/ag-grid/src/deephaven/ag_grid/AgGridMessageStream.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import logging
 from typing import Any
 from deephaven.plugin.object_type import MessageStream
@@ -24,11 +25,13 @@ class AgGridMessageStream(MessageStream):
 
     def start(self) -> None:
         """
-        Start the message stream. All this does right now is send the table instance that AgGrid is wrapping to the client.
-        If we added some options on AgGrid that we'd want to pass along to the client as well, we could serialize those as JSON options.
+        Start the message stream. Sends the options for the grid as a JSON payload, and the table
+        instance that AgGrid is wrapping as a reference.
         """
-        # Just send the table reference to the client
-        self._connection.on_data("".encode(), [self._grid.table])
+        options: dict[str, Any] = {}
+        if self._grid.column_defs:
+            options["columnDefs"] = self._grid.column_defs
+        self._connection.on_data(json.dumps(options).encode(), [self._grid.table])
 
     def on_close(self) -> None:
         pass

--- a/plugins/ag-grid/src/js/src/components/AgGridView.tsx
+++ b/plugins/ag-grid/src/js/src/components/AgGridView.tsx
@@ -26,11 +26,14 @@ import {
   type TreeNode,
 } from '../utils';
 import { DeephavenViewportDatasource } from '../datasources';
-import { type AgGridTableType } from '../types';
+import { type AgGridTableType, type AgGridWidgetOptions } from '../types';
 
 export type AgGridViewProps = {
   /** Table to be displayed */
   table: AgGridTableType;
+
+  /** Options provided by the server, such as column definition overrides */
+  options?: AgGridWidgetOptions;
 
   /** Settings controlling the formatting of the data */
   settings?: Settings;
@@ -47,6 +50,7 @@ const log = Log.module('@deephaven/js-plugin-ag-grid/AgGridView');
  */
 export function AgGridView({
   table,
+  options,
   settings,
   agGridProps,
 }: AgGridViewProps): JSX.Element | null {
@@ -61,7 +65,10 @@ export function AgGridView({
   log.debug('AgGridView rendering', table);
 
   /** Map from Deephaven Table Columns to AG Grid ColDefs */
-  const colDefs: ColDef[] = useMemo(() => getColumnDefs(table), [table]);
+  const colDefs: ColDef[] = useMemo(
+    () => getColumnDefs(table, options?.columnDefs),
+    [table, options]
+  );
 
   /** Create the ViewportDatasource to pass in to AG Grid based on the Deephaven Table */
   const datasource = useMemo(

--- a/plugins/ag-grid/src/js/src/components/AgGridWidget.tsx
+++ b/plugins/ag-grid/src/js/src/components/AgGridWidget.tsx
@@ -43,11 +43,16 @@ export function AgGridWidget(
     [theme, themeParams]
   );
 
-  const table = useWidgetFetch(dh, fetch);
+  const widgetResult = useWidgetFetch(dh, fetch);
 
-  return table != null ? (
+  return widgetResult != null ? (
     <div className="ui-table-container widget-container">
-      <AgGridView table={table} settings={settings} agGridProps={agGridProps} />
+      <AgGridView
+        table={widgetResult.table}
+        options={widgetResult.options}
+        settings={settings}
+        agGridProps={agGridProps}
+      />
     </div>
   ) : (
     <LoadingOverlay />

--- a/plugins/ag-grid/src/js/src/datasources/DeephavenViewportDatasource.test.ts
+++ b/plugins/ag-grid/src/js/src/datasources/DeephavenViewportDatasource.test.ts
@@ -12,7 +12,7 @@ jest.mock('../utils', () => {
     ...actual,
     AgGridFilterUtils: {
       ...actual.AgGridFilterUtils,
-      parseFilterModel: jest.fn().mockReturnValue([]),
+      getFilterFromGridApi: jest.fn().mockReturnValue([]),
     },
   };
 });

--- a/plugins/ag-grid/src/js/src/datasources/DeephavenViewportDatasource.ts
+++ b/plugins/ag-grid/src/js/src/datasources/DeephavenViewportDatasource.ts
@@ -365,11 +365,7 @@ export class DeephavenViewportDatasource implements IViewportDatasource {
     }
     log.debug('Applying filter', filterModel);
     this.table.applyFilter(
-      AgGridFilterUtils.parseFilterModel(
-        this.dh,
-        this.table,
-        this.gridApi.getFilterModel()
-      )
+      AgGridFilterUtils.getFilterFromGridApi(this.dh, this.table, this.gridApi)
     );
   }
 

--- a/plugins/ag-grid/src/js/src/hooks/useWidgetFetch.ts
+++ b/plugins/ag-grid/src/js/src/hooks/useWidgetFetch.ts
@@ -3,7 +3,7 @@ import type { dh as CorePlusDhType } from '@deephaven-enterprise/jsapi-coreplus-
 import Log from '@deephaven/log';
 import { useEffect, useState } from 'react';
 import { isCorePlusDhType } from '../utils/CorePlusUtils';
-import { type AgGridTableType } from '../types';
+import { type AgGridTableType, type AgGridWidgetOptions } from '../types';
 
 const log = Log.module('@deephaven/js-plugin-ag-grid/hooks/useWidgetFetch');
 
@@ -19,11 +19,25 @@ function isWidget(obj: unknown): obj is DhType.Widget {
 
 const PIVOT_TABLE_WIDGET_TYPE = 'PivotTable';
 
+/** Parse the options JSON sent from the server. Older servers send an empty payload. */
+function parseOptions(widget: DhType.Widget): AgGridWidgetOptions {
+  const data = widget.getDataAsString();
+  if (data === '') {
+    return {};
+  }
+  return JSON.parse(data);
+}
+
+export type WidgetFetchResult = {
+  table: AgGridTableType;
+  options: AgGridWidgetOptions;
+};
+
 export function useWidgetFetch(
   dh: typeof DhType | typeof CorePlusDhType,
   fetch: () => Promise<DhType.Widget>
-): AgGridTableType | undefined {
-  const [table, setTable] = useState<AgGridTableType>();
+): WidgetFetchResult | undefined {
+  const [result, setResult] = useState<WidgetFetchResult>();
 
   /** First we load the widget object. This is the object that is sent from the server in AgGridMessageStream. */
   useEffect(() => {
@@ -34,6 +48,7 @@ export function useWidgetFetch(
       log.debug('Fetched widget of type', widget.type);
       switch (widget.type) {
         case 'deephaven.ag_grid.AgGrid': {
+          const options = parseOptions(widget);
           let newTable = await widget.exportedObjects[0].fetch();
           if (isWidget(newTable)) {
             if (newTable.type !== PIVOT_TABLE_WIDGET_TYPE) {
@@ -49,8 +64,8 @@ export function useWidgetFetch(
             newTable = new dh.coreplus.pivot.PivotTable(newTable);
           }
           if (!cancelled) {
-            log.info('Loaded table', newTable);
-            setTable(newTable);
+            log.info('Loaded table', newTable, 'with options', options);
+            setResult({ table: newTable, options });
           }
           break;
         }
@@ -66,7 +81,7 @@ export function useWidgetFetch(
     };
   }, [dh, fetch]);
 
-  return table;
+  return result;
 }
 
 export default useWidgetFetch;

--- a/plugins/ag-grid/src/js/src/types/AgGridWidgetOptions.ts
+++ b/plugins/ag-grid/src/js/src/types/AgGridWidgetOptions.ts
@@ -1,0 +1,14 @@
+import type { ColDef } from 'ag-grid-community';
+
+/**
+ * Options sent from the server in the AgGrid widget payload.
+ */
+export type AgGridWidgetOptions = {
+  /**
+   * Map from column name to a partial column definition. These properties are merged on top of the
+   * column definitions generated from the table schema.
+   */
+  columnDefs?: Record<string, Partial<ColDef>>;
+};
+
+export default AgGridWidgetOptions;

--- a/plugins/ag-grid/src/js/src/types/index.ts
+++ b/plugins/ag-grid/src/js/src/types/index.ts
@@ -1,1 +1,2 @@
 export * from './AgGridTableType';
+export * from './AgGridWidgetOptions';

--- a/plugins/ag-grid/src/js/src/utils/AgGridFilterUtils.test.ts
+++ b/plugins/ag-grid/src/js/src/utils/AgGridFilterUtils.test.ts
@@ -1,6 +1,7 @@
 import { type dh as DhType } from '@deephaven/jsapi-types';
 import {
   type FilterModel,
+  type GridApi,
   type TextFilterModel,
   type NumberFilterModel,
   type DateFilterModel,
@@ -29,8 +30,25 @@ describe('AgGridFilterUtils', () => {
     findColumn: jest.fn().mockReturnValue(mockColumn),
   };
 
+  const mockGridApi = {
+    getColumnDef: jest.fn().mockReturnValue(null),
+    getFilterModel: jest.fn().mockReturnValue({}),
+  };
+
+  /** Set the filter model returned by the mock GridApi and parse it */
+  function parseModel(model: FilterModel | null): DhType.FilterCondition[] {
+    mockGridApi.getFilterModel.mockReturnValue(model);
+    return AgGridFilterUtils.getFilterFromGridApi(
+      mockDh as unknown as typeof DhType,
+      mockTable as unknown as DhType.Table,
+      mockGridApi as unknown as GridApi
+    );
+  }
+
   beforeEach(() => {
     jest.clearAllMocks();
+    mockTable.findColumn.mockReturnValue(mockColumn);
+    mockGridApi.getColumnDef.mockReturnValue(null);
   });
 
   describe('areFiltersEqual', () => {
@@ -62,31 +80,8 @@ describe('AgGridFilterUtils', () => {
     });
   });
 
-  describe('parseFilterModel', () => {
-    it('should return empty array for null filter model', () => {
-      const result = AgGridFilterUtils.parseFilterModel(
-        mockDh as unknown as typeof DhType,
-        mockTable as unknown as DhType.Table,
-        null
-      );
-      expect(result).toEqual([]);
-    });
-
-    it('should throw error for unsupported filter model', () => {
-      const model = {
-        col1: { filterType: 'unsupported' },
-      } as unknown as FilterModel;
-
-      expect(() =>
-        AgGridFilterUtils.parseFilterModel(
-          mockDh as unknown as typeof DhType,
-          mockTable as unknown as DhType.Table,
-          model
-        )
-      ).toThrow();
-    });
-
-    it('should parse text filter model', () => {
+  describe('parseFilterModel (deprecated)', () => {
+    it('should keep filtering text case-sensitively with the original signature', () => {
       const column = 'col1';
       const filterValue = 'test';
       const textModel: FilterModel = {
@@ -112,6 +107,52 @@ describe('AgGridFilterUtils', () => {
       expect(mockEq).toHaveBeenCalledWith(filterValue);
     });
 
+    it('should return empty array for null filter model', () => {
+      const result = AgGridFilterUtils.parseFilterModel(
+        mockDh as unknown as typeof DhType,
+        mockTable as unknown as DhType.Table,
+        null
+      );
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('getFilterFromGridApi', () => {
+    it('should return empty array for null filter model', () => {
+      const result = parseModel(null);
+      expect(result).toEqual([]);
+    });
+
+    it('should throw error for unsupported filter model', () => {
+      const model = {
+        col1: { filterType: 'unsupported' },
+      } as unknown as FilterModel;
+
+      expect(() => parseModel(model)).toThrow();
+    });
+
+    it('should parse text filter model case-insensitively by default', () => {
+      const column = 'col1';
+      const filterValue = 'test';
+      const textModel: FilterModel = {
+        [column]: {
+          filterType: 'text',
+          type: 'equals',
+          filter: filterValue,
+        } as TextFilterModel,
+      };
+
+      const mockEqIgnoreCase = jest.fn();
+      mockColumn.filter.mockReturnValue({
+        eqIgnoreCase: mockEqIgnoreCase,
+      });
+      mockDh.FilterValue.ofString.mockReturnValueOnce(filterValue);
+
+      parseModel(textModel);
+      expect(mockTable.findColumn).toHaveBeenCalledWith(column);
+      expect(mockEqIgnoreCase).toHaveBeenCalledWith(filterValue);
+    });
+
     it('should parse number filter model', () => {
       const column = 'col1';
       const filterValue = 123;
@@ -129,11 +170,7 @@ describe('AgGridFilterUtils', () => {
       });
       mockDh.FilterValue.ofNumber.mockReturnValueOnce(filterValue);
 
-      AgGridFilterUtils.parseFilterModel(
-        mockDh as unknown as typeof DhType,
-        mockTable as unknown as DhType.Table,
-        model
-      );
+      parseModel(model);
       expect(mockTable.findColumn).toHaveBeenCalledWith(column);
       expect(mockEq).toHaveBeenCalledWith(filterValue);
     });
@@ -158,11 +195,7 @@ describe('AgGridFilterUtils', () => {
       const mockFilterValue = 12345;
       mockDh.FilterValue.ofNumber.mockReturnValueOnce(mockFilterValue);
 
-      AgGridFilterUtils.parseFilterModel(
-        mockDh as unknown as typeof DhType,
-        mockTable as unknown as DhType.Table,
-        model
-      );
+      parseModel(model);
       expect(mockTable.findColumn).toHaveBeenCalledWith(column);
       expect(mockEq).toHaveBeenCalledWith(mockFilterValue);
     });
@@ -195,13 +228,13 @@ describe('AgGridFilterUtils', () => {
 
       // First condition
       mockColumn.filter.mockReturnValueOnce({
-        eq: mockEq1,
+        eqIgnoreCase: mockEq1,
       });
       mockDh.FilterValue.ofString.mockReturnValueOnce(filterValue1);
 
       // Second condition
       mockColumn.filter.mockReturnValueOnce({
-        eq: mockEq2,
+        eqIgnoreCase: mockEq2,
       });
       mockDh.FilterValue.ofString.mockReturnValueOnce(filterValue2);
 
@@ -210,16 +243,161 @@ describe('AgGridFilterUtils', () => {
         and: mockAnd,
       });
 
-      AgGridFilterUtils.parseFilterModel(
-        mockDh as unknown as typeof DhType,
-        mockTable as unknown as DhType.Table,
-        model
-      );
+      parseModel(model);
 
       expect(mockTable.findColumn).toHaveBeenCalledWith(column);
       expect(mockEq1).toHaveBeenCalledWith(filterValue1);
       expect(mockEq2).toHaveBeenCalledWith(filterValue2);
       expect(mockAnd).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('getFilterFromGridApi text filter case sensitivity', () => {
+    const column = 'col1';
+    const filterText = 'Test';
+
+    function makeTextModel(type: string): FilterModel {
+      return {
+        [column]: {
+          filterType: 'text',
+          type,
+          filter: filterText,
+        } as TextFilterModel,
+      };
+    }
+
+    function parse(model: FilterModel): void {
+      parseModel(model);
+    }
+
+    function setCaseSensitive(caseSensitive: boolean): void {
+      mockGridApi.getColumnDef.mockReturnValue({
+        filterParams: { caseSensitive },
+      });
+    }
+
+    it.each([
+      ['equals', 'eq', 'eqIgnoreCase'],
+      ['notEqual', 'notEq', 'notEqIgnoreCase'],
+      ['contains', 'contains', 'containsIgnoreCase'],
+    ])(
+      '%s uses %s when case-sensitive and %s otherwise',
+      (type, sensitiveMethod, insensitiveMethod) => {
+        const mockSensitive = jest.fn();
+        const mockInsensitive = jest.fn();
+        mockColumn.filter.mockReturnValue({
+          [sensitiveMethod]: mockSensitive,
+          [insensitiveMethod]: mockInsensitive,
+        });
+        mockDh.FilterValue.ofString.mockReturnValue(filterText);
+
+        setCaseSensitive(true);
+        parse(makeTextModel(type));
+        expect(mockSensitive).toHaveBeenCalledWith(filterText);
+        expect(mockInsensitive).not.toHaveBeenCalled();
+
+        mockSensitive.mockClear();
+        setCaseSensitive(false);
+        parse(makeTextModel(type));
+        expect(mockInsensitive).toHaveBeenCalledWith(filterText);
+        expect(mockSensitive).not.toHaveBeenCalled();
+      }
+    );
+
+    it('notContains uses contains when case-sensitive and containsIgnoreCase otherwise', () => {
+      const mockNot = jest.fn();
+      const mockOr = jest.fn();
+      const mockContains = jest.fn().mockReturnValue({ not: mockNot });
+      const mockContainsIgnoreCase = jest
+        .fn()
+        .mockReturnValue({ not: mockNot });
+      mockColumn.filter.mockReturnValue({
+        isNull: jest.fn().mockReturnValue({ or: mockOr }),
+        contains: mockContains,
+        containsIgnoreCase: mockContainsIgnoreCase,
+      });
+      mockDh.FilterValue.ofString.mockReturnValue(filterText);
+
+      setCaseSensitive(true);
+      parse(makeTextModel('notContains'));
+      expect(mockContains).toHaveBeenCalledWith(filterText);
+      expect(mockContainsIgnoreCase).not.toHaveBeenCalled();
+
+      mockContains.mockClear();
+      setCaseSensitive(false);
+      parse(makeTextModel('notContains'));
+      expect(mockContainsIgnoreCase).toHaveBeenCalledWith(filterText);
+      expect(mockContains).not.toHaveBeenCalled();
+    });
+
+    it.each([
+      ['startsWith', `(?s)^\\Q${filterText}\\E.*`],
+      ['endsWith', `(?s).*\\Q${filterText}\\E$`],
+    ])(
+      '%s uses invoke when case-sensitive and matchesIgnoreCase otherwise',
+      (type, expectedPattern) => {
+        const mockAnd = jest.fn();
+        const mockInvoke = jest.fn();
+        const mockMatchesIgnoreCase = jest.fn();
+        mockColumn.filter.mockReturnValue({
+          isNull: jest.fn().mockReturnValue({
+            not: jest.fn().mockReturnValue({ and: mockAnd }),
+          }),
+          invoke: mockInvoke,
+          matchesIgnoreCase: mockMatchesIgnoreCase,
+        });
+        mockDh.FilterValue.ofString.mockImplementation(value => value);
+
+        setCaseSensitive(true);
+        parse(makeTextModel(type));
+        expect(mockInvoke).toHaveBeenCalledWith(type, filterText);
+        expect(mockMatchesIgnoreCase).not.toHaveBeenCalled();
+
+        mockInvoke.mockClear();
+        setCaseSensitive(false);
+        parse(makeTextModel(type));
+        expect(mockMatchesIgnoreCase).toHaveBeenCalledWith(expectedPattern);
+        expect(mockInvoke).not.toHaveBeenCalled();
+      }
+    );
+
+    it('defaults to case-insensitive when column def has no filterParams', () => {
+      const mockEq = jest.fn();
+      const mockEqIgnoreCase = jest.fn();
+      mockColumn.filter.mockReturnValue({
+        eq: mockEq,
+        eqIgnoreCase: mockEqIgnoreCase,
+      });
+      mockDh.FilterValue.ofString.mockReturnValue(filterText);
+      mockGridApi.getColumnDef.mockReturnValue({});
+
+      parse(makeTextModel('equals'));
+      expect(mockEqIgnoreCase).toHaveBeenCalledWith(filterText);
+      expect(mockEq).not.toHaveBeenCalled();
+    });
+
+    it('applies case sensitivity to combined filter conditions', () => {
+      const model: FilterModel = {
+        [column]: {
+          conditions: [
+            { filterType: 'text', type: 'equals', filter: 'a' },
+            { filterType: 'text', type: 'equals', filter: 'b' },
+          ],
+          operator: 'OR',
+        } as ICombinedSimpleModel<TextFilterModel>,
+      };
+
+      const mockOr = jest.fn();
+      const mockEq = jest.fn().mockReturnValue({ or: mockOr });
+      mockColumn.filter.mockReturnValue({ eq: mockEq });
+      mockDh.FilterValue.ofString.mockImplementation(value => value);
+
+      setCaseSensitive(true);
+      parse(model);
+      expect(mockEq).toHaveBeenCalledTimes(2);
+      expect(mockEq).toHaveBeenCalledWith('a');
+      expect(mockEq).toHaveBeenCalledWith('b');
+      expect(mockOr).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/plugins/ag-grid/src/js/src/utils/AgGridFilterUtils.ts
+++ b/plugins/ag-grid/src/js/src/utils/AgGridFilterUtils.ts
@@ -3,6 +3,7 @@ import {
   type AdvancedFilterModel,
   type DateFilterModel,
   type FilterModel,
+  type GridApi,
   type ICombinedSimpleModel,
   type ISimpleFilterModel,
   type NumberFilterModel,
@@ -39,11 +40,54 @@ export class AgGridFilterUtils {
     return b.every(f => filters.has(f.toString()));
   }
 
-  // Not handling AdvancedFilterModel yet
+  /**
+   * Parses the given filter model into Deephaven filter conditions.
+   * @param dh Deephaven API instance
+   * @param table Table to filter
+   * @param filterModel Filter model to parse
+   * @returns The equivalent Deephaven filter conditions
+   * @deprecated Use `getFilterFromGridApi` instead, which respects column
+   * filter params such as `caseSensitive`. This method always filters
+   * case-sensitively.
+   */
   static parseFilterModel(
     dh: typeof DhType,
     table: DhType.Table | DhType.TreeTable,
     filterModel: FilterModel | AdvancedFilterModel | null
+  ): DhType.FilterCondition[] {
+    // Preserves the original behavior of always filtering case-sensitively
+    return this.parseFilterModelInternal(dh, table, filterModel, () => true);
+  }
+
+  /**
+   * Gets the Deephaven filter conditions for the current filter model set on
+   * the given GridApi, respecting column filter params such as
+   * `caseSensitive`. AG Grid text filters are case-insensitive unless the
+   * column's filterParams specify otherwise.
+   * @param dh Deephaven API instance
+   * @param table Table to filter
+   * @param gridApi GridApi to get the filter model and column definitions from
+   * @returns The equivalent Deephaven filter conditions
+   */
+  static getFilterFromGridApi(
+    dh: typeof DhType,
+    table: DhType.Table | DhType.TreeTable,
+    gridApi: GridApi
+  ): DhType.FilterCondition[] {
+    // Not handling AdvancedFilterModel (gridApi.getAdvancedFilterModel()) yet
+    return this.parseFilterModelInternal(
+      dh,
+      table,
+      gridApi.getFilterModel(),
+      colId => gridApi.getColumnDef(colId)?.filterParams?.caseSensitive === true
+    );
+  }
+
+  private static parseFilterModelInternal(
+    dh: typeof DhType,
+    table: DhType.Table | DhType.TreeTable,
+    filterModel: FilterModel | AdvancedFilterModel | null,
+    isCaseSensitive: (colId: string) => boolean
   ): DhType.FilterCondition[] {
     if (filterModel == null) {
       return [];
@@ -51,12 +95,13 @@ export class AgGridFilterUtils {
 
     return Object.entries(filterModel).map(([colId, model]) => {
       const column = table.findColumn(colId);
+      const caseSensitive = isCaseSensitive(colId);
 
       if (this.isCombinedSimpleModel(model, this.isSimpleFilterModel)) {
         return model.conditions
           .map(m => {
             if (this.isSupportedSimpleFilterModel(m)) {
-              return this.parseSimpleFilter(dh, column, m);
+              return this.parseSimpleFilter(dh, column, m, caseSensitive);
             }
             throw new Error(`Filter model ${m} is not supported`);
           })
@@ -77,7 +122,7 @@ export class AgGridFilterUtils {
         this.isSimpleFilterModel(model) &&
         this.isSupportedSimpleFilterModel(model)
       ) {
-        return this.parseSimpleFilter(dh, column, model);
+        return this.parseSimpleFilter(dh, column, model, caseSensitive);
       }
       throw new Error(`Filter model ${model} is not supported`);
     });
@@ -127,11 +172,12 @@ export class AgGridFilterUtils {
   private static parseSimpleFilter(
     dh: typeof DhType,
     column: DhType.Column,
-    model: SupportedSimpleFilterModel
+    model: SupportedSimpleFilterModel,
+    caseSensitive = false
   ): DhType.FilterCondition {
     switch (model.filterType) {
       case 'text':
-        return this.parseTextFilter(dh, column, model);
+        return this.parseTextFilter(dh, column, model, caseSensitive);
       case 'number':
         return this.parseNumberFilter(dh, column, model);
       case 'date':
@@ -144,34 +190,63 @@ export class AgGridFilterUtils {
   private static parseTextFilter(
     dh: typeof DhType,
     column: DhType.Column,
-    model: TextFilterModel
+    model: TextFilterModel,
+    caseSensitive = false
   ): DhType.FilterCondition {
-    const filterValue = dh.FilterValue.ofString(model.filter ?? '');
+    const filterText = model.filter ?? '';
+    const filterValue = dh.FilterValue.ofString(filterText);
 
     switch (model.type as ExtendedTextFilterModelType) {
       case 'equals':
-        return column.filter().eq(filterValue);
+        return caseSensitive
+          ? column.filter().eq(filterValue)
+          : column.filter().eqIgnoreCase(filterValue);
       case 'notEqual':
-        return column.filter().notEq(filterValue);
+        return caseSensitive
+          ? column.filter().notEq(filterValue)
+          : column.filter().notEqIgnoreCase(filterValue);
       case 'contains':
-        return column.filter().contains(filterValue);
+        return caseSensitive
+          ? column.filter().contains(filterValue)
+          : column.filter().containsIgnoreCase(filterValue);
       case 'notContains':
         return column
           .filter()
           .isNull()
-          .or(column.filter().contains(filterValue).not());
+          .or(
+            (caseSensitive
+              ? column.filter().contains(filterValue)
+              : column.filter().containsIgnoreCase(filterValue)
+            ).not()
+          );
       case 'startsWith':
         return column
           .filter()
           .isNull()
           .not()
-          .and(column.filter().invoke('startsWith', filterValue));
+          .and(
+            caseSensitive
+              ? column.filter().invoke('startsWith', filterValue)
+              : column
+                  .filter()
+                  .matchesIgnoreCase(
+                    dh.FilterValue.ofString(`(?s)^\\Q${filterText}\\E.*`)
+                  )
+          );
       case 'endsWith':
         return column
           .filter()
           .isNull()
           .not()
-          .and(column.filter().invoke('endsWith', filterValue));
+          .and(
+            caseSensitive
+              ? column.filter().invoke('endsWith', filterValue)
+              : column
+                  .filter()
+                  .matchesIgnoreCase(
+                    dh.FilterValue.ofString(`(?s).*\\Q${filterText}\\E$`)
+                  )
+          );
       // filterValue becomes ofString('') for blank/notBlank filters
       case 'blank':
         return column.filter().isNull().or(column.filter().eq(filterValue));

--- a/plugins/ag-grid/src/js/src/utils/AgGridTableUtils.test.ts
+++ b/plugins/ag-grid/src/js/src/utils/AgGridTableUtils.test.ts
@@ -300,4 +300,64 @@ describe('getColumnDefs', () => {
       expect(columnDefs[2].headerName).toBe('Foo_Bar');
     });
   });
+
+  describe('column def overrides', () => {
+    it('merges overrides by field name', () => {
+      const table = createMockTable({
+        columns: [
+          createMockColumn({ name: 'col1' }),
+          createMockColumn({ name: 'col2' }),
+        ],
+      });
+      const columnDefs = getColumnDefs(table, {
+        col1: { filterParams: { caseSensitive: true } },
+      });
+      expect(columnDefs[0].field).toBe('col1');
+      expect(columnDefs[0].headerName).toBe('col1');
+      expect(columnDefs[0].filterParams).toEqual({ caseSensitive: true });
+      expect(columnDefs[1].filterParams).toBeUndefined();
+    });
+
+    it('ignores overrides for unknown fields', () => {
+      const table = createMockTable({
+        columns: [createMockColumn({ name: 'col1' })],
+      });
+      const columnDefs = getColumnDefs(table, {
+        unknownCol: { filterParams: { caseSensitive: true } },
+      });
+      expect(columnDefs).toHaveLength(1);
+      expect(columnDefs[0].filterParams).toBeUndefined();
+    });
+
+    it('merges overrides for tree table columns', () => {
+      const treeTable = createMockTreeTable({
+        columns: [
+          createMockColumn({ name: 'col1' }),
+          createMockColumn({ name: 'col2' }),
+        ],
+        groupedColumns: [createMockColumn({ name: 'col1' })],
+      });
+      const columnDefs = getColumnDefs(treeTable, {
+        col1: { headerName: 'Custom' },
+      });
+      expect(columnDefs[0].headerName).toBe('Custom');
+      expect(columnDefs[0].rowGroup).toBe(true);
+    });
+
+    it('merges overrides for pivot table columns', () => {
+      const pivotTable = createMockPivotTable({
+        rowSources: [createMockPivotSource({ name: 'row1' })],
+        columnSources: [createMockPivotSource({ name: 'col1' })],
+        valueSources: [createMockPivotSource({ name: 'value1' })],
+      });
+      const columnDefs = getColumnDefs(pivotTable, {
+        row1: { headerName: 'Row One' },
+        value1: { headerName: 'Value One' },
+      });
+      expect(columnDefs[0].headerName).toBe('Row One');
+      expect(columnDefs[0].rowGroup).toBe(true);
+      expect(columnDefs[1].headerName).toBeUndefined();
+      expect(columnDefs[2].headerName).toBe('Value One');
+    });
+  });
 });

--- a/plugins/ag-grid/src/js/src/utils/AgGridTableUtils.ts
+++ b/plugins/ag-grid/src/js/src/utils/AgGridTableUtils.ts
@@ -157,7 +157,14 @@ export function getColumnDefs(
   const applyOverride = (colDef: ColDef): ColDef => {
     const override =
       colDef.field != null ? columnDefOverrides[colDef.field] : undefined;
-    return override != null ? { ...colDef, ...override } : colDef;
+    return override != null
+      ? {
+          ...colDef,
+          ...override,
+          field: colDef.field,
+          colId: colDef.colId,
+        }
+      : colDef;
   };
 
   if (isTable(table) || isTreeTable(table)) {

--- a/plugins/ag-grid/src/js/src/utils/AgGridTableUtils.ts
+++ b/plugins/ag-grid/src/js/src/utils/AgGridTableUtils.ts
@@ -2,7 +2,7 @@ import type { dh as DhType } from '@deephaven/jsapi-types';
 import type { ColDef, SideBarDef } from 'ag-grid-community';
 import type { dh as CorePlusDhType } from '@deephaven-enterprise/jsapi-coreplus-types';
 import { TableUtils } from '@deephaven/jsapi-utils';
-import { type AgGridTableType } from '../types';
+import { type AgGridTableType, type AgGridWidgetOptions } from '../types';
 import AgGridFormatter from './AgGridFormatter';
 
 export type SingleRowData = { [columnKey: string]: unknown };
@@ -142,7 +142,24 @@ export function convertColumnToColDef(
   }
 }
 
-export function getColumnDefs(table: AgGridTableType): ColDef[] {
+/**
+ * Get the column definitions for the given table, applying any server provided overrides.
+ *
+ * @param table Table to get the column definitions for
+ * @param columnDefOverrides Map from column name to a partial column definition to merge on top of
+ *                           the generated column definition
+ * @returns The column definitions to pass to AG Grid
+ */
+export function getColumnDefs(
+  table: AgGridTableType,
+  columnDefOverrides: AgGridWidgetOptions['columnDefs'] = {}
+): ColDef[] {
+  const applyOverride = (colDef: ColDef): ColDef => {
+    const override =
+      colDef.field != null ? columnDefOverrides[colDef.field] : undefined;
+    return override != null ? { ...colDef, ...override } : colDef;
+  };
+
   if (isTable(table) || isTreeTable(table)) {
     const groupedColSet = new Set(
       (isTreeTable(table) ? table.groupedColumns : []).map(c => c.name)
@@ -161,7 +178,7 @@ export function getColumnDefs(table: AgGridTableType): ColDef[] {
               enableRowGroup: isRowGroupable(c.type),
               enableValue: true,
             };
-        return convertColumnToColDef(c, templateColDef);
+        return applyOverride(convertColumnToColDef(c, templateColDef));
       }) ?? [];
     return newDefs;
   }
@@ -170,15 +187,17 @@ export function getColumnDefs(table: AgGridTableType): ColDef[] {
     // For pivot tables, we need to create ColDefs for the row, column, and value sources.
     const colDefs: ColDef[] = [];
     table.rowSources.forEach(c => {
-      colDefs.push({ field: c.name, rowGroup: true });
+      colDefs.push(applyOverride({ field: c.name, rowGroup: true }));
     });
     table.columnSources.forEach(c => {
-      colDefs.push({ field: c.name, pivot: true });
+      colDefs.push(applyOverride({ field: c.name, pivot: true }));
     });
     table.valueSources.forEach(c => {
       // We're just pushing an `aggFunc` here so it shows up correctly in the UI, but we also set the `suppressAggFuncInHeader` so that it doesn't actually appear.
       // We specify our own custom aggregation name. We don't actually use it, since the server does the aggregation already.
-      colDefs.push({ field: c.name, aggFunc: 'deephaven-aggregation' });
+      colDefs.push(
+        applyOverride({ field: c.name, aggFunc: 'deephaven-aggregation' })
+      );
     });
     return colDefs;
   }

--- a/plugins/ag-grid/test/deephaven/ag-grid/test.py
+++ b/plugins/ag-grid/test/deephaven/ag-grid/test.py
@@ -1,24 +1,53 @@
+import json
 import unittest
+from unittest.mock import MagicMock
 from .BaseTest import BaseTestCase
 
-from deephaven.ag_grid import AgGrid
+from deephaven.ag_grid import AgGrid, AgGridMessageStream
 from deephaven import new_table
 from deephaven.column import string_col, double_col
 
 
 class Test(BaseTestCase):
-    # Trivial test just to check if plugin runs for now
-    def test(self):
-        result = AgGrid(
-            new_table(
-                [
-                    double_col("Doubles", [3.1, 5.45, -1.0]),
-                    string_col("Strings", ["Creating", "New", "Tables"]),
-                ]
-            )
+    def make_table(self):
+        return new_table(
+            [
+                double_col("Doubles", [3.1, 5.45, -1.0]),
+                string_col("Strings", ["Creating", "New", "Tables"]),
+            ]
         )
 
-    pass
+    # Trivial test just to check if plugin runs for now
+    def test(self):
+        result = AgGrid(self.make_table())
+
+    def test_default_column_defs(self):
+        grid = AgGrid(self.make_table())
+        self.assertEqual(grid.column_defs, {})
+
+    def test_column_defs(self):
+        column_defs = {"Strings": {"filterParams": {"caseSensitive": True}}}
+        grid = AgGrid(self.make_table(), column_defs=column_defs)
+        self.assertEqual(grid.column_defs, column_defs)
+
+    def test_start_sends_empty_options(self):
+        table = self.make_table()
+        grid = AgGrid(table)
+        connection = MagicMock()
+        AgGridMessageStream(grid, connection).start()
+        payload, references = connection.on_data.call_args[0]
+        self.assertEqual(json.loads(payload.decode()), {})
+        self.assertEqual(references, [table])
+
+    def test_start_sends_column_defs(self):
+        table = self.make_table()
+        column_defs = {"Strings": {"filterParams": {"caseSensitive": True}}}
+        grid = AgGrid(table, column_defs=column_defs)
+        connection = MagicMock()
+        AgGridMessageStream(grid, connection).start()
+        payload, references = connection.on_data.call_args[0]
+        self.assertEqual(json.loads(payload.decode()), {"columnDefs": column_defs})
+        self.assertEqual(references, [table])
 
 
 if __name__ == "__main__":

--- a/tests/ag_grid.spec.ts
+++ b/tests/ag_grid.spec.ts
@@ -67,3 +67,42 @@ test('Grid restores rows after clearing a filter that returned zero rows', async
   const restoredRowCount = await rows.count();
   expect(restoredRowCount).toBeGreaterThan(0);
 });
+
+test('Text filters are case-insensitive by default', async ({ page }) => {
+  await gotoPage(page, '');
+  await openPanel(page, 'ag_mixed_case');
+
+  const agRoot = page.locator('.ag-root');
+  await expect(agRoot).toBeVisible();
+
+  // Wait for all 5 rows to load
+  const rows = agRoot.locator('.ag-center-cols-container .ag-row');
+  await expect(rows).toHaveCount(5);
+
+  // Open the filter popup on the Fruit column
+  const fruitHeader = agRoot.locator('.ag-header-cell').first();
+  await fruitHeader.locator('.ag-header-cell-filter-button').click();
+
+  const filterPopup = page.locator('.ag-filter');
+  await expect(filterPopup).toBeVisible();
+
+  // Select the "Equals" filter type
+  await filterPopup.locator('.ag-filter-select').click();
+  await page.getByRole('option', { name: 'Equals', exact: true }).click();
+
+  // Filter for "apple" and apply - should match "Apple", "apple", and "APPLE"
+  const filterInput = filterPopup.getByLabel('Filter Value');
+  await filterInput.fill('apple');
+  await filterPopup.getByRole('button', { name: 'Apply' }).click();
+  await expect(rows).toHaveCount(3, { timeout: 5000 });
+
+  // Change to a "Starts with" filter - should match "Banana" and "banana"
+  await fruitHeader.locator('.ag-header-cell-filter-button').click();
+  await expect(filterPopup).toBeVisible();
+  // Once a filter is applied, AG Grid shows an extra condition row, so target the first one
+  await filterPopup.locator('.ag-filter-select').first().click();
+  await page.getByRole('option', { name: 'Begins with', exact: true }).click();
+  await filterInput.first().fill('ban');
+  await filterPopup.getByRole('button', { name: 'Apply' }).click();
+  await expect(rows).toHaveCount(2, { timeout: 5000 });
+});

--- a/tests/ag_grid.spec.ts
+++ b/tests/ag_grid.spec.ts
@@ -106,3 +106,44 @@ test('Text filters are case-insensitive by default', async ({ page }) => {
   await filterPopup.getByRole('button', { name: 'Apply' }).click();
   await expect(rows).toHaveCount(2, { timeout: 5000 });
 });
+
+test('Text filters are case-sensitive when caseSensitive is set in column_defs', async ({
+  page,
+}) => {
+  await gotoPage(page, '');
+  await openPanel(page, 'ag_case_sensitive');
+
+  const agRoot = page.locator('.ag-root');
+  await expect(agRoot).toBeVisible();
+
+  // Wait for all 5 rows to load
+  const rows = agRoot.locator('.ag-center-cols-container .ag-row');
+  await expect(rows).toHaveCount(5);
+
+  // Open the filter popup on the Fruit column
+  const fruitHeader = agRoot.locator('.ag-header-cell').first();
+  await fruitHeader.locator('.ag-header-cell-filter-button').click();
+
+  const filterPopup = page.locator('.ag-filter');
+  await expect(filterPopup).toBeVisible();
+
+  // Select the "Equals" filter type
+  await filterPopup.locator('.ag-filter-select').click();
+  await page.getByRole('option', { name: 'Equals', exact: true }).click();
+
+  // Filter for "apple" and apply - should only match the lowercase "apple"
+  const filterInput = filterPopup.getByLabel('Filter Value');
+  await filterInput.fill('apple');
+  await filterPopup.getByRole('button', { name: 'Apply' }).click();
+  await expect(rows).toHaveCount(1, { timeout: 5000 });
+
+  // Change to a "Begins with" filter - should only match the lowercase "banana"
+  await fruitHeader.locator('.ag-header-cell-filter-button').click();
+  await expect(filterPopup).toBeVisible();
+  // Once a filter is applied, AG Grid shows an extra condition row, so target the first one
+  await filterPopup.locator('.ag-filter-select').first().click();
+  await page.getByRole('option', { name: 'Begins with', exact: true }).click();
+  await filterInput.first().fill('ban');
+  await filterPopup.getByRole('button', { name: 'Apply' }).click();
+  await expect(rows).toHaveCount(1, { timeout: 5000 });
+});

--- a/tests/app.d/ag_grid.py
+++ b/tests/app.d/ag_grid.py
@@ -32,3 +32,11 @@ foo_bar_table = new_table(
 )
 
 ag_foo_bar = AgGrid(foo_bar_table)
+
+mixed_case_table = new_table(
+    [
+        string_col("Fruit", ["Apple", "apple", "APPLE", "Banana", "banana"]),
+    ]
+)
+
+ag_mixed_case = AgGrid(mixed_case_table)

--- a/tests/app.d/ag_grid.py
+++ b/tests/app.d/ag_grid.py
@@ -40,3 +40,8 @@ mixed_case_table = new_table(
 )
 
 ag_mixed_case = AgGrid(mixed_case_table)
+
+ag_case_sensitive = AgGrid(
+    mixed_case_table,
+    column_defs={"Fruit": {"filterParams": {"caseSensitive": True}}},
+)


### PR DESCRIPTION
AG Grid text filters are case-insensitive by default, but parsed filter models always produced case-sensitive Deephaven filters.

- Add AgGridFilterUtils.getFilterFromGridApi(dh, table, gridApi) that reads the filter model and per-column filterParams.caseSensitive from the GridApi
- Deprecate parseFilterModel, keeping its original signature and case-sensitive behavior for API compatibility
- Use eqIgnoreCase/notEqIgnoreCase/containsIgnoreCase and matchesIgnoreCase regexes for case-insensitive text operations
- Add unit tests for both modes and an e2e test for the default case-insensitive behaviour
- Updated Python plugin to pass some grid options as well, useful for testing
  - Added e2e tests to verify the change as well