### PR TITLE
feat: Pass through loader field from package.json in create_js_plugin

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,6 +20,7 @@ repos:
           [
             pandas,
             deephaven-core,
+            deephaven-plugin>=0.8.0,
             plotly,
             json-rpc,
             matplotlib,
@@ -28,7 +29,7 @@ repos:
             click,
             watchdog,
             pyjsonpatch,
-            puremagic
+            puremagic,
           ]
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.2.2

--- a/plugins/ui/src/deephaven/ui/hooks/_transform.py
+++ b/plugins/ui/src/deephaven/ui/hooks/_transform.py
@@ -19,8 +19,10 @@ try:
     # maintain compatibility with 41.x, where ImportError is caught and the transform is enforced.
     from deephaven.configuration import get_configuration  # type: ignore[import-untyped,import-not-found]
 
-    skip_transform = get_configuration().get_bool(
-        _DISABLE_AUTHORIZATION_EXPORT_TRANSFORM_PROPERTY, False
+    skip_transform = bool(
+        get_configuration().get_bool(
+            _DISABLE_AUTHORIZATION_EXPORT_TRANSFORM_PROPERTY, False
+        )
     )
 except Exception:
     skip_transform = False

--- a/plugins/utilities/setup.cfg
+++ b/plugins/utilities/setup.cfg
@@ -24,7 +24,7 @@ package_dir=
     =src
 packages=find_namespace:
 install_requires =
-    deephaven-plugin>=0.6.0
+    deephaven-plugin>=0.8.0
 include_package_data = True
 
 [options.packages.find]

--- a/plugins/utilities/src/deephaven/plugin/utilities/utils.py
+++ b/plugins/utilities/src/deephaven/plugin/utilities/utils.py
@@ -1,12 +1,12 @@
 import abc
 import logging
 from functools import partial
-from typing import Callable, ContextManager, Type
+from typing import Callable, ContextManager, Optional, Type
 import importlib.resources
 import json
 import pathlib
 import sys
-from deephaven.plugin.js import JsPlugin
+from deephaven.plugin.js import JsPlugin, JsonValue
 
 logger = logging.getLogger(__name__)
 
@@ -20,11 +20,13 @@ class CommonJsPlugin(JsPlugin):
         version: str,
         main: str,
         path: pathlib.Path,
+        loader: Optional[JsonValue] = None,
     ) -> None:
         self._name = name
         self._version = version
         self._main = main
         self._path = path
+        self._loader = loader
 
     @property
     def name(self) -> str:
@@ -37,6 +39,10 @@ class CommonJsPlugin(JsPlugin):
     @property
     def main(self) -> str:
         return self._main
+
+    @property
+    def loader(self) -> Optional[JsonValue]:
+        return self._loader
 
     def path(self) -> pathlib.Path:
         return self._path
@@ -54,7 +60,7 @@ def is_enterprise_environment() -> bool:
 
 
 def _create_from_npm_package_json(
-    path_provider: Callable[[], ContextManager[pathlib.Path]]
+    path_provider: Callable[[], ContextManager[pathlib.Path]],
 ) -> JsPlugin:
     """
     Create a JsPlugin from an npm package.json file.
@@ -78,6 +84,7 @@ def _create_from_npm_package_json(
         package_json["version"],
         package_json["main"],
         js_path,
+        package_json.get("loader"),
     )
 
 


### PR DESCRIPTION
CommonJsPlugin now exposes the optional loader field from package.json,
which is included in the js-plugins/manifest.json entry.
Requires deephaven-plugin>=0.8.0 where JsPlugin.loader was added.
