### PR TITLE
ci: DH-23319: Fix checks on js-only plugins

### DIFF
--- a/.github/actions/get-changes/action.yml
+++ b/.github/actions/get-changes/action.yml
@@ -46,6 +46,12 @@ runs:
           pivot-builder:
             - plugins/pivot-builder/**
             - .github/workflows/test-*.yml
+          auth-keycloak:
+            - plugins/auth-keycloak/**
+            - .github/workflows/test-*.yml
+          table-example:
+            - plugins/table-example/**
+            - .github/workflows/test-*.yml
           table-middleware-example:
             - plugins/table-middleware-example/**
             - .github/workflows/test-*.yml

--- a/.github/actions/get-changes/action.yml
+++ b/.github/actions/get-changes/action.yml
@@ -43,3 +43,9 @@ runs:
           python-remote-file-source:
             - plugins/python-remote-file-source/**
             - .github/workflows/test-*.yml
+          pivot-builder:
+            - plugins/pivot-builder/**
+            - .github/workflows/test-*.yml
+          table-middleware-example:
+            - plugins/table-middleware-example/**
+            - .github/workflows/test-*.yml

--- a/.github/workflows/test-python-package.yml
+++ b/.github/workflows/test-python-package.yml
@@ -8,7 +8,25 @@ on:
         type: string
 
 jobs:
+  # Some plugins are JS-only and have no Python side (no tox.ini). They still
+  # flow through the changed-packages matrix, so skip the Python tests for them.
+  check-tox:
+    runs-on: ubuntu-24.04
+    outputs:
+      files_exists: ${{ steps.check_files.outputs.files_exists }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Check file existence
+        id: check_files
+        uses: andstor/file-existence-action@v3
+        with:
+          files: 'plugins/${{ inputs.package }}/tox.ini'
+
   test:
+    needs: check-tox
+    if: ${{ needs.check-tox.outputs.files_exists == 'true' }}
     runs-on: ubuntu-24.04
     strategy:
       fail-fast: false

--- a/package-lock.json
+++ b/package-lock.json
@@ -24247,6 +24247,7 @@
         "@deephaven/plugin": "^1.24.0",
         "@deephaven/react-hooks": "^1.21.1",
         "@deephaven/utils": "^1.10.0",
+        "classnames": "^2.5.1",
         "fast-deep-equal": "^3.1.3"
       },
       "devDependencies": {

--- a/plugins/pivot-builder/src/js/package.json
+++ b/plugins/pivot-builder/src/js/package.json
@@ -43,6 +43,7 @@
     "@deephaven/plugin": "^1.24.0",
     "@deephaven/react-hooks": "^1.21.1",
     "@deephaven/utils": "^1.10.0",
+    "classnames": "^2.5.1",
     "fast-deep-equal": "^3.1.3"
   },
   "devDependencies": {

--- a/plugins/pivot-builder/src/js/src/CreatePivotPage.test.tsx
+++ b/plugins/pivot-builder/src/js/src/CreatePivotPage.test.tsx
@@ -29,14 +29,17 @@ const DOUBLE = 'double';
 // mount; jsdom has no ResizeObserver and the shared Jest setup doesn't mock it.
 beforeAll(() => {
   global.ResizeObserver = class ResizeObserver {
+    // eslint-disable-next-line class-methods-use-this
     observe(): void {
       // no-op
     }
 
+    // eslint-disable-next-line class-methods-use-this
     unobserve(): void {
       // no-op
     }
 
+    // eslint-disable-next-line class-methods-use-this
     disconnect(): void {
       // no-op
     }
@@ -269,11 +272,9 @@ describe('CreatePivotPage reconcile — hasLiveColumn gating', () => {
     // The inverted aggregation is NOT dropped — it produces a real totals row
     // over the surviving (live) columns.
     expect(cfg.totals).not.toBeNull();
-    const operationMap = (
-      cfg.totals as unknown as {
-        operationMap: Record<string, string[]>;
-      }
-    ).operationMap;
+    const { operationMap } = cfg.totals as unknown as {
+      operationMap: Record<string, string[]>;
+    };
     expect(Object.keys(operationMap).length).toBeGreaterThan(0);
   });
 

--- a/plugins/pivot-builder/src/js/src/makePivotModelTransform.ts
+++ b/plugins/pivot-builder/src/js/src/makePivotModelTransform.ts
@@ -104,7 +104,7 @@ export function makePivotModelTransform(
       // when rollup is unavailable the derivation can never pick pivot, and we
       // must not fatally probe PSP for a pivot that won't be built.
       // Legacy configs (no `ui`) fall back to the persisted `pivot` field.
-      const columns = augmented.sourceTable.columns;
+      const { columns } = augmented.sourceTable;
       const hostRollupAvailable =
         (augmented as unknown as { isRollupAvailable?: boolean })
           .isRollupAvailable === true;

--- a/plugins/pivot-builder/src/js/src/pivotConfig/rows/ColumnRow.test.tsx
+++ b/plugins/pivot-builder/src/js/src/pivotConfig/rows/ColumnRow.test.tsx
@@ -17,6 +17,7 @@ function renderColumnRow(
           name="price"
           container="rollup-rows"
           onDelete={() => undefined}
+          // eslint-disable-next-line react/jsx-props-no-spreading
           {...props}
         />
       </SortableContext>
@@ -27,7 +28,9 @@ function renderColumnRow(
 describe('ColumnRow stale passthrough', () => {
   it('renders a normal (non-stale) label by default', () => {
     renderColumnRow({ name: 'price' });
-    expect(screen.getByText('price')).not.toHaveClass('pivot-column-name--stale');
+    expect(screen.getByText('price')).not.toHaveClass(
+      'pivot-column-name--stale'
+    );
   });
 
   it('renders a stale label when isStale is true', () => {

--- a/plugins/pivot-builder/src/js/src/pivotConfig/rows/aggregateRows.test.tsx
+++ b/plugins/pivot-builder/src/js/src/pivotConfig/rows/aggregateRows.test.tsx
@@ -13,14 +13,17 @@ const { SortableContext } = DndKitSortable;
 // jsdom has no ResizeObserver and deephaven-plugins' Jest setup doesn't mock it.
 beforeAll(() => {
   global.ResizeObserver = class ResizeObserver {
+    // eslint-disable-next-line class-methods-use-this
     observe(): void {
       // no-op
     }
 
+    // eslint-disable-next-line class-methods-use-this
     unobserve(): void {
       // no-op
     }
 
+    // eslint-disable-next-line class-methods-use-this
     disconnect(): void {
       // no-op
     }
@@ -43,6 +46,7 @@ function renderRow(overrides: Partial<AggregateSelectRowProps> = {}): void {
     <Provider theme={defaultTheme}>
       <DndContext>
         <SortableContext items={[props.id]}>
+          {/* eslint-disable-next-line react/jsx-props-no-spreading */}
           <AggregateSelectRow {...props} />
         </SortableContext>
       </DndContext>

--- a/plugins/pivot-builder/src/js/src/pivotConfig/rows/rowParts.test.tsx
+++ b/plugins/pivot-builder/src/js/src/pivotConfig/rows/rowParts.test.tsx
@@ -21,7 +21,9 @@ describe('RowLabel stale styling', () => {
 
   it('does not add the stale modifier when `stale` is explicitly false', () => {
     render(<RowLabel stale={false}>here</RowLabel>);
-    expect(screen.getByText('here')).not.toHaveClass('pivot-column-name--stale');
+    expect(screen.getByText('here')).not.toHaveClass(
+      'pivot-column-name--stale'
+    );
   });
 
   it('keeps the non-column-name variant (columnName=false) unstyled by default', () => {


### PR DESCRIPTION
Eslint check didn't run on the pivot builder PR #1394 because the pivot builder wasn't in the changed plugins filter.

The errors surfaced later on an unrelated PR #1398 as `npm run test:ci` checked all files on the PR with non-JS-only changes.


## Changes:

- Add js-only plugins to the changed-packages filter

- Guard `test-python-package.yml` with a `tox.ini` existence check that skips the
Python test matrix when absent - mirroring the check-make-docs job in
build-docs.yml

- Fix eslint errors in Pivot Builder