### PR TITLE
fix: DH-23473: Hide dashboard headers when specified for outer dashboards

### DIFF
--- a/plugins/ui/src/js/src/layout/Dashboard.tsx
+++ b/plugins/ui/src/js/src/layout/Dashboard.tsx
@@ -25,7 +25,7 @@ function Dashboard({
   const isNested = contextPanelId != null || reactPanelId != null;
 
   // We need to make sure the headers are showing in the top-level dashboard if we're not nested and the showHeaders prop is set
-  const { showHeaders } = otherProps;
+  const { showHeaders = true } = otherProps;
   useEffect(() => {
     if (isNested) {
       return;

--- a/plugins/ui/src/js/src/layout/Dashboard.tsx
+++ b/plugins/ui/src/js/src/layout/Dashboard.tsx
@@ -30,15 +30,11 @@ function Dashboard({
     if (isNested) {
       return;
     }
-    const hasHeaders = layoutManager?.config?.settings?.hasHeaders;
-    if (showHeaders === true) {
-      if (hasHeaders === false) {
-        layoutManager?.enableHeaders();
-      }
-    } else if (showHeaders === false) {
-      if (hasHeaders === true) {
-        layoutManager?.disableHeaders();
-      }
+    const hasHeaders = layoutManager?.config?.settings?.hasHeaders ?? true;
+    if (showHeaders && !hasHeaders) {
+      layoutManager?.enableHeaders();
+    } else if (!showHeaders && hasHeaders) {
+      layoutManager?.disableHeaders();
     }
   }, [isNested, layoutManager, showHeaders]);
 

--- a/plugins/ui/src/js/src/layout/Dashboard.tsx
+++ b/plugins/ui/src/js/src/layout/Dashboard.tsx
@@ -1,5 +1,8 @@
-import React from 'react';
-import { usePanelId as useLayoutPanelId } from '@deephaven/dashboard';
+import React, { useContext, useEffect } from 'react';
+import {
+  LayoutManagerContext,
+  usePanelId as useLayoutPanelId,
+} from '@deephaven/dashboard';
 import { type ElementIdProps, type DashboardElementProps } from './LayoutUtils';
 import { usePanelId as useReactPanelId } from './ReactPanelContext';
 import NestedDashboard from './NestedDashboard';
@@ -15,9 +18,30 @@ function Dashboard({
   children,
   ...otherProps
 }: DashboardElementProps & ElementIdProps): JSX.Element | null {
+  const layoutManager = useContext(LayoutManagerContext);
+
   const contextPanelId = useLayoutPanelId();
   const reactPanelId = useReactPanelId();
   const isNested = contextPanelId != null || reactPanelId != null;
+
+  // We need to make sure the headers are showing in the top-level dashboard if we're not nested and the showHeaders prop is set
+  const { showHeaders } = otherProps;
+  useEffect(() => {
+    if (isNested) {
+      return;
+    }
+    const hasHeaders = layoutManager?.config.settings.hasHeaders;
+    if (showHeaders === true) {
+      if (hasHeaders === false) {
+        layoutManager?.enableHeaders();
+      }
+    } else if (showHeaders === false) {
+      if (hasHeaders === true) {
+        layoutManager?.disableHeaders();
+      }
+    }
+  }, [isNested, layoutManager, showHeaders]);
+
   if (isNested) {
     // eslint-disable-next-line react/jsx-props-no-spreading
     return <NestedDashboard {...otherProps}>{children}</NestedDashboard>;

--- a/plugins/ui/src/js/src/layout/Dashboard.tsx
+++ b/plugins/ui/src/js/src/layout/Dashboard.tsx
@@ -30,7 +30,7 @@ function Dashboard({
     if (isNested) {
       return;
     }
-    const hasHeaders = layoutManager?.config.settings.hasHeaders;
+    const hasHeaders = layoutManager?.config?.settings?.hasHeaders;
     if (showHeaders === true) {
       if (hasHeaders === false) {
         layoutManager?.enableHeaders();

--- a/plugins/ui/src/js/src/layout/LayoutUtils.tsx
+++ b/plugins/ui/src/js/src/layout/LayoutUtils.tsx
@@ -116,9 +116,12 @@ export function isStackElementNode(obj: unknown): obj is StackElementNode {
   );
 }
 
-export type DashboardElementProps = React.PropsWithChildren<
-  Record<string, unknown>
->;
+export type DashboardElementProps = React.PropsWithChildren<{
+  /**
+   * Whether to show the headers on panels in this dashboard. Defaults to `true`
+   */
+  showHeaders?: boolean;
+}>;
 
 /**
  * Elements rendered via deephaven.ui will have a unique element assigned to them.

--- a/plugins/ui/src/js/src/layout/NestedDashboard.tsx
+++ b/plugins/ui/src/js/src/layout/NestedDashboard.tsx
@@ -14,7 +14,7 @@ import {
 import Log from '@deephaven/log';
 import { useDashboardPlugins } from '@deephaven/plugin';
 import { useThrottledCallback } from '@deephaven/react-hooks';
-import { type ElementIdProps } from './LayoutUtils';
+import type { DashboardElementProps, ElementIdProps } from './LayoutUtils';
 import { InitialLayoutConfigContext } from './InitialLayoutConfigContext';
 import PortalPanelManager from './PortalPanelManager';
 import { usePanelManager } from './usePanelManager';
@@ -28,12 +28,7 @@ const log = Log.module('@deephaven/js-plugin-ui/NestedDashboard');
 
 const DATA_CHANGE_THROTTLE_MS = 1000;
 
-type NestedDashboardProps = PropsWithChildren<ElementIdProps> & {
-  /**
-   * Whether to show the headers on panels in this dashboard. Defaults to `true`
-   */
-  showHeaders?: boolean;
-};
+type NestedDashboardProps = ElementIdProps & DashboardElementProps;
 
 type DashboardData = {
   layoutConfig?: DashboardLayoutConfig;

--- a/plugins/ui/src/js/src/layout/NestedDashboard.tsx
+++ b/plugins/ui/src/js/src/layout/NestedDashboard.tsx
@@ -1,5 +1,4 @@
 import React, {
-  type PropsWithChildren,
   useCallback,
   useEffect,
   useMemo,

--- a/tests/app.d/tests.app
+++ b/tests/app.d/tests.app
@@ -27,3 +27,4 @@ file_20=ui_multi_select.py
 file_21=ui_dashboard_persistence.py
 file_22=express_events.py
 file_23=ui_shared_state.py
+file_24=ui_dashboard_headers.py

--- a/tests/app.d/ui_dashboard_headers.py
+++ b/tests/app.d/ui_dashboard_headers.py
@@ -1,0 +1,77 @@
+"""
+Test fixtures for dashboard panel headers (``show_headers``).
+
+These fixtures back the tests in ``tests/ui_dashboard_headers.spec.ts``:
+
+- ``ui_dashboard_headers_on``: top-level dashboard using the default headers.
+- ``ui_dashboard_headers_off``: top-level dashboard with ``show_headers=False``.
+- ``ui_dashboard_headers_off_nested_on``: headerless top-level dashboard
+  containing a nested dashboard that opts back in to headers.
+- ``ui_dashboard_headers_on_nested_off``: top-level dashboard with headers
+  containing a nested dashboard with ``show_headers=False``.
+- ``ui_dashboard_headers_off_nested_default``: headerless top-level dashboard
+  containing a nested dashboard that does not set ``show_headers``.
+"""
+
+from deephaven import ui
+
+ui_dashboard_headers_on = ui.dashboard(
+    ui.row(
+        ui.panel(ui.text("Content shown alpha"), title="Shown Alpha"),
+        ui.panel(ui.text("Content shown beta"), title="Shown Beta"),
+    )
+)
+
+ui_dashboard_headers_off = ui.dashboard(
+    ui.row(
+        ui.panel(ui.text("Content hidden alpha"), title="Hidden Alpha"),
+        ui.panel(ui.text("Content hidden beta"), title="Hidden Beta"),
+    ),
+    show_headers=False,
+)
+
+ui_dashboard_headers_off_nested_on = ui.dashboard(
+    ui.row(
+        ui.panel(ui.text("Content outer hidden"), title="Outer Hidden"),
+        ui.panel(
+            ui.dashboard(
+                ui.row(
+                    ui.panel(ui.text("Content inner shown"), title="Inner Shown"),
+                ),
+                show_headers=True,
+            ),
+            title="Wrapper Hidden",
+        ),
+    ),
+    show_headers=False,
+)
+
+ui_dashboard_headers_on_nested_off = ui.dashboard(
+    ui.row(
+        ui.panel(ui.text("Content outer shown"), title="Outer Shown"),
+        ui.panel(
+            ui.dashboard(
+                ui.row(
+                    ui.panel(ui.text("Content inner hidden"), title="Inner Hidden"),
+                ),
+                show_headers=False,
+            ),
+            title="Wrapper Shown",
+        ),
+    ),
+)
+
+ui_dashboard_headers_off_nested_default = ui.dashboard(
+    ui.row(
+        ui.panel(ui.text("Content outer default"), title="Outer Default"),
+        ui.panel(
+            ui.dashboard(
+                ui.row(
+                    ui.panel(ui.text("Content inner default"), title="Inner Default"),
+                )
+            ),
+            title="Wrapper Default",
+        ),
+    ),
+    show_headers=False,
+)

--- a/tests/ui_dashboard_headers.spec.ts
+++ b/tests/ui_dashboard_headers.spec.ts
@@ -50,6 +50,20 @@ async function expectHeaderHidden(
   await expect(tab).toBeHidden();
 }
 
+/**
+ * Asserts the panel tab for the given title is displayed.
+ * @param scope The page or locator to search within
+ * @param title The panel title
+ */
+async function expectHeaderVisible(
+  scope: Page | Locator,
+  title: string
+): Promise<void> {
+  const tab = panelTab(scope, title);
+  await expect(tab).toHaveCount(1);
+  await expect(tab).toBeVisible();
+}
+
 test.describe('Dashboard headers', () => {
   test('shows panel headers by default', async ({ page }) => {
     await gotoPage(page, '');
@@ -58,8 +72,8 @@ test.describe('Dashboard headers', () => {
     await expect(page.getByText('Content shown alpha')).toBeVisible();
     await expect(page.getByText('Content shown beta')).toBeVisible();
 
-    await expect(panelTab(page, 'Shown Alpha')).toBeVisible();
-    await expect(panelTab(page, 'Shown Beta')).toBeVisible();
+    await expectHeaderVisible(page, 'Shown Alpha');
+    await expectHeaderVisible(page, 'Shown Beta');
   });
 
   test('hides panel headers when show_headers is False', async ({ page }) => {
@@ -89,7 +103,7 @@ test.describe('Dashboard headers', () => {
     await expectHeaderHidden(page, 'Wrapper Hidden');
 
     // The nested dashboard opts back in to headers
-    await expect(panelTab(nested, 'Inner Shown')).toBeVisible();
+    await expectHeaderVisible(nested, 'Inner Shown');
   });
 
   test('nested dashboard hides its headers inside a dashboard with headers', async ({
@@ -102,8 +116,8 @@ test.describe('Dashboard headers', () => {
     await expect(page.getByText('Content outer shown')).toBeVisible();
     await expect(nested.getByText('Content inner hidden')).toBeVisible();
 
-    await expect(panelTab(page, 'Outer Shown')).toBeVisible();
-    await expect(panelTab(page, 'Wrapper Shown')).toBeVisible();
+    await expectHeaderVisible(page, 'Outer Shown');
+    await expectHeaderVisible(page, 'Wrapper Shown');
 
     await expectHeaderHidden(nested, 'Inner Hidden');
   });
@@ -121,6 +135,6 @@ test.describe('Dashboard headers', () => {
     await expectHeaderHidden(page, 'Outer Default');
     await expectHeaderHidden(page, 'Wrapper Default');
 
-    await expect(panelTab(nested, 'Inner Default')).toBeVisible();
+    await expectHeaderVisible(nested, 'Inner Default');
   });
 });

--- a/tests/ui_dashboard_headers.spec.ts
+++ b/tests/ui_dashboard_headers.spec.ts
@@ -1,0 +1,126 @@
+import { expect, test, type Locator, type Page } from '@playwright/test';
+import { gotoPage, waitForLoad } from './utils';
+
+/**
+ * Opens a top-level dashboard widget from the Panels menu. Unlike `openPanel`,
+ * a dashboard widget opens as its own dashboard tab rather than a single panel.
+ * @param page The page
+ * @param name The name of the dashboard variable
+ */
+async function openDashboard(page: Page, name: string): Promise<void> {
+  await test.step(`Open dashboard (${name})`, async () => {
+    const appPanels = page.getByRole('button', { name: 'Panels', exact: true });
+    await expect(appPanels).toBeEnabled();
+    await appPanels.click();
+
+    const search = page.getByRole('searchbox', {
+      name: 'Find Table, Plot or Widget',
+      exact: true,
+    });
+    await search.fill(name);
+    await page.getByRole('button', { name, exact: true }).click();
+
+    // Reset mouse position to not cause unintended hover effects
+    await page.mouse.move(0, 0);
+
+    await waitForLoad(page);
+  });
+}
+
+/**
+ * Gets the golden-layout tab for the panel with the given title.
+ * @param scope The page or locator to search within
+ * @param title The panel title
+ */
+function panelTab(scope: Page | Locator, title: string): Locator {
+  return scope.locator('.lm_tab', { hasText: title });
+}
+
+/**
+ * Asserts the panel tab exists in the DOM but its header is not displayed.
+ * @param scope The page or locator to search within
+ * @param title The panel title
+ */
+async function expectHeaderHidden(
+  scope: Page | Locator,
+  title: string
+): Promise<void> {
+  const tab = panelTab(scope, title);
+  await expect(tab).toHaveCount(1);
+  await expect(tab).toBeHidden();
+}
+
+test.describe('Dashboard headers', () => {
+  test('shows panel headers by default', async ({ page }) => {
+    await gotoPage(page, '');
+    await openDashboard(page, 'ui_dashboard_headers_on');
+
+    await expect(page.getByText('Content shown alpha')).toBeVisible();
+    await expect(page.getByText('Content shown beta')).toBeVisible();
+
+    await expect(panelTab(page, 'Shown Alpha')).toBeVisible();
+    await expect(panelTab(page, 'Shown Beta')).toBeVisible();
+  });
+
+  test('hides panel headers when show_headers is False', async ({ page }) => {
+    await gotoPage(page, '');
+    await openDashboard(page, 'ui_dashboard_headers_off');
+
+    await expect(page.getByText('Content hidden alpha')).toBeVisible();
+    await expect(page.getByText('Content hidden beta')).toBeVisible();
+
+    await expectHeaderHidden(page, 'Hidden Alpha');
+    await expectHeaderHidden(page, 'Hidden Beta');
+  });
+
+  test('nested dashboard shows its headers inside a headerless dashboard', async ({
+    page,
+  }) => {
+    await gotoPage(page, '');
+    await openDashboard(page, 'ui_dashboard_headers_off_nested_on');
+
+    const nested = page.locator('.dh-nested-dashboard');
+    await expect(page.getByText('Content outer hidden')).toBeVisible();
+    await expect(nested.getByText('Content inner shown')).toBeVisible();
+
+    // The outer dashboard hides its headers, including the panel wrapping the
+    // nested dashboard
+    await expectHeaderHidden(page, 'Outer Hidden');
+    await expectHeaderHidden(page, 'Wrapper Hidden');
+
+    // The nested dashboard opts back in to headers
+    await expect(panelTab(nested, 'Inner Shown')).toBeVisible();
+  });
+
+  test('nested dashboard hides its headers inside a dashboard with headers', async ({
+    page,
+  }) => {
+    await gotoPage(page, '');
+    await openDashboard(page, 'ui_dashboard_headers_on_nested_off');
+
+    const nested = page.locator('.dh-nested-dashboard');
+    await expect(page.getByText('Content outer shown')).toBeVisible();
+    await expect(nested.getByText('Content inner hidden')).toBeVisible();
+
+    await expect(panelTab(page, 'Outer Shown')).toBeVisible();
+    await expect(panelTab(page, 'Wrapper Shown')).toBeVisible();
+
+    await expectHeaderHidden(nested, 'Inner Hidden');
+  });
+
+  test('nested dashboard without show_headers defaults to showing headers', async ({
+    page,
+  }) => {
+    await gotoPage(page, '');
+    await openDashboard(page, 'ui_dashboard_headers_off_nested_default');
+
+    const nested = page.locator('.dh-nested-dashboard');
+    await expect(page.getByText('Content outer default')).toBeVisible();
+    await expect(nested.getByText('Content inner default')).toBeVisible();
+
+    await expectHeaderHidden(page, 'Outer Default');
+    await expectHeaderHidden(page, 'Wrapper Default');
+
+    await expect(panelTab(nested, 'Inner Default')).toBeVisible();
+  });
+});


### PR DESCRIPTION
- The outer dashboard was not respecting the showHeaders flag
- Add e2e tests: covers top-level dashboards with headers shown and hidden, plus nested
dashboards that set the opposite value or leave show_headers unset.
