### PR TITLE
fix(ui): Set the debounced onChange ref during render

### DIFF
--- a/plugins/ui/src/js/src/elements/hooks/useDebouncedOnChange.test.ts
+++ b/plugins/ui/src/js/src/elements/hooks/useDebouncedOnChange.test.ts
@@ -32,12 +32,9 @@ describe('useDebouncedOnChange', () => {
   });
 
   it('does not drop a pending change when the onChange prop identity changes', () => {
-    // The server hands down a NEW on_change callable on every re-render —
-    // including the re-render caused by its own previous onChange. A pending
-    // trailing call must survive that identity change and fire with the
-    // latest callable, or the user's final keystrokes are silently lost
-    // (type "world" fast: "wor" round-trips, the re-render lands, and
-    // "world" was never delivered).
+    // An unmemoized server handler is a new callable every render. A pending
+    // call has to survive that and fire with the latest one, or the user's
+    // last keystrokes are lost.
     const first = jest.fn(() => Promise.resolve());
     const second = jest.fn(() => Promise.resolve());
     const { result, rerender } = renderHook(

--- a/plugins/ui/src/js/src/elements/hooks/useDebouncedOnChange.ts
+++ b/plugins/ui/src/js/src/elements/hooks/useDebouncedOnChange.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect, useRef } from 'react';
+import { useState, useCallback, useRef } from 'react';
 import Log from '@deephaven/log';
 import { useDebouncedCallback, usePrevious } from '@deephaven/react-hooks';
 
@@ -32,19 +32,13 @@ function useDebouncedOnChange<T, P = T>(
     setValue(propValue);
   }
 
-  // The server hands down a NEW propOnChange callable on every re-render —
-  // including the re-render its own previous onChange caused. Because
-  // useDebouncedCallback cancels its pending trailing call whenever the
-  // callback identity changes, keying the debounce on propOnChange silently
-  // drops whatever the user typed while a round trip was in flight (e.g.
-  // type "world" fast: "wor" fires, the re-render lands, and the trailing
-  // "world" call is cancelled — the final keystrokes never reach Python).
-  // Keep ONE stable debounced instance and resolve the latest callable at
-  // fire time instead.
+  // useDebouncedCallback cancels its pending call when the callback identity
+  // changes, and an unmemoized server handler is a new callable every render.
+  // Keying the debounce on propOnChange would drop the user's last keystrokes
+  // whenever a re-render landed mid-typing, so keep one debounced instance and
+  // read the latest callable when it fires.
   const propOnChangeRef = useRef(propOnChange);
-  useEffect(() => {
-    propOnChangeRef.current = propOnChange;
-  }, [propOnChange]);
+  propOnChangeRef.current = propOnChange;
 
   const propDebouncedOnChange = useCallback(
     async (newValue: T) => {


### PR DESCRIPTION
Follow-up to #1406.

## Why the ref is there at all

`useDebouncedCallback` cancels its pending call whenever the callback identity changes.

A handler the user doesn't memoize is a new Python function on every render, which gets a new callable id, which reaches the client as a new `onChange`. So when a server re-render lands while a debounced change is still waiting to fire, that change is cancelled and those keystrokes never reach Python.

That is what made `ui_events.spec.ts` flaky. Type "world" quickly:

```
type "w" "o" "r"      debounce armed with "wor"
250ms                 "wor" sent to Python, handler appends to the log
type "l" "d"          debounce re-armed with "world"
server render lands   new handler -> new onChange -> pending call CANCELLED
                      "change:world" never arrives, the test times out
```

Locally all five keystrokes land inside one 250ms window, so nothing re-renders mid-typing and it passes. Under CI load the gaps stretch, the re-render lands in the wrong spot, and it fails.

The fix in #1406 keeps one debounced instance for the life of the component and reads the current handler from a ref when it fires, so nothing cancels it.

## What this PR changes

The ref was being updated in a `useEffect`, so it lagged a render behind. The value is already available at render time, so it is now assigned there. This matches how the rest of the repo keeps a latest-value ref (`usePivotBuilderMiddlewareCore`, `useWaitForWorkerVariables`, `CreatePivotPage`).

Also shortened the comment. It said the server sends a new `on_change` on every render, which is only true for handlers the user doesn't memoize. A memoized one keeps a stable callable id, and so does a `use_state` setter since #1386.

No behavior change.

## Testing

Unit tests pass; `tsc`, eslint and prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)